### PR TITLE
Equality checks for Result and Async*

### DIFF
--- a/__tests__/Relude_Array_test.re
+++ b/__tests__/Relude_Array_test.re
@@ -315,7 +315,8 @@ describe("Array", () => {
   );
 
   test("dropExactly some from long array ", () =>
-    expect(Array.dropExactly(2, [|1, 2, 3, 4|])) |> toEqual(Some([|3, 4|]))
+    expect(Array.dropExactly(2, [|1, 2, 3, 4|]))
+    |> toEqual(Some([|3, 4|]))
   );
 
   test("dropExactly more from long array ", () =>
@@ -550,13 +551,28 @@ describe("Array", () => {
   );
 
   test("Array.String.joinWith", () =>
-    expect(Array.String.joinWith(", ", [|"a", "b", "c"|])) |> toEqual("a, b, c")
+    expect(Array.String.joinWith(", ", [|"a", "b", "c"|]))
+    |> toEqual("a, b, c")
   );
 
   test("showBy", () =>
     expect(Array.showBy(string_of_int, [|1, 2, 3|]))
     |> toEqual("[1, 2, 3]")
   );
+
+  // TODO: this fails
+  // https://github.com/Risto-Stevcev/bs-abstract/issues/9
+  // test("alt", () =>
+  //   expect(Array.Alt.alt([|"a", "b"|], [|"c"|]))
+  //   |> toEqual([|"a", "b", "c"|])
+  // );
+
+  test("<|> is associative", () => {
+    let (<|>) = Array.Infix.(<|>);
+    expect([|0, 1|] <|> [|2, 3|] <|> [|4, 5|])
+    |> toEqual([|0, 1|] <|> ([|2, 3|] <|> [|4, 5|]));
+  });
+
   /*
    test("void", () =>
      expect(Array.void([1, 2, 3])) |> toEqual([(), (), ()])

--- a/__tests__/Relude_AsyncData_test.re
+++ b/__tests__/Relude_AsyncData_test.re
@@ -109,11 +109,13 @@ describe("AsyncData state checks", () => {
   );
 
   test("toBusy when Reloading", () =>
-    expect(AsyncData.toBusy(Reloading(1))) |> toEqual(AsyncData.Reloading(1))
+    expect(AsyncData.toBusy(Reloading(1)))
+    |> toEqual(AsyncData.Reloading(1))
   );
 
   test("toBusy when Complete", () =>
-    expect(AsyncData.toBusy(Complete(1))) |> toEqual(AsyncData.Reloading(1))
+    expect(AsyncData.toBusy(Complete(1)))
+    |> toEqual(AsyncData.Reloading(1))
   );
 
   test("toIdle when Init", () =>
@@ -125,11 +127,13 @@ describe("AsyncData state checks", () => {
   );
 
   test("toIdle when Reloading", () =>
-    expect(AsyncData.toIdle(Reloading(1))) |> toEqual(AsyncData.Complete(1))
+    expect(AsyncData.toIdle(Reloading(1)))
+    |> toEqual(AsyncData.Complete(1))
   );
 
   test("toIdle when Complete", () =>
-    expect(AsyncData.toIdle(Complete(1))) |> toEqual(AsyncData.Complete(1))
+    expect(AsyncData.toIdle(Complete(1)))
+    |> toEqual(AsyncData.Complete(1))
   );
 
   test("getReloading when Init", () =>
@@ -275,6 +279,27 @@ describe("AsyncData state checks", () => {
   test("foldByValueLazy when Complete", () =>
     expect(AsyncData.foldByValueLazy(() => 1, a => a + 2, Complete(10)))
     |> toEqual(12)
+  );
+
+  // some sanity checks for equality
+
+  test("eqBy false for Init vs Loading", () =>
+    expect(AsyncData.eqBy((_, _) => true, Init, Loading)) |> toEqual(false)
+  );
+
+  test("eqBy false for Reloading and Complete", () =>
+    expect(AsyncData.eqBy((_, _) => true, Reloading(1), Complete(1)))
+    |> toEqual(false)
+  );
+
+  test("eqBy true for both Complete", () =>
+    expect(AsyncData.eqBy(Relude_String.eq, Complete("a"), Complete("a")))
+    |> toEqual(true)
+  );
+
+  test("eqBy false for both Complete, different values", () =>
+    expect(AsyncData.eqBy(Relude_Int.eq, Complete(0), Complete(1)))
+    |> toEqual(false)
   );
 });
 

--- a/__tests__/Relude_AsyncResult_test.re
+++ b/__tests__/Relude_AsyncResult_test.re
@@ -123,4 +123,28 @@ describe("AsyncResult state checks", () => {
     expect(AsyncResult.(reloadingError("fail") |> getCompleteError))
     |> toEqual(None)
   );
+
+  test("eqBy different constructors", () =>
+    expect(
+      AsyncResult.eqBy(
+        (_, _) => true,
+        (_, _) => true,
+        AsyncResult.init,
+        AsyncResult.loading,
+      ),
+    )
+    |> toEqual(false)
+  );
+
+  test("eqBy same success value", () =>
+    expect(
+      AsyncResult.eqBy(
+        Relude_String.eq,
+        Relude_Int.eq,
+        AsyncResult.ok(1),
+        AsyncResult.ok(1),
+      ),
+    )
+    |> toEqual(true)
+  );
 });

--- a/__tests__/Relude_Result_test.re
+++ b/__tests__/Relude_Result_test.re
@@ -82,4 +82,36 @@ describe("Result", () => {
   test("getError when Ok", () =>
     expect(Result.getError(Belt.Result.Ok(1))) |> toEqual(None)
   );
+
+  test("eqBy when eq, both Ok", () =>
+    expect(Result.eqBy(Relude_Int.eq, Relude_String.eq, Ok("a"), Ok("a")))
+    |> toEqual(true)
+  );
+
+  test("eqBy when not eq, both Ok", () =>
+    expect(Result.eqBy((_, _) => true, Relude_Int.eq, Ok(1), Ok(2)))
+    |> toEqual(false)
+  );
+
+  test("eqBy when first Ok, second Error", () =>
+    expect(Result.eqBy((_, _) => true, (_, _) => true, Ok(1), Error(1)))
+    |> toEqual(false)
+  );
+
+  test("eqBy when first Error, second Ok", () =>
+    expect(Result.eqBy((_, _) => true, (_, _) => true, Error(1), Ok(1)))
+    |> toEqual(false)
+  );
+
+  test("eqBy when eq, both Error", () =>
+    expect(Result.eqBy(Relude_Int.eq, (_, _) => true, Error(1), Error(1)))
+    |> toEqual(true)
+  );
+
+  test("eqBy when not eq, both Error", () =>
+    expect(
+      Result.eqBy((_, _) => false, (_, _) => true, Error(1), Error(1)),
+    )
+    |> toEqual(false)
+  );
 });

--- a/src/Relude_AsyncResult.re
+++ b/src/Relude_AsyncResult.re
@@ -117,6 +117,12 @@ let bind: 'a 'b 'e. (t('a, 'e), 'a => t('b, 'e)) => t('b, 'e) =
 let flatMap: 'a 'b 'e. ('a => t('b, 'e), t('a, 'e)) => t('b, 'e) =
   (f, fa) => bind(fa, f);
 
+let eqBy:
+  'a 'e.
+  (('e, 'e) => bool, ('a, 'a) => bool, t('a, 'e), t('a, 'e)) => bool
+ =
+  (errEq, okEq) => Relude_AsyncData.eqBy(Relude_Result.eqBy(errEq, okEq));
+
 /*******************************************************************************
  * Utilities specific to this type
  ******************************************************************************/

--- a/src/Relude_Result.re
+++ b/src/Relude_Result.re
@@ -140,6 +140,18 @@ let isOk: 'a 'e. t('a, 'e) => bool = r => fold(_ => false, _ => true, r);
 
 let isError: 'a 'e. t('a, 'e) => bool = r => fold(_ => true, _ => false, r);
 
+let eqBy:
+  'a 'e.
+  (('e, 'e) => bool, ('a, 'a) => bool, t('a, 'e), t('a, 'e)) => bool
+ =
+  (errorEq, okEq, a, b) =>
+    switch (a, b) {
+    | (Ok(innerA), Ok(innerB)) => okEq(innerA, innerB)
+    | (Error(innerA), Error(innerB)) => errorEq(innerA, innerB)
+    | (Ok(_), Error(_))
+    | (Error(_), Ok(_)) => false
+    };
+
 let tries: 'a. (unit => 'a) => t('a, exn) =
   fn =>
     try (Ok(fn())) {

--- a/src/Relude_String.re
+++ b/src/Relude_String.re
@@ -24,6 +24,8 @@ let toNonEmpty: string => option(string) =
       Some(s);
     };
 
+let eq: (string, string) => bool = (==);
+
 let isWhitespace: string => bool = s => s |> trim |> isEmpty;
 
 let toNonWhitespace: string => option(string) =


### PR DESCRIPTION
- `Relude.Result.eqBy: (errEq, okEq, resultA, resultB) => bool`
- `Relude.AsyncResult.eqBy: (errEq, okEq, asyncA, asyncB) => bool`
- `Relude.AsyncData.eqBy: (innerEq, asyncA, asyncB) => bool`

I'm realizing the above isn't valid syntax, but it's less verbose than writing out the full signature, and it explains what's going on.

Also, there seems to be some issue with the inferred type of `Relude.String.Eq` which makes it impossible to get into the inner functions, but at least now you can use `Relude.String.eq` like a champ.