### PR TITLE
Remove get and set functions to avoid refmt/shadowing issues

### DIFF
--- a/__tests__/Relude_Array_test.re
+++ b/__tests__/Relude_Array_test.re
@@ -44,9 +44,9 @@ describe("Array", () => {
   test("makeWithIndex creates a array of n items using f", () =>
     expect(Array.makeWithIndex(3, i => i + 2)) |> toEqual([|2, 3, 4|])
   );
-  
+
   test("makeWithIndex creates an empty array if given a negative count", () =>
-    expect(Array.makeWithIndex(-1, i => i + 2)) |> toEqual([| |])
+    expect(Array.makeWithIndex(-1, i => i + 2)) |> toEqual([||])
   );
 
   test("concat", () =>
@@ -87,12 +87,11 @@ describe("Array", () => {
     )
     |> toEqual([|1, 2, 3, 4, 5|])
   );
-  
+
   test("foldLeft2", () =>
     expect(Array.foldLeft((acc, item) => acc - item, 0, [|1, 2, 3|]))
     |> toEqual(-6)
   );
-  
 
   test("foldRight", () =>
     expect(
@@ -105,8 +104,6 @@ describe("Array", () => {
     |> toEqual([|5, 4, 3, 2, 1|])
   );
 
-
-  
   test("scanLeft", () =>
     expect(
       Array.scanLeft(
@@ -141,16 +138,29 @@ describe("Array", () => {
        |])
   );
 
-  test("get empty array", () =>
-    expect(0[[||]]) |> toEqual(None)
+  test("at empty array", () =>
+    expect(Array.at(0, [||])) |> toEqual(None)
   );
 
-  test("get success", () =>
-    expect(2[[|0, 10, 20, 30|]]) |> toEqual(Some(20))
+  test("at Some", () =>
+    expect(Array.at(2, [|0, 10, 20, 30|])) |> toEqual(Some(20))
   );
 
-  test("get failure", () =>
-    expect(10[[|0, 10, 20, 30|]]) |> toEqual(None)
+  test("at None", () =>
+    expect(Array.at(10, [|0, 10, 20, 30|])) |> toEqual(None)
+  );
+
+  test("setAt empty array", () =>
+    /* Apparently setAt 0 doesn't work on an empty array... */
+    expect(Array.setAt(0, "a", [||])) |> toEqual(None)
+  );
+
+  test("setAt valid index in non-empty array", () =>
+    expect(Array.setAt(1, "a", [|"0", "1", "2"|])) |> toEqual(Some([|"0", "a", "2"|]))
+  );
+
+  test("setAt invalid index in non-empty array", () =>
+    expect(Array.setAt(5, "a", [|"0", "1", "2"|])) |> toEqual(None)
   );
 
   test("head empty array", () =>

--- a/__tests__/Relude_List_test.re
+++ b/__tests__/Relude_List_test.re
@@ -117,16 +117,16 @@ describe("List", () => {
     |> toEqual([[5, 4, 3, 2, 1], [5, 4, 3, 2], [5, 4, 3], [5, 4], [5]])
   );
 
-  test("get empty list", () =>
-    expect(List.get(0, [])) |> toEqual(None)
+  test("at empty list", () =>
+    expect(List.at(0, [])) |> toEqual(None)
   );
 
-  test("get success", () =>
-    expect(List.get(2, [0, 10, 20, 30])) |> toEqual(Some(20))
+  test("at success", () =>
+    expect(List.at(2, [0, 10, 20, 30])) |> toEqual(Some(20))
   );
 
-  test("get failure", () =>
-    expect(List.get(10, [0, 10, 20, 30])) |> toEqual(None)
+  test("at failure", () =>
+    expect(List.at(10, [0, 10, 20, 30])) |> toEqual(None)
   );
 
   test("head empty list", () =>

--- a/__tests__/Relude_String_test.re
+++ b/__tests__/Relude_String_test.re
@@ -73,30 +73,30 @@ describe("String", () => {
     expect(Str.toLowerCase("ReLude!")) |> toEqual("relude!")
   );
 
-  test("get success", () =>
-    expect(Str.get(2, "abcdefg")) |> toEqual(Some("c"))
+  test("charAt success", () =>
+    expect(Str.charAt(2, "abcdefg")) |> toEqual(Some("c"))
   );
 
-  test("get failure", () =>
-    expect(Str.get(7, "abcdefg")) |> toEqual(None)
+  test("charAt failure", () =>
+    expect(Str.charAt(7, "abcdefg")) |> toEqual(None)
   );
 
-  test("getNullable success", () =>
-    expect(Str.getNullable(2, "abcdefg"))
+  test("charAtNullable success", () =>
+    expect(Str.charAtNullable(2, "abcdefg"))
     |> toEqual(Js.Nullable.return("c"))
   );
 
-  test("getNullable failure", () =>
-    expect(Str.getNullable(7, "abcdefg")) |> toEqual(Js.Nullable.undefined)
+  test("charAtNullable failure", () =>
+    expect(Str.charAtNullable(7, "abcdefg")) |> toEqual(Js.Nullable.undefined)
   );
 
-  test("getOrThrow success", () =>
-    expect(Str.getOrThrow(2, "abcdefg")) |> toEqual("c")
+  test("charAtOrThrow success", () =>
+    expect(Str.charAtOrThrow(2, "abcdefg")) |> toEqual("c")
   );
 
-  test("getOrThrow failure", () =>
+  test("charAtOrThrow failure", () =>
     expect(() =>
-      Str.getOrThrow(7, "abcdefg")
+      Str.charAtOrThrow(7, "abcdefg")
     ) |> toThrow
   );
 

--- a/src/Relude_Array.re
+++ b/src/Relude_Array.re
@@ -26,7 +26,7 @@ let empty: array('a) = [||];
 
 /**
   `pure(item)` returns an array containing the given item.
-  
+
   ## Example
   ```re
   pure("single") == [|"single"|];
@@ -41,7 +41,7 @@ let one: 'a => array('a) = pure;
 
 /**
   `repeat(n, x)` returns an array containing `n` copies of `x`.
-  
+
   ## Example
   ```re
   repeat(3, "ha") == [|"ha", "ha", "ha"|];
@@ -53,8 +53,8 @@ let repeat: (int, 'a) => array('a) = (i, x) => Belt.Array.make(i, x);
 
 /**
   `makeWithIndex(n, f)` returns the array `[|f(0), f(1), ... f(n - 1)|]`.
-  
-  
+
+
   ## Example
   ```re
   makeWithIndex(3, (x) => {(x + 4) * (x + 4)}) == [|16, 25, 36|];
@@ -67,7 +67,7 @@ let makeWithIndex: (int, int => 'a) => array('a) = Belt.Array.makeBy;
 /**
   `concat(xs, ys)` returns an array with the elements of `xs` followed
   by the elements of `ys`.
-  
+
   ## Example
   ```re
   concat([|"a", "b"|], [|"c", "d"|]) == [|"a", "b", "c", "d"|];
@@ -79,7 +79,7 @@ let concat: (array('a), array('a)) => array('a) = Belt.Array.concat;
 
 /**
   `cons(x, xs)` returns a new array with value `x` at the beginning.
-  
+
   ## Example
   ```re
   cons(99, [|100, 101|]) == [|99, 100, 101|];
@@ -114,7 +114,7 @@ let prepend: ('a, array('a)) => array('a) = cons;
 
 /**
   `append(x, xs)` adds the value `x` at the end of array `xs`.
-  
+
   ## Example
   ```re
   append(999, [|100, 101, 102|]) == [|100, 102, 103, 999|];
@@ -131,7 +131,7 @@ let append: ('a, array('a)) => array('a) =
   becomes the new value of the accumulator, and `f` is applied to that value
   and the next element in `xs`. This process continues until all elements in
   `xs` are processed. The final value of the accumulator is returned.
-  
+
   ## Example
   ```re
   foldLeft((acc, item) => append(item, acc), [| |], [|1, 2, 3|]) == [|1, 2, 3|];
@@ -147,7 +147,7 @@ let foldLeft: (('b, 'a) => 'b, 'b, array('a)) => 'b = BsAbstract.Array.Foldable.
   becomes the new value of the accumulator, and `f` is applied to that value
   and the preceding element in `xs`. This process continues until all elements in
   `xs` are processed. The final value of the accumulator is returned.
-  
+
   ## Example
   ```re
   foldRight((item, acc) => append(item, acc), [| |], [|1, 2, 3|]) == [|3, 2, 1|];
@@ -182,10 +182,15 @@ let scanRight: (('a, 'b) => 'b, 'b, array('a)) => array('b) =
       ),
     );
 
-let get: (int, array('a)) => option('a) = (i, xs) => Belt.Array.get(xs, i);
+let at: (int, array('a)) => option('a) = (i, xs) => Belt.Array.get(xs, i);
 
-let set: (int, 'a, array('a)) => bool =
-  (i, x, xs) => Belt.Array.set(xs, i, x);
+let setAt: (int, 'a, array('a)) => option(array('a)) =
+  (i, x, xs) =>
+    if (Belt.Array.set(xs, i, x)) {
+      Some(xs);
+    } else {
+      None;
+    };
 
 let head: array('a) => option('a) = arr => Belt.Array.get(arr, 0);
 
@@ -221,7 +226,7 @@ let last: array('a) => option('a) =
     if (l == 0) {
       None;
     } else {
-      get(l - 1, xs);
+      at(l - 1, xs);
     };
   };
 
@@ -234,13 +239,12 @@ let take: (int, array('a)) => option(array('a)) =
     };
 
 let takeUpTo: (int, array('a)) => array('a) =
-  (i, xs) => {
+  (i, xs) =>
     if (i >= 0) {
       Belt.Array.slice(xs, ~offset=0, ~len=i);
     } else {
-      [| |]
-    }
-  };
+      [||];
+    };
 
 let rec takeWhile: ('a => bool, array('a)) => array('a) =
   (f, xs) =>
@@ -270,8 +274,8 @@ let dropUpTo: (int, array('a)) => array('a) =
         },
       );
     } else {
-      [| |]
-    }
+      [||];
+    };
   };
 
 let rec dropWhile: ('a => bool, array('a)) => array('a) =
@@ -336,7 +340,11 @@ let intersperse: ('a, array('a)) => array('a) =
 
 let replicate: (int, array('a)) => array('a) =
   (i, xs) =>
-    foldLeft((acc, _i) => concat(acc, xs), [||], Relude_Int.rangeAsArray(0, i));
+    foldLeft(
+      (acc, _i) => concat(acc, xs),
+      [||],
+      Relude_Int.rangeAsArray(0, i),
+    );
 
 let zip: (array('a), array('b)) => array(('a, 'b)) = Belt.Array.zip;
 
@@ -413,7 +421,8 @@ let apply: (array('a => 'b), array('a)) => array('b) = BsAbstract.Array.Apply.ap
 
 let bind: (array('a), 'a => array('b)) => array('b) = BsAbstract.Array.Monad.flat_map;
 
-let flatMap: ('a => array('b), array('a)) => array('b) = (f, fa) => bind(fa, f);
+let flatMap: ('a => array('b), array('a)) => array('b) =
+  (f, fa) => bind(fa, f);
 
 let flatten: array(array('a)) => array('a) = Belt.Array.concatMany;
 

--- a/src/Relude_List.re
+++ b/src/Relude_List.re
@@ -49,7 +49,7 @@ let isEmpty: list('a) => bool =
 
 let isNotEmpty: list('a) => bool = xs => !isEmpty(xs);
 
-let get: (int, list('a)) => option('a) = (i, xs) => Belt.List.get(xs, i);
+let at: (int, list('a)) => option('a) = (i, xs) => Belt.List.get(xs, i);
 
 let head: list('a) => option('a) =
   fun

--- a/src/Relude_String.re
+++ b/src/Relude_String.re
@@ -49,16 +49,16 @@ let toUpperCase: string => string = Js.String.toUpperCase;
 
 let toLowerCase: string => string = Js.String.toLowerCase;
 
-let get: (int, string) => option(string) =
+let charAt: (int, string) => option(string) =
   (i, str) =>
     Js.String.get(str, i) |> Js.Nullable.return |> Js.Nullable.toOption;
 
-let getNullable: (int, string) => Js.Nullable.t(string) =
+let charAtNullable: (int, string) => Js.Nullable.t(string) =
   (i, str) => Js.String.get(str, i) |> Js.Nullable.return;
 
-let getOrThrow: (int, string) => string =
+let charAtOrThrow: (int, string) => string =
   (i, str) =>
-    switch (get(i, str)) {
+    switch (charAt(i, str)) {
     | None =>
       Js.Exn.raiseRangeError(
         "Failed to get string at index "
@@ -70,10 +70,10 @@ let getOrThrow: (int, string) => string =
     };
 
 let toList: string => list(string) =
-  str => Relude_List.makeWithIndex(length(str), i => getOrThrow(i, str));
+  str => Relude_List.makeWithIndex(length(str), i => charAtOrThrow(i, str));
 
 let toArray: string => array(string) =
-  str => Relude_Array.makeWithIndex(length(str), i => getOrThrow(i, str));
+  str => Relude_Array.makeWithIndex(length(str), i => charAtOrThrow(i, str));
 
 let foldLeft: (('b, string) => 'b, 'b, string) => 'b =
   (f, init, str) => Relude_List.foldLeft(f, init, toList(str));


### PR DESCRIPTION
- Closes #46
- Renamed all bare `get` and `set` functions to avoid the dreaded
`String.get` shadowing and the refmt treatment of such functions.