### PR TITLE
Rename *F functions to *By

### DIFF
--- a/__tests__/Relude_Array_test.re
+++ b/__tests__/Relude_Array_test.re
@@ -486,16 +486,16 @@ describe("Array", () => {
     expect(Array.toList([|1, 2, 3|])) |> toEqual([1, 2, 3])
   );
 
-  test("eqF returns true if array items are equal", () =>
-    expect(Array.eqF(Int.eq, [|1, 2, 3|], [|1, 2, 3|])) |> toBe(true)
+  test("eqBy returns true if array items are equal", () =>
+    expect(Array.eqBy(Int.eq, [|1, 2, 3|], [|1, 2, 3|])) |> toBe(true)
   );
 
-  test("eqF returns false if array items are not equal", () =>
-    expect(Array.eqF(Int.eq, [|1, 2, 3|], [|1, 2, 4|])) |> toBe(false)
+  test("eqBy returns false if array items are not equal", () =>
+    expect(Array.eqBy(Int.eq, [|1, 2, 3|], [|1, 2, 4|])) |> toBe(false)
   );
 
-  test("eqF returns false if array are of different sizes", () =>
-    expect(Array.eqF(Int.eq, [|1|], [|1, 2|])) |> toBe(false)
+  test("eqBy returns false if array are of different sizes", () =>
+    expect(Array.eqBy(Int.eq, [|1|], [|1, 2|])) |> toBe(false)
   );
 
   test("eq returns true if array items are equal", () =>
@@ -512,8 +512,8 @@ describe("Array", () => {
     expect(Array.mkString(", ", [|"a", "b", "c"|])) |> toEqual("a, b, c")
   );
 
-  test("showF", () =>
-    expect(Array.showF(string_of_int, [|1, 2, 3|])) |> toEqual("[1, 2, 3]")
+  test("showBy", () =>
+    expect(Array.showBy(string_of_int, [|1, 2, 3|])) |> toEqual("[1, 2, 3]")
   );
   /*
    test("void", () =>

--- a/__tests__/Relude_List_test.re
+++ b/__tests__/Relude_List_test.re
@@ -470,48 +470,48 @@ describe("List", () => {
     expect(List.all(a => a < 3, [0, 1, 2, 3])) |> toEqual(false)
   );
 
-  test("removeF empty", () =>
-    expect(List.removeF(Int.eq, 0, [])) |> toEqual([])
+  test("removeBy empty", () =>
+    expect(List.removeBy(Int.eq, 0, [])) |> toEqual([])
   );
 
-  test("removeF single match", () =>
-    expect(List.removeF(Int.eq, 0, [0])) |> toEqual([])
+  test("removeBy single match", () =>
+    expect(List.removeBy(Int.eq, 0, [0])) |> toEqual([])
   );
 
-  test("removeF single not a match", () =>
-    expect(List.removeF(Int.eq, 0, [1])) |> toEqual([1])
+  test("removeBy single not a match", () =>
+    expect(List.removeBy(Int.eq, 0, [1])) |> toEqual([1])
   );
 
-  test("removeF one match at beginning", () =>
-    expect(List.removeF(Int.eq, 0, [0, 1, 2])) |> toEqual([1, 2])
+  test("removeBy one match at beginning", () =>
+    expect(List.removeBy(Int.eq, 0, [0, 1, 2])) |> toEqual([1, 2])
   );
 
-  test("removeF one match at end", () =>
-    expect(List.removeF(Int.eq, 2, [0, 1, 2])) |> toEqual([0, 1])
+  test("removeBy one match at end", () =>
+    expect(List.removeBy(Int.eq, 2, [0, 1, 2])) |> toEqual([0, 1])
   );
 
-  test("removeF many matches", () =>
-    expect(List.removeF(Int.eq, 0, [1, 0, 2, 0])) |> toEqual([1, 2, 0])
+  test("removeBy many matches", () =>
+    expect(List.removeBy(Int.eq, 0, [1, 0, 2, 0])) |> toEqual([1, 2, 0])
   );
 
-  test("removeEachF empty", () =>
-    expect(List.removeEachF(Int.eq, 0, [])) |> toEqual([])
+  test("removeEachBy empty", () =>
+    expect(List.removeEachBy(Int.eq, 0, [])) |> toEqual([])
   );
 
-  test("removeEachF single match", () =>
-    expect(List.removeEachF(Int.eq, 0, [0])) |> toEqual([])
+  test("removeEachBy single match", () =>
+    expect(List.removeEachBy(Int.eq, 0, [0])) |> toEqual([])
   );
 
-  test("removeEachF single not a match", () =>
-    expect(List.removeEachF(Int.eq, 0, [1])) |> toEqual([1])
+  test("removeEachBy single not a match", () =>
+    expect(List.removeEachBy(Int.eq, 0, [1])) |> toEqual([1])
   );
 
-  test("removeEachF many matches removed", () =>
-    expect(List.removeEachF(Int.eq, 0, [0, 2, 0, 4, 0])) |> toEqual([2, 4])
+  test("removeEachBy many matches removed", () =>
+    expect(List.removeEachBy(Int.eq, 0, [0, 2, 0, 4, 0])) |> toEqual([2, 4])
   );
 
-  test("distinct", () =>
-    expect(List.distinctF(Int.eq, [6, 1, 1, 2, 1, 3, 2, 3, 2, 4, 5, 5]))
+  test("distinctBy", () =>
+    expect(List.distinctBy(Int.eq, [6, 1, 1, 2, 1, 3, 2, 3, 2, 4, 5, 5]))
     |> toEqual([6, 1, 2, 3, 4, 5])
   );
 
@@ -541,16 +541,16 @@ describe("List", () => {
     expect(List.toArray([1, 2, 3])) |> toEqual([|1, 2, 3|])
   );
 
-  test("eqF returns true if list items are equal", () =>
-    expect(List.eqF(Int.eq, [1, 2, 3], [1, 2, 3])) |> toBe(true)
+  test("eqBy returns true if list items are equal", () =>
+    expect(List.eqBy(Int.eq, [1, 2, 3], [1, 2, 3])) |> toBe(true)
   );
 
-  test("eqF returns false if list items are not equal", () =>
-    expect(List.eqF(Int.eq, [1, 2, 3], [1, 2, 4])) |> toBe(false)
+  test("eqBy returns false if list items are not equal", () =>
+    expect(List.eqBy(Int.eq, [1, 2, 3], [1, 2, 4])) |> toBe(false)
   );
 
-  test("eqF returns false if lists are of different sizes", () =>
-    expect(List.eqF(Int.eq, [1], [1, 2])) |> toBe(false)
+  test("eqBy returns false if lists are of different sizes", () =>
+    expect(List.eqBy(Int.eq, [1], [1, 2])) |> toBe(false)
   );
 
   test("eq returns true if list items are equal", () =>
@@ -575,8 +575,8 @@ describe("List", () => {
     |> toEqual([1, 2, 3])
   );
 
-  test("showF", () =>
-    expect(List.showF(string_of_int, [1, 2, 3])) |> toEqual("[1, 2, 3]")
+  test("showBy", () =>
+    expect(List.showBy(string_of_int, [1, 2, 3])) |> toEqual("[1, 2, 3]")
   );
 
   test("void", () =>

--- a/__tests__/Relude_Option_test.re
+++ b/__tests__/Relude_Option_test.re
@@ -162,20 +162,20 @@ describe("Option", () => {
     expect(Option.flatten(Some(Some(1)))) |> toEqual(Some(1))
   );
 
-  test("eqF is true when inner values match", () =>
-    expect(Option.eqF(Int.eq, Some(1), Some(1))) |> toEqual(true)
+  test("eqBy is true when inner values match", () =>
+    expect(Option.eqBy(Int.eq, Some(1), Some(1))) |> toEqual(true)
   );
 
-  test("eqF is false when inner values do not match", () =>
-    expect(Option.eqF(Int.eq, Some(1), Some(2))) |> toEqual(false)
+  test("eqBy is false when inner values do not match", () =>
+    expect(Option.eqBy(Int.eq, Some(1), Some(2))) |> toEqual(false)
   );
 
-  test("eqF is false when one option is Some and one is None", () =>
-    expect(Option.eqF(Int.eq, Some(1), None)) |> toEqual(false)
+  test("eqBy is false when one option is Some and one is None", () =>
+    expect(Option.eqBy(Int.eq, Some(1), None)) |> toEqual(false)
   );
 
-  test("eqF is true when both options are None", () =>
-    expect(Option.eqF(Int.eq, None, None)) |> toEqual(true)
+  test("eqBy is true when both options are None", () =>
+    expect(Option.eqBy(Int.eq, None, None)) |> toEqual(true)
   );
 
   test("eq is true when inner values match", () =>

--- a/src/Relude_Array.re
+++ b/src/Relude_Array.re
@@ -297,12 +297,12 @@ let mkString: (string, array(string)) => string =
 
 module Eq = BsAbstract.Array.Eq;
 
-let rec eqF: (('a, 'a) => bool, array('a), array('a)) => bool =
+let rec eqBy: (('a, 'a) => bool, array('a), array('a)) => bool =
   (innerEq, xs, ys) =>
     switch (head(xs), head(ys)) {
     | (None, None) => true
     | (Some(x), Some(y)) when innerEq(x, y) =>
-      eqF(innerEq, tailOrEmpty(xs), tailOrEmpty(ys))
+      eqBy(innerEq, tailOrEmpty(xs), tailOrEmpty(ys))
     | _ => false
     };
 
@@ -315,12 +315,12 @@ let eq =
     )
     : bool => {
   module EqA = (val eqA);
-  eqF(EqA.eq, xs, ys);
+  eqBy(EqA.eq, xs, ys);
 };
 
 module Show = BsAbstract.Array.Show;
 
-let showF: ('a => string, array('a)) => string =
+let showBy: ('a => string, array('a)) => string =
   (showX, xs) => {
     let strings = map(showX, xs);
     "[" ++ mkString(", ", strings) ++ "]";
@@ -334,7 +334,7 @@ let show =
     )
     : string => {
   module ShowA = (val showA);
-  showF(ShowA.show, xs);
+  showBy(ShowA.show, xs);
 };
 
 module SemigroupAny:
@@ -387,8 +387,8 @@ module Sequence: Relude_Sequence.SEQUENCE with type t('a) = array('a) = {
   let head = head;
   let tail = tail;
   let tailOrEmpty = tailOrEmpty;
-  let eqF = eqF;
-  let showF = showF;
+  let eqBy = eqBy;
+  let showBy = showBy;
   let mkString = mkString;
 
   module SemigroupAny = SemigroupAny;

--- a/src/Relude_Identity.re
+++ b/src/Relude_Identity.re
@@ -56,7 +56,7 @@ let eq =
   AEq.eq(unwrap(fa), unwrap(fb));
 };
 
-let eqF: (('a, 'a) => bool, t('a), t('a)) => bool =
+let eqBy: (('a, 'a) => bool, t('a), t('a)) => bool =
   (f, fa, fb) => f(unwrap(fa), unwrap(fb));
 
 let show =
@@ -70,7 +70,7 @@ let show =
   AShow.show(unwrap(fa));
 };
 
-let showF: ('a => string, t('a)) => string = (f, fa) => f(unwrap(fa));
+let showBy: ('a => string, t('a)) => string = (f, fa) => f(unwrap(fa));
 
 /* TODO: semigroup/monoid/plus/alt/etc. */
 
@@ -101,7 +101,7 @@ module type EQ_F =
 module Eq: EQ_F =
   (E: BsAbstract.Interface.EQ) => {
     type nonrec t = t(E.t);
-    let eq: (t, t) => bool = (fa, fb) => eqF(E.eq, fa, fb);
+    let eq: (t, t) => bool = (fa, fb) => eqBy(E.eq, fa, fb);
   };
 
 module type SHOW_F =
@@ -111,5 +111,5 @@ module type SHOW_F =
 module Show: SHOW_F =
   (E: BsAbstract.Interface.SHOW) => {
     type nonrec t = t(E.t);
-    let show: t => string = fa => showF(E.show, fa);
+    let show: t => string = fa => showBy(E.show, fa);
   };

--- a/src/Relude_List.re
+++ b/src/Relude_List.re
@@ -330,7 +330,7 @@ let scanRight: (('a, 'b) => 'b, 'b, list('a)) => list('b) =
 
 module Show = BsAbstract.List.Show;
 
-let showF: ('a => string, list('a)) => string =
+let showBy: ('a => string, list('a)) => string =
   (innerShow, xs) => {
     let joinStrings = intercalate((module BsAbstract.String.Monoid));
     "[" ++ joinStrings(", ", map(innerShow, xs)) ++ "]";
@@ -344,16 +344,16 @@ let show =
     )
     : string => {
   module ShowA = (val showA);
-  showF(ShowA.show, xs);
+  showBy(ShowA.show, xs);
 };
 
 module Eq = BsAbstract.List.Eq;
 
-let rec eqF: (('a, 'a) => bool, list('a), list('a)) => bool =
+let rec eqBy: (('a, 'a) => bool, list('a), list('a)) => bool =
   (innerEq, a, b) =>
     switch (a, b) {
     | ([], []) => true
-    | ([x, ...xs], [y, ...ys]) when innerEq(x, y) => eqF(innerEq, xs, ys)
+    | ([x, ...xs], [y, ...ys]) when innerEq(x, y) => eqBy(innerEq, xs, ys)
     | _ => false
     };
 
@@ -366,11 +366,11 @@ let eq =
     )
     : bool => {
   module EqA = (val eqA);
-  eqF(EqA.eq, xs, ys);
+  eqBy(EqA.eq, xs, ys);
 };
 
 /* TODO: distinct function that uses ordering so we can use a faster Set (Belt.Set?) to check for uniqueness */
-let distinctF: 'a. (('a, 'a) => bool, list('a)) => list('a) =
+let distinctBy: 'a. (('a, 'a) => bool, list('a)) => list('a) =
   (eq, xs) =>
     foldLeft(
       /* foldRight would probably be faster with cons, but you lose the original ordering on the list */
@@ -388,10 +388,10 @@ let distinct =
     )
     : list(a) => {
   module EqA = (val eqA);
-  distinctF(EqA.eq, xs);
+  distinctBy(EqA.eq, xs);
 };
 
-let removeF: 'a. (('a, 'a) => bool, 'a, list('a)) => list('a) =
+let removeBy: 'a. (('a, 'a) => bool, 'a, list('a)) => list('a) =
   (innerEq, v, xs) => {
     let go = ((found, ys), x) =>
       found ?
@@ -409,10 +409,10 @@ let remove =
     )
     : list(a) => {
   module EqA = (val eqA);
-  removeF(EqA.eq, x, xs);
+  removeBy(EqA.eq, x, xs);
 };
 
-let removeEachF: 'a. (('a, 'a) => bool, 'a, list('a)) => list('a) =
+let removeEachBy: 'a. (('a, 'a) => bool, 'a, list('a)) => list('a) =
   (innerEq, x, xs) =>
     foldLeft((ys, v) => innerEq(x, v) ? ys : [v, ...ys], [], xs) |> reverse;
 
@@ -425,7 +425,7 @@ let removeEach =
     )
     : list(a) => {
   module EqA = (val eqA);
-  removeEachF(EqA.eq, x, xs);
+  removeEachBy(EqA.eq, x, xs);
 };
 
 let sumFloat: list(float) => float =
@@ -446,8 +446,8 @@ module Sequence: Relude_Sequence.SEQUENCE with type t('a) = list('a) = {
   let tail = tail;
   let tailOrEmpty = tailOrEmpty;
   let mkString = intercalate((module BsAbstract.String.Monoid));
-  let eqF = eqF;
-  let showF = showF;
+  let eqBy = eqBy;
+  let showBy = showBy;
 
   module SemigroupAny = SemigroupAny;
   module MonoidAny = MonoidAny;

--- a/src/Relude_NonEmpty.re
+++ b/src/Relude_NonEmpty.re
@@ -81,11 +81,11 @@ module NonEmptyF = (TailSequence: Relude_Sequence.SEQUENCE) => {
       | NonEmpty(y, ys) => y ++ delim ++ TailSequence.mkString(delim, ys)
       };
 
-  let eqF: (('a, 'a) => bool, t('a), t('a)) => bool =
+  let eqBy: (('a, 'a) => bool, t('a), t('a)) => bool =
     (eqA, xs, ys) =>
       switch (xs, ys) {
       | (NonEmpty(x, xs), NonEmpty(y, ys)) =>
-        eqA(x, y) && TailSequence.eqF(eqA, xs, ys)
+        eqA(x, y) && TailSequence.eqBy(eqA, xs, ys)
       };
 
   let eq =
@@ -97,10 +97,10 @@ module NonEmptyF = (TailSequence: Relude_Sequence.SEQUENCE) => {
       )
       : bool => {
     module EqA = (val eqA);
-    eqF(EqA.eq, xs, ys);
+    eqBy(EqA.eq, xs, ys);
   };
 
-  let showF: ('a => string, t('a)) => string =
+  let showBy: ('a => string, t('a)) => string =
     (showX, xs) => {
       let strings = map(showX, xs);
       "[!" ++ mkString(", ", strings) ++ "!]";
@@ -114,7 +114,7 @@ module NonEmptyF = (TailSequence: Relude_Sequence.SEQUENCE) => {
       )
       : string => {
     module ShowA = (val showA);
-    showF(ShowA.show, xs);
+    showBy(ShowA.show, xs);
   };
 
   module SemigroupAny:
@@ -219,7 +219,7 @@ module NonEmptyF = (TailSequence: Relude_Sequence.SEQUENCE) => {
   module Eq: EQ_F =
     (EqA: BsAbstract.Interface.EQ) => {
       type nonrec t = t(EqA.t);
-      let eq = (xs, ys) => eqF(EqA.eq, xs, ys);
+      let eq = (xs, ys) => eqBy(EqA.eq, xs, ys);
     };
 };
 

--- a/src/Relude_Option.re
+++ b/src/Relude_Option.re
@@ -60,7 +60,7 @@ let filter: ('a => bool, option('a)) => option('a) =
 
 let flatten: option(option('a)) => option('a) = opt => bind(opt, a => a);
 
-let eqF: (('a, 'a) => bool, option('a), option('a)) => bool =
+let eqBy: (('a, 'a) => bool, option('a), option('a)) => bool =
   (innerEq, a, b) =>
     switch (a, b) {
     | (Some(va), Some(vb)) => innerEq(va, vb)

--- a/src/Relude_Sequence.re
+++ b/src/Relude_Sequence.re
@@ -8,8 +8,8 @@ module type SEQUENCE = {
   let tail: t('a) => option(t('a));
   let tailOrEmpty: t('a) => t('a);
   let mkString: (string, t(string)) => string;
-  let eqF: (('a, 'a) => bool, t('a), t('a)) => bool;
-  let showF: ('a => string, t('a)) => string;
+  let eqBy: (('a, 'a) => bool, t('a), t('a)) => bool;
+  let showBy: ('a => string, t('a)) => string;
 
   module SemigroupAny: BsAbstract.Interface.SEMIGROUP_ANY with type t('a) = t('a);
   module MonoidAny: BsAbstract.Interface.MONOID_ANY with type t('a) = t('a);

--- a/src/Relude_Void.re
+++ b/src/Relude_Void.re
@@ -6,7 +6,7 @@ type t =
 
 /**
 A function that can be used when you need to provide a function from Void.t => 'a.
-The function will never actually be called, because it's impossible to construct a valud of type Void.t.
+The function will never actually be called, because it's impossible to construct a value of type Void.t.
  */
 let absurd: t => 'a =
   void => {


### PR DESCRIPTION
- Closes #28 - changes all functions that were previously named showF,
eqF, etc. to showBy, eqBy, etc.  I tried to find them all, but it's
possible that I missed some, which we can fix as we find them.