### PR TITLE
Fix Option Infix (>>=) argument order

### DIFF
--- a/__tests__/Relude_Option_test.re
+++ b/__tests__/Relude_Option_test.re
@@ -69,6 +69,11 @@ describe("Option", () => {
     expect(Option.bind(Some(1), a => Some(a + 2))) |> toEqual(Some(3))
   );
 
+  test(">>=", () => {
+    let (>>=) = Relude_Option.Infix.(>>=);
+    expect(Some(1) >>= a => Some(a + 2)) |> toEqual(Some(3))
+  });
+
   test("map2", () =>
     expect(Option.map2((a, b) => a + b, Some(1), Some(2)))
     |> toEqual(Some(3))

--- a/__tests__/Relude_Result_test.re
+++ b/__tests__/Relude_Result_test.re
@@ -13,6 +13,16 @@ describe("Result", () => {
     |> toEqual(Belt.Result.Ok(3))
   );
 
+  test("flatMap", () =>
+    expect(Result.flatMap(a => Belt.Result.Ok(a + 2), Belt.Result.Ok(1)))
+    |> toEqual(Belt.Result.Ok(3))
+  );
+
+  test("bind", () =>
+    expect(Result.bind(Belt.Result.Ok(1), a => Belt.Result.Ok(a + 2)))
+    |> toEqual(Belt.Result.Ok(3))
+  );
+
   test("fold Ok", () =>
     expect(Result.fold(_ => "error", _ => "ok", Belt.Result.Ok(1)))
     |> toEqual("ok")

--- a/src/Relude_Option.re
+++ b/src/Relude_Option.re
@@ -157,5 +157,5 @@ module Infix = {
   let (<|>) = alt;
   let (<$>) = map;
   let (<*>) = apply;
-  let (>>=) = flatMap;
+  let (>>=) = bind;
 };


### PR DESCRIPTION
- This was a result of our shuffling of flatMap/bind functions.
- Closes #47