### PR TITLE
Fix negative indices.

### DIFF
--- a/__tests__/Relude_List_test.re
+++ b/__tests__/Relude_List_test.re
@@ -190,7 +190,7 @@ describe("List", () => {
   );
 
   test("take negative from list", () =>
-    expect(List.take(-2, [])) |> toEqual(Some([]))
+    expect(List.take(-2, [])) |> toEqual(None)
   );
 
   test("take zero from empty list", () =>

--- a/src/Relude_Array.re
+++ b/src/Relude_Array.re
@@ -227,14 +227,20 @@ let last: array('a) => option('a) =
 
 let take: (int, array('a)) => option(array('a)) =
   (i, xs) =>
-    if (i > length(xs)) {
+    if (i < 0 || i > length(xs)) {
       None;
     } else {
       Some(Belt.Array.slice(xs, ~offset=0, ~len=i));
     };
 
 let takeUpTo: (int, array('a)) => array('a) =
-  (i, xs) => Belt.Array.slice(xs, ~offset=0, ~len=i);
+  (i, xs) => {
+    if (i >= 0) {
+      Belt.Array.slice(xs, ~offset=0, ~len=i);
+    } else {
+      [| |]
+    }
+  };
 
 let rec takeWhile: ('a => bool, array('a)) => array('a) =
   (f, xs) =>
@@ -245,7 +251,7 @@ let rec takeWhile: ('a => bool, array('a)) => array('a) =
 
 let drop: (int, array('a)) => option(array('a)) =
   (i, xs) =>
-    if (i > length(xs)) {
+    if (i < 0 || i > length(xs)) {
       None;
     } else {
       Some(Belt.Array.sliceToEnd(xs, i));
@@ -254,14 +260,18 @@ let drop: (int, array('a)) => option(array('a)) =
 let dropUpTo: (int, array('a)) => array('a) =
   (i, xs) => {
     let l = length(xs);
-    Belt.Array.sliceToEnd(
-      xs,
-      if (i > l) {
-        l;
-      } else {
-        i;
-      },
-    );
+    if (i >= 0) {
+      Belt.Array.sliceToEnd(
+        xs,
+        if (i > l) {
+          l;
+        } else {
+          i;
+        },
+      );
+    } else {
+      [| |]
+    }
   };
 
 let rec dropWhile: ('a => bool, array('a)) => array('a) =
@@ -301,7 +311,7 @@ let partition: ('a => bool, array('a)) => (array('a), array('a)) =
 
 let splitAt: (int, array('a)) => option((array('a), array('a))) =
   (i, xs) =>
-    if (i > length(xs)) {
+    if (i < 0 || i > length(xs)) {
       None;
     } else {
       Some((

--- a/src/Relude_List.re
+++ b/src/Relude_List.re
@@ -77,6 +77,7 @@ let rec last: list('a) => option('a) =
   | [x] => Some(x)
   | [_, ...xs] => last(xs);
 
+  /* TODO: why not use Belt.List.take(), as drop uses Belt.List.drop()? */
 let take: (int, list('a)) => option(list('a)) =
   (i, xs) => {
     let rec go = (acc, count, rest) =>
@@ -85,7 +86,11 @@ let take: (int, list('a)) => option(list('a)) =
       | [] => None
       | [y, ...ys] => go([y, ...acc], count - 1, ys)
       };
-    go([], i, xs) |> Relude_Option.map(reverse);
+    if (i >= 0) {
+      go([], i, xs) |> Relude_Option.map(reverse);
+    } else {
+      None;
+    }
   };
 
 let takeUpTo: (int, list('a)) => list('a) =
@@ -96,7 +101,11 @@ let takeUpTo: (int, list('a)) => list('a) =
       | [] => acc
       | [y, ...ys] => go([y, ...acc], count - 1, ys)
       };
-    go([], i, xs) |> reverse;
+    if (i >= 0) {
+      go([], i, xs) |> reverse;
+    } else {
+      [| |]
+    }
   };
 
 let takeWhile: ('a => bool, list('a)) => list('a) =
@@ -115,10 +124,14 @@ let drop: (int, list('a)) => option(list('a)) =
 
 let rec dropUpTo: (int, list('a)) => list('a) =
   (i, xs) =>
-    switch (xs) {
-    | [] => []
-    | [_, ..._] when i <= 0 => xs
-    | [_, ...ys] => dropUpTo(i - 1, ys)
+    if (i >= 0) {
+      switch (xs) {
+      | [] => []
+      | [_, ..._] when i <= 0 => xs
+      | [_, ...ys] => dropUpTo(i - 1, ys)
+      };
+    } else {
+      [ ]
     };
 
 let rec dropWhile: ('a => bool, list('a)) => list('a) =

--- a/src/Relude_List.re
+++ b/src/Relude_List.re
@@ -104,7 +104,7 @@ let takeUpTo: (int, list('a)) => list('a) =
     if (i >= 0) {
       go([], i, xs) |> reverse;
     } else {
-      [| |]
+      [ ]
     }
   };
 


### PR DESCRIPTION
Fix `take()`, `takeUpTo()`, `drop()`, `dropUpTo()`, and `splitAt()` to return `None` or the empty array (depending upon their return type) when given a negative index.