### PR TITLE
Ideas on Promise/IO conversions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: npm ci
+      - run: npm install
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: npm install
+      - run: npm ci
 
       - save_cache:
           paths:

--- a/src/Relude.re
+++ b/src/Relude.re
@@ -23,5 +23,6 @@ module Result = Relude_Result;
 module ResultIor = Relude_ResultIor;
 module Sequence = Relude_Sequence;
 module String = Relude_String;
+module Unsafe = Relude_Unsafe;
 module Validation = Relude_Validation;
 module Void = Relude_Void;

--- a/src/Relude_IO.re
+++ b/src/Relude_IO.re
@@ -162,7 +162,7 @@ let triesJS: 'a. (unit => 'a) => t('a, Js.Exn.t) =
         try (Pure(getA())) {
         | Js.Exn.Error(jsExn) => Throw(jsExn)
         | exn =>
-          let jsExn = JsExn.fromExn(exn);
+          let jsExn = JsExn.unsafeFromExn(exn);
           Throw(jsExn);
         },
     );

--- a/src/Relude_JsExn.re
+++ b/src/Relude_JsExn.re
@@ -6,7 +6,7 @@ let throw: string => unit = [%bs.raw
   {| function(message) { throw new Error(message); } |}
 ];
 
-let fromExn: exn => Js.Exn.t =
+let unsafeFromExn: exn => Js.Exn.t =
   exn => {
     let makeUnknownJsExn: exn => Js.Exn.t = [%bs.raw
       {| function(exn) { return new Error("Unexpected error: " + exn); } |}
@@ -16,3 +16,5 @@ let fromExn: exn => Js.Exn.t =
     | _ => makeUnknownJsExn(exn)
     };
   };
+
+external unsafeToExn: Js.Exn.t => exn = "%identity";

--- a/src/Relude_JsPromise.re
+++ b/src/Relude_JsPromise.re
@@ -1,4 +1,4 @@
-let toIO: Js.Promise.t('a) => Relude_IO.t('a, Js.Promise.error) =
+let toIO: 'a. Js.Promise.t('a) => Relude_IO.t('a, Js.Promise.error) =
   promise =>
     Relude_IO.async(onDone =>
       promise
@@ -13,7 +13,21 @@ let toIO: Js.Promise.t('a) => Relude_IO.t('a, Js.Promise.error) =
       |> ignore
     );
 
-let fromIO: Relude_IO.t('a, 'e) => Js.Promise.t('a) =
+/* TODO: not sure how best to handle exn/Js.Exn.t/Js.Promise.error below... open to suggestions/ideas */
+
+let fromIO: 'a 'e. Relude_IO.t('a, 'e) => Js.Promise.t('a) =
+  io =>
+    Js.Promise.make((~resolve, ~reject) =>
+      io
+      |> Relude_IO.unsafeRunAsync(result =>
+           switch (result) {
+           | Belt.Result.Ok(v) => resolve(. v)
+           | Belt.Result.Error(e) => reject(. Relude_Unsafe.coerce(e)) /* TODO: not sure if this is wise/good */
+           }
+         )
+    );
+
+let fromIOExn: 'a. Relude_IO.t('a, exn) => Js.Promise.t('a) =
   io =>
     Js.Promise.make((~resolve, ~reject) =>
       io
@@ -21,6 +35,18 @@ let fromIO: Relude_IO.t('a, 'e) => Js.Promise.t('a) =
            switch (result) {
            | Belt.Result.Ok(v) => resolve(. v)
            | Belt.Result.Error(e) => reject(. e)
+           }
+         )
+    );
+
+let fromIOJsExn: 'a. Relude_IO.t('a, Js.Exn.t) => Js.Promise.t('a) =
+  io =>
+    Js.Promise.make((~resolve, ~reject) =>
+      io
+      |> Relude_IO.unsafeRunAsync(result =>
+           switch (result) {
+           | Belt.Result.Ok(v) => resolve(. v)
+           | Belt.Result.Error(e) => reject(. Relude_JsExn.unsafeToExn(e))
            }
          )
     );

--- a/src/Relude_Unsafe.re
+++ b/src/Relude_Unsafe.re
@@ -1,0 +1,1 @@
+external coerce: 'a => 'b = "%identity";


### PR DESCRIPTION
The Js.Promise error handling is strange, sometimes it uses the OCaml
extensible `exn` type and sometimes `Js.Promise.error` (an opaque type).
Neither of these seem quite right, but we have to satisfy the compiler
somehow.