### PR TITLE
Add helpers to AsyncData and AsyncResult

### DIFF
--- a/__tests__/Relude_AsyncData_test.re
+++ b/__tests__/Relude_AsyncData_test.re
@@ -3,24 +3,83 @@ open Expect;
 
 module AsyncData = Relude_AsyncData;
 
-describe("AsyncData", () => {
-  test("map2 Init Init", () => {
-    expect(AsyncData.map2((_, _) => (), Init, Init)) |> toEqual(AsyncData.Init);
-  });
+describe("AsyncData state checks", () => {
+  test("isInit when Init", () =>
+    expect(AsyncData.isInit(Init)) |> toEqual(true)
+  );
 
-  test("map2 Init Loading", () => {
-    expect(AsyncData.map2((_, _) => (), Init, Loading)) |> toEqual(AsyncData.Loading);
-  });
+  test("isInit when Complete", () =>
+    expect(AsyncData.isInit(Complete(3))) |> toEqual(false)
+  );
 
-  test("map2 Init Reloading", () => {
-    expect(AsyncData.map2((_, _) => (), Init, Reloading(123))) |> toEqual(AsyncData.Init);
-  });
+  test("isBusy when Init", () =>
+    expect(AsyncData.isBusy(Init)) |> toEqual(false)
+  );
 
-  test("map2 Reloading Reloading", () => {
-    expect(AsyncData.map2((+), Reloading(10), Reloading(20))) |> toEqual(AsyncData.Reloading(30));
-  });
+  test("isBusy when Loading", () =>
+    expect(AsyncData.isBusy(Loading)) |> toEqual(true)
+  );
 
-  test("map2 Reloading Complete", () => {
-    expect(AsyncData.map2((+), Reloading(10), Complete(20))) |> toEqual(AsyncData.Reloading(30));
-  });
+  test("isBusy when Reloading", () =>
+    expect(AsyncData.isBusy(Reloading(10))) |> toEqual(true)
+  );
+
+  test("isComplete when Loading", () =>
+    expect(AsyncData.isComplete(Loading)) |> toEqual(false)
+  );
+
+  test("isComplete when Complete", () =>
+    expect(AsyncData.isComplete(Complete(""))) |> toEqual(true)
+  );
+
+  test("getComplete when Init", () =>
+    expect(AsyncData.getComplete(Init)) |> toEqual(None)
+  );
+
+  test("getComplete when Reloading", () =>
+    expect(AsyncData.getComplete(Reloading(1))) |> toEqual(None)
+  );
+
+  test("getComplete when Complete", () =>
+    expect(AsyncData.getComplete(Complete(1))) |> toEqual(Some(1))
+  );
+
+  test("getValue when Complete", () =>
+    expect(AsyncData.getValue(Complete(1))) |> toEqual(Some(1))
+  );
+
+  test("getValue when Reloading", () =>
+    expect(AsyncData.getValue(Reloading(1))) |> toEqual(Some(1))
+  );
+
+  test("getValue when Loading", () =>
+    expect(AsyncData.getValue(Loading)) |> toEqual(None)
+  );
+});
+
+describe("AsyncData apply", () => {
+  test("map2 Init Init", () =>
+    expect(AsyncData.map2((_, _) => (), Init, Init))
+    |> toEqual(AsyncData.Init)
+  );
+
+  test("map2 Init Loading", () =>
+    expect(AsyncData.map2((_, _) => (), Init, Loading))
+    |> toEqual(AsyncData.Loading)
+  );
+
+  test("map2 Init Reloading", () =>
+    expect(AsyncData.map2((_, _) => (), Init, Reloading(123)))
+    |> toEqual(AsyncData.Init)
+  );
+
+  test("map2 Reloading Reloading", () =>
+    expect(AsyncData.map2((+), Reloading(10), Reloading(20)))
+    |> toEqual(AsyncData.Reloading(30))
+  );
+
+  test("map2 Reloading Complete", () =>
+    expect(AsyncData.map2((+), Reloading(10), Complete(20)))
+    |> toEqual(AsyncData.Reloading(30))
+  );
 });

--- a/__tests__/Relude_AsyncResult_test.re
+++ b/__tests__/Relude_AsyncResult_test.re
@@ -1,0 +1,126 @@
+open Jest;
+open Expect;
+module AsyncData = Relude_AsyncData;
+module AsyncResult = Relude_AsyncResult;
+
+describe("AsyncResult constructors", () => {
+  test("Init", () =>
+    expect(AsyncResult.init) |> toEqual(AsyncData.init)
+  );
+
+  test("Loading", () =>
+    expect(AsyncResult.loading) |> toEqual(AsyncData.loading)
+  );
+
+  test("Complete Ok", () =>
+    expect(AsyncResult.ok(1))
+    |> toEqual(AsyncData.complete(Belt.Result.Ok(1)))
+  );
+
+  test("Complete Error", () =>
+    expect(AsyncResult.error("Fail"))
+    |> toEqual(AsyncData.complete(Belt.Result.Error("Fail")))
+  );
+});
+
+describe("AsyncResult state checks", () => {
+  test("isOk when Loading", () =>
+    expect(AsyncResult.(loading |> isOk)) |> toEqual(false)
+  );
+
+  test("isOk when Reloading Ok", () =>
+    expect(AsyncResult.(reloadingOk(1) |> isOk)) |> toEqual(true)
+  );
+
+  test("isOk when Complete Ok", () =>
+    expect(AsyncResult.(ok(1) |> isOk)) |> toEqual(true)
+  );
+
+  test("isOk when Complete Error", () =>
+    expect(AsyncResult.(error("Fail") |> isOk)) |> toEqual(false)
+  );
+
+  test("isOk when Reloading Error", () =>
+    expect(AsyncResult.(reloadingError("Fail") |> isOk)) |> toEqual(false)
+  );
+
+  test("isError when Complete Error", () =>
+    expect(AsyncResult.(error("Fail") |> isError)) |> toEqual(true)
+  );
+
+  test("isError when Reloading Error", () =>
+    expect(AsyncResult.(reloadingError("Fail") |> isError)) |> toEqual(true)
+  );
+
+  test("isError when Reloading Ok", () =>
+    expect(AsyncResult.(reloadingOk(1) |> isError)) |> toEqual(false)
+  );
+
+  test("isError when Complete Ok", () =>
+    expect(AsyncResult.(ok(1) |> isError)) |> toEqual(false)
+  );
+
+  test("isCompleteOk when Complete Ok", () =>
+    expect(AsyncResult.(ok(1) |> isCompleteOk)) |> toEqual(true)
+  );
+
+  test("isCompleteOk when Reloading Ok", () =>
+    expect(AsyncResult.(reloadingOk(1) |> isCompleteOk)) |> toEqual(false)
+  );
+
+  test("isCompleteOk when Complete Error", () =>
+    expect(AsyncResult.(error("fail") |> isCompleteOk)) |> toEqual(false)
+  );
+
+  test("getOk when Reloading Ok", () =>
+    expect(AsyncResult.(reloadingOk(1) |> getOk)) |> toEqual(Some(1))
+  );
+
+  test("getOk when Complete Ok", () =>
+    expect(AsyncResult.(ok(1) |> getOk)) |> toEqual(Some(1))
+  );
+
+  test("getOk when Reloading Error", () =>
+    expect(AsyncResult.(reloadingError("fail") |> getOk)) |> toEqual(None)
+  );
+
+  test("getOk when Complete Error", () =>
+    expect(AsyncResult.(error("fail") |> getOk)) |> toEqual(None)
+  );
+
+  test("getCompleteOk when Reloading Ok", () =>
+    expect(AsyncResult.(reloadingOk(1) |> getCompleteOk)) |> toEqual(None)
+  );
+
+  test("getCompleteOk when Complete Ok", () =>
+    expect(AsyncResult.(ok(1) |> getCompleteOk)) |> toEqual(Some(1))
+  );
+
+  test("getError when Reloading Error", () =>
+    expect(AsyncResult.(reloadingError("fail") |> getError))
+    |> toEqual(Some("fail"))
+  );
+
+  test("getError when Complete Error", () =>
+    expect(AsyncResult.(error("fail") |> getError))
+    |> toEqual(Some("fail"))
+  );
+
+  test("getError when Reloading Ok", () =>
+    expect(AsyncResult.(reloadingOk(1) |> getError)) |> toEqual(None)
+  );
+
+  test("getError when Complete Ok", () =>
+    expect(AsyncResult.(ok(1) |> getError)) |> toEqual(None)
+  );
+
+  test("getCompleteError when Complete Error", () =>
+    expect(AsyncResult.(error("fail") |> getCompleteError))
+    |> toEqual(Some("fail"))
+  );
+
+  test("getCompleteError when Reloading Error", () =>
+    expect(AsyncResult.(reloadingError("fail") |> getCompleteError))
+    |> toEqual(None)
+  );
+});

--- a/src/Relude_AsyncData.re
+++ b/src/Relude_AsyncData.re
@@ -1,29 +1,33 @@
 /*
-AsyncData represents the state of data that is being loaded asynchronously.
+ AsyncData represents the state of data that is being loaded asynchronously.
 
-This type does not represent failures by default, but it can by using Belt.Result.t as your 'a type.
+ This type does not represent failures by default, but it can by using Belt.Result.t as your 'a type.
 
-The reason for this is that not all async data loading mechanisms will necessarily fail.
+ The reason for this is that not all async data loading mechanisms will necessarily fail.
 
-The other interesting bit is that `Reloading` can be used if you already have data (e.g. an Ok or Error Result),
-but you need to reload the data to get a new Result.
-*/
+ The other interesting bit is that `Reloading` can be used if you already have data (e.g. an Ok or Error Result),
+ but you need to reload the data to get a new Result.
+ */
 
+/*******************************************************************************
+ * Type definition and constructors
+ ******************************************************************************/
 type t('a) =
   | Init
   | Loading
   | Reloading('a)
   | Complete('a);
 
-let pure: 'a => t('a) = a => Complete(a);
-
 let init: t('a) = Init;
-
 let loading: t('a) = Loading;
-
 let reloading: 'a => t('a) = a => Reloading(a);
-
 let complete: 'a => t('a) = a => Complete(a);
+
+/*******************************************************************************
+ * Needed by typeclasses
+ ******************************************************************************/
+
+let pure: 'a => t('a) = a => Complete(a);
 
 let map: ('a => 'b, t('a)) => t('b) =
   (f, fa) =>
@@ -94,6 +98,59 @@ let bind: (t('a), 'a => t('b)) => t('b) =
 
 let flatMap: ('a => t('b), t('a)) => t('b) = (f, fa) => bind(fa, f);
 
+/*******************************************************************************
+ * Utilities specific to this type
+ ******************************************************************************/
+
+let isInit: t('a) => bool =
+  fun
+  | Init => true
+  | _ => false;
+
+let isBusy: t('a) => bool =
+  fun
+  | Loading
+  | Reloading(_) => true
+  | _ => false;
+
+let isLoading: t('a) => bool =
+  fun
+  | Loading => true
+  | _ => false;
+
+let isReloading: t('a) => bool =
+  fun
+  | Reloading(_) => true
+  | _ => false;
+
+let isComplete: t('a) => bool =
+  fun
+  | Complete(_) => true
+  | _ => false;
+
+/**
+ * Get a value of type `'a`, using the `Complete` value if the AsyncData is
+ * complete, or the last known complete value in `Reloading`.
+ */
+let getValue: t('a) => option('a) =
+  fun
+  | Complete(v)
+  | Reloading(v) => Some(v)
+  | _ => None;
+
+/**
+ * Get `Some` value of type `'a` only from the `Complete` state, and `None` in
+ * all other cases, including `Reloading`.
+ */
+let getComplete: t('a) => option('a) =
+  fun
+  | Complete(v) => Some(v)
+  | _ => None;
+
+/*******************************************************************************
+ * Typeclass implementations
+ ******************************************************************************/
+
 module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
   type nonrec t('a) = t('a);
   let map = map;
@@ -109,6 +166,26 @@ module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
   let apply = apply;
 };
 
+module Applicative: BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+  include Apply;
+  let pure = pure;
+};
+
+module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+  include Applicative;
+  let flat_map = bind;
+};
+
+module Infix = {
+  include BsAbstract.Infix.Functor(Functor);
+  include BsAbstract.Infix.Apply(Apply);
+  include BsAbstract.Infix.Monad(Monad);
+};
+
+/*******************************************************************************
+ * Free utilities from typeclasses
+ ******************************************************************************/
+
 module ApplyFunctions = BsAbstract.Functions.Apply(Apply);
 
 /* These can be derived from BsAbstract.Functions.Apply, but because we have an error type, it becomes a module functor with an error type */
@@ -121,19 +198,3 @@ let map4: (('a, 'b, 'c, 'd) => 'e, t('a), t('b), t('c), t('d)) => t('e) = ApplyF
 let map5:
   (('a, 'b, 'c, 'd, 'e) => 'f, t('a), t('b), t('c), t('d), t('e)) =>
   t('f) = ApplyFunctions.lift5;
-
-module Applicative: BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
-  include Apply;
-  let pure = pure;
-};
-
-module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
-  include Applicative;
-  let flat_map = bind;
-};
-
-module Infix {
-  include BsAbstract.Infix.Functor(Functor);
-  include BsAbstract.Infix.Apply(Apply);
-  include BsAbstract.Infix.Monad(Monad);
-}


### PR DESCRIPTION
This fixes #33 and adds several additional helpers. I added tests to confirm my current expectations, but if people disagree with those expectations, or if we find the names confusing, I'm certainly open to changes.

I also ran `refmt` on the files, which added some noise to the diff.