### PR TITLE
Array with modules

### DIFF
--- a/src/data/Relude_Array.rei
+++ b/src/data/Relude_Array.rei
@@ -62,7 +62,7 @@ let map: ('a => 'b, array('a)) => array('b);
 let void: array('a) => array(unit);
 
 /**
-  `apply(fs, xs) takes an array of functions and an array of values and creates
+  `apply(fs, xs)` takes an array of functions and an array of values and creates
   an array whose contents are the result of applying the first function of `fs`
   to all the elements of `xs`, the second function of
   `fs` to all the elements of `xs`, and so on. All the functions in `fs` must
@@ -88,7 +88,6 @@ let apply: (array('a => 'b), array('a)) => array('b);
   flap([|square, cube|], 10) == [|100, 1000|];
   ```
 */
-
 let flap: (array('a => 'b), 'a) => array('b);
 
 /**
@@ -219,7 +218,7 @@ let flatten: array(array('a)) => array('a);
 /**
   `foldLeft(f, init, xs)` accumulates a value. Starting with `init`,
   as the initial value of the accumulator, `foldLeft` applies function
-  `f` to the accumulator and the first element in the list. The result
+  `f` to the accumulator and the first element in the array `xs`. The result
   becomes the new value of the accumulator, and `f` is applied to that value
   and the next element in `xs`. This process continues until all elements in
   `xs` are processed. The final value of the accumulator is returned.
@@ -235,7 +234,7 @@ let foldLeft: (('b, 'a) => 'b, 'b, array('a)) => 'b;
 /**
   `foldRight(f, init, xs)` accumulates a value. Starting with `init`,
   as the initial value of the accumulator, `foldRight` applies function
-  `f` to the last element in the list and the accumulator. The result
+  `f` to the last element in the array `xs` and the accumulator. The result
   becomes the new value of the accumulator, and `f` is applied to that value
   and the preceding element in `xs`. This process continues until all elements in
   `xs` are processed. The final value of the accumulator is returned.
@@ -298,7 +297,7 @@ let containsBy: (('a, 'a) => bool, 'a, array('a)) => bool;
   
   `indexOfBy() returns `Some(position)` where `position` is the index
   of the first item in `xs` that satisfies this new predicate function `p()`,
-  or `None` if no item in `xs` satisfies the predicate..
+  or `None` if no item in `xs` satisfies the predicate.
   
   ### Example
   ```re
@@ -309,10 +308,77 @@ let containsBy: (('a, 'a) => bool, 'a, array('a)) => bool;
 */
 let indexOfBy: (('a, 'a) => bool, 'a, array('a)) => option(int);
 
+/**
+  `minBy(f, xs)` returns the minimum value in array `xs` as
+  `Some(val)`. It uses function `f` to compare values in the array.
+  Function `f` takes two parameters of the type in the array and
+  returns a value of ` `less_than `, ` `equal_to `, or ` `greater_than `,
+  depending on the relationship of the values.
+  
+  If given an empty array, `minBy()` returns `None`.
+  
+  ### Example
+  ```re
+  let clockCompare = (a, b) => {
+    if (a mod 12 < b mod 12) {
+      `less_than
+    } else if (a mod 12 > b mod 12) {
+      `greater_than
+    } else {
+      `equal_to
+    }
+  };
+  
+  minBy(clockCompare, [|5, 3, 17, 14, 9|]) == Some(14);
+  minBy(clockCompare, [|5, 17|]) == Some(5);
+  minBy(clockCompare, [| |]) == None;
+  ```
+*/
 let minBy:
   (('a, 'a) => BsAbstract.Interface.ordering, array('a)) => option('a);
+
+  
+/**
+  `maxBy(f, xs)` returns the maximum value in array `xs` as
+  `Some(val)`. It uses function `f` to compare values in the array.
+  Function `f` takes two parameters of the type in the array and
+  returns a value of ` `less_than `, ` `equal_to `, or ` `greater_than `,
+  depending on the relationship of the values.
+  
+  If given an empty array, `maxBy()` returns `None`.
+  
+  ### Example
+  ```re
+  let clockCompare = (a, b) => {
+    if (a mod 12 < b mod 12) {
+      `less_than
+    } else if (a mod 12 > b mod 12) {
+      `greater_than
+    } else {
+      `equal_to
+    }
+  };
+  
+  maxBy(clockCompare, [|5, 3, 17, 14, 9|]) == Some(9);
+  maxBy(clockCompare, [|5, 17|]) == Some(5);
+  maxBy(clockCompare, [| |]) == None;
+  ```
+*/
 let maxBy:
   (('a, 'a) => BsAbstract.Interface.ordering, array('a)) => option('a);
+  
+/**
+  `countBy(countFcn, xs)` returns the number of items `x` in array `xs`
+  for which `countFcn(x)` returns `true`.
+  
+  ### Example
+  ```re
+  let isOdd = (x) => {x mod 2 == 1};
+  countBy(isOdd, [|33, 22, 55, 11, 44, 66|]) == 3;
+  countBy(isOdd, [|22, 44, 66|]) == 0;
+  countBy(isOdd, [| |]) == 0;
+  ```
+*/
 let countBy: ('a => bool, array('a)) => int;
 
 /**
@@ -326,15 +392,140 @@ let countBy: ('a => bool, array('a)) => int;
 */
 let length: array('a) => int;
 
+/**
+  In `forEach(f, xs)`, `f()` is a function that takes an element
+  of `xs` and returns `unit`. `forEach()` applies this function to
+  each element of `xs`. You use `forEach()` when you are interested in
+  the side effects rather than the result of a function.
+  
+  ### Example
+  ```re
+  forEach(Js.log, [|"a", "b", "c"|]) == (); // prints a, b, and c
+  ```
+*/
 let forEach: ('a => unit, array('a)) => unit;
+
+/**
+  In `forEachWithIndex(f, xs)`, `f()` is a function that takes an element
+  of `xs` and an integer and returns `unit`. `forEach()` applies this function to
+  each element of `xs`, passing the element and its index number (starting
+  at zero). You use `forEachWithIndex()` when you are interested in
+  the side effects rather than the result of a function.
+  
+  ### Example
+  ```re
+  let debug = (x, i) => {Js.log(string_of_int(i) ++ " " ++ x)};
+  forEachWithIndex(debug, [|"a", "b", "c"|]) == (); // prints 0 a, 1 b, and 2 c
+  ```
+*/
 let forEachWithIndex: (('a, int) => unit, array('a)) => unit;
+
+/**
+  `find(pred, xs)` returns `Some(x)` for the first value in `xs`
+  for which the predicate function `pred(x)` returns `true`.
+  If no value in the array satisfies `pred()`, `find()` returns `None`.
+  
+  ### Example
+  ```re
+  find((x) => {x mod 2 == 0}, [|3, 7, 4, 2, 5|]) == Some(4);
+  find((x) => {x mod 2 == 0}, [|3, 7, 5|]) == None;
+  ```
+*/
 let find: ('a => bool, array('a)) => option('a);
+
+/**
+  `findWithIndex(pred, xs)` calls `pred()` with two arguments: an element
+  of `xs` and its index value (zero-based). If `pred()` returns `true`,
+  the element is returned as `Some(x)`.  If no element in the array satisfies
+  `pred()`, `findWithIndex()` returns `None`.
+
+  
+  ### Example
+  ```re
+  let bothEven = (x, i) => {x mod 2 == 0 && i mod 2 == 0};
+  findWithIndex(bothEven, [|3, 6, 4, 7, 5|]) == Some(4);
+  findWithIndex(bothEven, [|3, 6, 7, 8, 5|]) == None;
+  findWithIndex(bothEven, [|3, 7, 5|]) == None;
+  ```
+*/
 let findWithIndex: (('a, int) => bool, array('a)) => option('a);
 
+/**
+  `fold((module M), xs)` concatenates the elements of `xs` as specified by
+  the given module. The module you provide must define the following:
+  
+  - a type specification
+  - an `append()` function which takes two items of the type and appends them
+    to one another
+  - an “empty” element
+  
+  Appending the empty element and an item must be commutative;
+  `append(x, empty) == append(empty, x)`
+  
+  ### Example
+  ```re
+  module CapString = {
+    type t = string;
+    let append(a, b) = Js.String.toUpperCase(a) ++ Js.String.toUpperCase(b);
+    let empty = "";
+  };
+  
+  fold((module CapString), [|"it ", "works!"|]) == "IT WORKS!";
+  ```
+*/
 let fold:
   ((module BsAbstract.Interface.MONOID with type t = 'a), array('a)) => 'a;
+
+/**
+  `intercalate((module M), delim, xs)` concatenates the elements of `xs` as specified by
+  the given module, with `delim` between all the elements. The module you provide
+  must define:
+  
+  - a type `t`
+  - an `append()` function which takes two items of the type and appends them
+    to one another
+  - an “empty” element
+  
+  Appending the empty element and an item must be commutative;
+  `append(x, empty) == append(empty, x)`
+  
+  ### Example
+  ```re
+  module LowerString = {
+    type t = string;
+    let append(a, b) = Js.String.toLowerCase(a) ++ Js.String.toLowerCase(b);
+    let empty = "";
+  };
+  
+  intercalate((module LowerString), "--", [|"2019", "MAY", "5"|]) == "2019--may--5";
+  ```
+*/
 let intercalate:
   ((module BsAbstract.Interface.MONOID with type t = 'a), 'a, array('a)) => 'a;
+  
+/**
+  `contains((module M), val, xs)` returns `true` if any element of `xs` equals
+  `val`, as determined by the module. It returns `false` if no element equals
+  `val`.  The module you provide must define:
+  
+  - a type `t`
+  - a function `eq()` which takes two items of type `t` and returns `true` if
+    they are to be considered equal, `false` otherwise.
+    
+  ### Example
+  ```re
+  module Pair = {
+    type t = (string, int);
+    let eq = ((pair1First, pair1Second), (pair2First, pair2Second)) => {
+      pair1First == pair2First && pair1Second == pair2Second
+    };
+  };
+  
+  contains((module Pair), ("c", 5), [|("a", 1), ("b", 3), ("c", 5), ("d", 7)|]) == true;
+  contains((module Pair), ("c", 5), [|("c", 1), ("b", 5)|]) == false;
+  contains((module Pair), ("c", 5), [| |]) == false;
+  ```
+*/
 let contains:
   ((module BsAbstract.Interface.EQ with type t = 'a), 'a, array('a)) => bool;
 let indexOf:

--- a/src/data/Relude_Array.rei
+++ b/src/data/Relude_Array.rei
@@ -1,3 +1,118 @@
+/**
+  `Relude.Array` contains a large number of functions that assist you
+  in manipulating arrays.
+  
+  Besides arrays of primitive types such as strings or integers, `Relude.Array`
+  lets you manipulate arrays of data types that you create. In order to do this,
+  you must sometimes provide a `module` that tells `Relude.Array` how to do
+  operations such as comparison or checking for equality with your data type.
+  
+  For the documentation of `Relude.Array`, we will create a data type that
+  represents a duration of time in minutes and seconds as a two-tuple of integers.
+  Some of the examples will manipulate an array of these durations. We will use
+  the following type definition:
+  
+  ```re
+  type duration = (int, int);
+  ```
+  
+  Here is a module that will be used when `Relude.Array` needs to check for equality
+  of two `duration` values. We will call this an `EQ` module. An `EQ` module must define:
+  
+  - the type under consideration
+  - a function `eq()`, which takes two items of that type and returns `true` if
+    they are to be considered equal, `false` otherwise
+    
+  ```re
+  module DurationEqual = {
+    type t = duration;
+    let eq = (a, b) => {
+      fst(a) == fst(b) && snd(a) == snd(b)
+    };
+  };
+  ```
+  Here is another `EQ` module that we will use in our examples; it checks if
+  two integers are equal with respect to “clock time” (mod 12):
+  
+  ```re
+  module ClockEqual = {
+    type t = int;
+    let eq = (a, b) => { a mod 12 == b mod 12 };
+  };
+  ```
+
+  Here is a module that will be used when we need to compare
+  two `duration` values. We will call this an `ORD` module. An `ORD` module must define:
+  
+  - the type under consideration
+  - an `eq()` function, as in the preceding module
+  - a `compare()` function that returns one of ` `less_than `, ` `_greater_than `, or ` `equal_to `,
+    depending on the relationship between its two arguments
+    
+  ```re
+  module DurationOrder = {
+    type t = duration;
+    let eq = (a, b) => {
+      fst(a) == fst(b) && snd(a) == snd(b)
+    };
+    let compare = ((min1, sec1), (min2, sec2)) => {
+      if (min1 < min2) {
+        `less_than
+      } else if (min1 > min2) {
+        `greater_than
+      } else {
+        if (sec1 < sec2) {
+          `less_than
+        } else if (sec1 > sec2) {
+          `greater_than
+        } else {
+          `equal_to
+        }
+      }
+    };
+  };
+  ```
+  
+  Here is a module that defines how you append two values of a datatype. We will
+  call this a `MONOID` module. “Monoid“ is a mathematical term that just happens to
+  apply nicely in this context, so we’ll go with it. Besides, it sounds more impressive
+  than “append.” A `MONOID` module must provide:
+  
+  - a type specification
+  - an `append()` function which takes two items of the type and appends them to one another
+  - an `empty` elemnt for which `append(x, empty) == append(empty, x) == x`
+  
+  For our example data type, we will define appending as addition of minutes and seconds, with
+  appropriate calculations to make sure seconds is never greater than 59.
+  
+  ```re
+  module DurationAppend = {
+    type t = duration;
+    let append = ((min1, sec1), (min2, sec2)) => {
+      (min1 + min2 + (sec1 + sec2) / 60, (sec1 + sec2) mod 60)
+    };
+    let empty = (0, 0);
+  };
+  ```
+  
+  The last type of module we will use in the examples is a module
+  that defines how to show a data type. We will call this a `SHOW` module.
+  A `SHOW` module must specify:
+  
+  - the type under consideration
+  - a `show()` function that takes a value of the given type and converts it to a string
+  
+    ```re
+  module DurationShow = {
+    type t = duration;
+    let show = ((min1, sec1)) => {
+      string_of_int(min1) ++ "m " ++ string_of_int(sec1) ++ "s";
+    };
+  };
+  ```
+*/
+
+
 module Foldable: BsAbstract.Interface.FOLDABLE with type t('a) = array('a);
 module SemigroupAny:
   BsAbstract.Interface.SEMIGROUP_ANY with type t('a) = array('a);
@@ -452,25 +567,11 @@ let findWithIndex: (('a, int) => bool, array('a)) => option('a);
 
 /**
   `fold((module M), xs)` concatenates the elements of `xs` as specified by
-  the given module. The module you provide must define the following:
-  
-  - a type specification
-  - an `append()` function which takes two items of the type and appends them
-    to one another
-  - an “empty” element
-  
-  Appending the empty element and an item must be commutative;
-  `append(x, empty) == append(empty, x)`
+  the given module, which is a `MONOID` module.
   
   ### Example
   ```re
-  module CapString = {
-    type t = string;
-    let append(a, b) = Js.String.toUpperCase(a) ++ Js.String.toUpperCase(b);
-    let empty = "";
-  };
-  
-  fold((module CapString), [|"it ", "works!"|]) == "IT WORKS!";
+  fold((module DurationAppend), [|(3, 25), (7, 45)|]) == (11, 10);
   ```
 */
 let fold:
@@ -478,26 +579,15 @@ let fold:
 
 /**
   `intercalate((module M), delim, xs)` concatenates the elements of `xs` as specified by
-  the given module, with `delim` between all the elements. The module you provide
-  must define:
+  the given module, with `delim` between all the elements. The module must be a
+  `MONOID` module.
   
-  - a type `t`
-  - an `append()` function which takes two items of the type and appends them
-    to one another
-  - an “empty” element
-  
-  Appending the empty element and an item must be commutative;
-  `append(x, empty) == append(empty, x)`
+  The following example inserts a “rest period“ of fifteen seconds between each
+  duration, for a total of an additional thirty seconds:
   
   ### Example
   ```re
-  module LowerString = {
-    type t = string;
-    let append(a, b) = Js.String.toLowerCase(a) ++ Js.String.toLowerCase(b);
-    let empty = "";
-  };
-  
-  intercalate((module LowerString), "--", [|"2019", "MAY", "5"|]) == "2019--may--5";
+  intercalate((module DurationAppend), (0, 15), [|(1, 0), (2, 0), (3, 0)|]) == (6, 30);
   ```
 */
 let intercalate:
@@ -506,39 +596,84 @@ let intercalate:
 /**
   `contains((module M), val, xs)` returns `true` if any element of `xs` equals
   `val`, as determined by the module. It returns `false` if no element equals
-  `val`.  The module you provide must define:
-  
-  - a type `t`
-  - a function `eq()` which takes two items of type `t` and returns `true` if
-    they are to be considered equal, `false` otherwise.
+  `val`. The module must be an `EQ` module.
     
   ### Example
   ```re
-  module Pair = {
-    type t = (string, int);
-    let eq = ((pair1First, pair1Second), (pair2First, pair2Second)) => {
-      pair1First == pair2First && pair1Second == pair2Second
-    };
-  };
-  
-  contains((module Pair), ("c", 5), [|("a", 1), ("b", 3), ("c", 5), ("d", 7)|]) == true;
-  contains((module Pair), ("c", 5), [|("c", 1), ("b", 5)|]) == false;
-  contains((module Pair), ("c", 5), [| |]) == false;
+  contains((module DurationEqual), (3, 20), [|(1, 10), (3, 20), (4, 40)|]) == true;
+  contains((module DurationEqual), (3, 20), [|(1, 10), (2, 20), (4, 40)|]) == false;
+  contains((module DurationEqual), (3, 20), [| |]) == false;
   ```
 */
 let contains:
   ((module BsAbstract.Interface.EQ with type t = 'a), 'a, array('a)) => bool;
+  
+/**
+  `indexOf((module M), val, xs)` finds the position of `val` in the array `xs`.
+  If `val` is at position `index`, the return value is `Some(index)`; if `val`
+  is not in the array, the return value is `None`. The module you pass must be
+  an `EQ` module.
+
+  ### Example
+  ```re
+  indexOf((module DurationEqual), (3, 20), [|(1, 10), (3, 20), (4, 40)|]) == Some(1);
+  indexOf((module DurationEqual), (3, 20), [|(1, 10), (2, 20), (4, 40)|]) == None;
+  indexOf((module DurationEqual), (3, 20), [| |]) == None;
+  ```
+*/
 let indexOf:
   ((module BsAbstract.Interface.EQ with type t = 'a), 'a, array('a)) =>
   option(int);
+  
+/**
+  `min((module M), xs)` returns `Some(val)` where `val` is the
+  minimum value in `xs` as determined by the  module. The module must be an `ORD` module.
+  `min()` returns `None` if the array is empty.
+  
+  ### Example
+  ```re
+  min((module DurationOrder), [|(2, 20), (1, 10), (4, 40), (3, 30)|]) == Some((1, 10));
+  min((module DurationOrder), [| |]) == None;
+  ```
+*/
 let min:
   ((module BsAbstract.Interface.ORD with type t = 'a), array('a)) =>
   option('a);
+
+/**
+  `max((module M), xs)` returns `Some(val)` where `val` is the
+  maximum value in `xs` as determined by the  module. The module must be an `ORD` module.
+  `max()` returns `None` if the array is empty.
+  
+  ### Example
+  ```re
+  max((module DurationOrder), [|(2, 20), (1, 10), (4, 40), (3, 30)|]) == Some((4, 40));
+  max((module DurationOrder), [| |]) == None;
+  ```
+*/
 let max:
   ((module BsAbstract.Interface.ORD with type t = 'a), array('a)) =>
   option('a);
 
+/**
+  `fromList(xs)` converts a list to an array.
+  
+  ### Example
+  ```re
+  fromList([100, 101, 102]) == [|100, 101, 102|];
+  ```
+*/
 let fromList: list('a) => array('a);
+
+
+/**
+  `toList(xs)` converts an array to a list.
+  
+  ### Example
+  ```re
+  toList([|100, 101, 102|]) == [100, 101, 102];
+  ```
+*/
 let toList: array('a) => list('a);
 
 module Traversable:
@@ -584,8 +719,40 @@ let scanLeft: (('b, 'a) => 'b, 'b, array('a)) => array('b);
 */
 let scanRight: (('a, 'b) => 'b, 'b, array('a)) => array('b);
 
+/**
+  `eqBy(f, xs, ys)` compares each element of `xs` to the corresponding
+  element of `ys`, using `f(x, y)` to determine if the elements are equal
+  or not. If all elements are equal, `eqBy()` returns `true`; otherwise
+  it returns `false`.
+  
+  ### Example
+  ```re
+  let eqMod12 = (a, b) => {a mod 12 == b mod 12};
+  eqBy(eqMod12, [|2, 4, 3, 5|], [|14, 16, 15, 17|]) == true;
+  eqBy(eqMod12, [|2, 4, 3, 5|], [|2, 4, 3|]) == false;
+  eqBy(eqMod12, [| |], [| |]) == true;
+  ```
+*/
 let eqBy: (('a, 'a) => bool, array('a), array('a)) => bool;
+
 module Eq: (BsAbstract.Interface.EQ) => BsAbstract.Interface.EQ;
+
+/**
+  `eq((module M), xs, ys)` compares each element of `xs` to the corresponding
+  element of `ys`, using an `EQ` module to determine if the elements are equal
+  or not. If all elements are equal, `eq()` returns `true`; otherwise
+  it returns `false`.
+  
+  ### Example
+  ```re
+  eq((module DurationEqual), [|(3, 30), (2, 20), (4, 40)|],
+    [|(3, 30), (2, 20), (4, 40)|]) == true;
+  eq((module DurationEqual), [|(3, 30), (2, 20), (4, 40)|],
+    [|(3, 30), (2, 20)|]) == false;
+  eq((module DurationEqual), [|(3, 30), (2, 20), (4, 40)|],
+    [|(3, 30), (2, 25), (4, 40)|]) == false;
+  ```
+*/
 let eq:
   (
     (module BsAbstract.Interface.EQ with type t = 'a),
@@ -594,13 +761,46 @@ let eq:
   ) =>
   bool;
 
+/**
+  `showBy(f, xs)` uses `f(x)` to convert each element
+  of `xs` to a string, separates the strings with commas, and
+  encloses it all in square brackets to be returned as one string.
+  
+  ### Example
+  ```re
+  let toString = (x) => {string_of_int(x)};
+  showBy(toString, [|100, 101, 102|]) == "[100, 101, 102]";
+  ```
+*/
 let showBy: ('a => string, array('a)) => string;
 module Show: (BsAbstract.Interface.SHOW) => BsAbstract.Interface.SHOW;
+
+/**
+  `show((module M), xs)` uses the given module, which must be a
+  `SHOW` module, to convert each element
+  of `xs` to a string, separates the strings with commas, and
+  encloses it all in square brackets to be returned as one string.
+  
+  ### Example
+  ```re
+  show((module DurationShow), [|(1, 10), (2, 20), (3, 30)|]) == "[1m 10s, 2m 20s, 3m 30s]";
+  ```
+*/
 let show:
   ((module BsAbstract.Interface.SHOW with type t = 'a), array('a)) => string;
 
 module Ord: (BsAbstract.Interface.ORD) => BsAbstract.Interface.ORD;
 
+/**
+  `mapWithIndex(f, xs)` creates a new array by applying `f(x, n)` to each element of `xs`,
+  where `n` is the zero-based index of the array element.
+  
+  ### Example
+  ```re
+  let numbered =(s, index) => {string_of_int(index + 1) ++ ". " ++ s};
+  mapWithIndex(numbered, [|"ant", "bee", "cat"|]) == [|"1. ant", "2. bee", "3. cat"|];
+  ```
+*/
 let mapWithIndex: (('a, int) => 'b, array('a)) => array('b);
 
 /**
@@ -1112,36 +1312,16 @@ let sortBy:
   (('a, 'a) => BsAbstract.Interface.ordering, array('a)) => array('a);
 
 /**
-  `sort((module M), xs)` sorts the array `xs`, using the given module to
-  compare items in the array.  The module must:
-  
-  - Specify a type `t` for the items to be compared
-  - Specify a function `eq`, which takes two items of type `t` and returns
-    `true` if they are considered equal, `false` otherwise.
-  - Specify a function `compare`, which takes two items of type `t` and
-    returns ` `less_than `, ` `equal_to `, or ` `greater_than `, depending on the
-    relation between the two items.
+  `sort((module M), xs)` sorts the array `xs`, using an `ORD` module to
+  compare items in the array.
   
   This is a stable sort; equal elements will appear in the output array in the
   same order that they appeared in the input array.
   
   ### Example
   ```re
-  module ClockArithmetic = {
-    type t = int;
-    let eq = (a, b) => { a mod 12 == b mod 12 };
-    let compare = (a, b) => {
-      if (a mod 12 < b mod 12) {
-        `less_than
-      } else if (a mod 12 > b mod 12) {
-        `greater_than
-      } else {
-        `equal_to
-      };
-    }
-  };
-  
-  sort((module ClockArithmetic), [|17, 3, 9, 4, 15, 20|]) == [|3, 15, 4, 17, 20, 9|];
+  sort((module DurationOrder), [|(3, 40), (2, 30), (1, 10), (2,20)|]) ==
+    [|(1, 10), (2, 20), (2, 30), (3, 40) |];
   ```
 */
 let sort:
@@ -1204,20 +1384,10 @@ let removeEachBy: (('a, 'a) => bool, 'a, array('a)) => array('a);
 
 /*
   `distinct((module M), xs)` returns an array of the unique elements `xs`,
-  using the given module to determine which elements are considered to be equal.
-  The module must:
-  
-  - Specify a type `t` for the items to be compared
-  - Specify a function `eq`, which takes two items of type `t` and returns
-    `true` if they are considered equal, `false` otherwise.
+  using the given module, which must be an `EQ` module.
     
   ### Example
   ```re
-  module ClockEqual = {
-    type t = int;
-    let eq = (a, b) => { a mod 12 == b mod 12 };
-  };
-
   distinct((module ClockEqual), [|16, 4, 2, 12, 9, 21, 0|]) == [|16, 2, 12, 9|];
   ```
 */    
@@ -1226,24 +1396,15 @@ let distinct:
 
 /**
   `removeFirst((module M), value, xs)` returns an array with the first element that
-  is considered equal to `value` with respect to `module M` removed.
+  is considered equal to `value` with respect to `module M` removed. The module
+  must be an `EQ` module.
  
-  The module must:
-  
-  - Specify a type `t` for the items to be compared
-  - Specify a function `eq`, which takes two items of type `t` and returns
-    `true` if they are considered equal, `false` otherwise.
-  
-  If no elements are equal to the `value`, the result is the same as the original array.
+ If no elements are equal to the `value`, the result is the same as the original array.
  
   ### Example
   ```re
-  module ClockEq2 = {
-    type t = int;
-    let eq = (a, b) => { a mod 12 == b mod 12 };
-  };
-  removeFirst((module ClockEq2), 14, [|16, 4, 2, 12, 9, 21, 0|]) == [|16, 4, 12, 9, 21, 0|];
-  removeFirst((module ClockEq2), 15, [|16, 4, 2, 12, 9, 21, 0|]) == [|16, 4, 2, 12, 9, 21, 0|];
+  removeFirst((module ClockEqual), 14, [|16, 4, 2, 12, 9, 21, 0|]) == [|16, 4, 12, 9, 21, 0|];
+  removeFirst((module ClockEqual), 15, [|16, 4, 2, 12, 9, 21, 0|]) == [|16, 4, 2, 12, 9, 21, 0|];
   ```
 */
 let removeFirst:
@@ -1264,12 +1425,8 @@ let removeFirst:
  
   ### Example
   ```re
-  module ClockEq3 = {
-    type t = int;
-    let eq = (a, b) => { a mod 12 == b mod 12 };
-  };
-  removeEach((module ClockEq3), 12, [|16, 4, 2, 12, 9, 21, 0|]) == [|16, 4, 2, 9, 21|];
-  removeEach((module ClockEq3), 15, [|16, 4, 2, 12, 9, 21, 0|]) == [|16, 4, 2, 12, 9, 21, 0|];
+  removeEach((module ClockEqual), 12, [|16, 4, 2, 12, 9, 21, 0|]) == [|16, 4, 2, 9, 21|];
+  removeEach((module ClockEqual), 15, [|16, 4, 2, 12, 9, 21, 0|]) == [|16, 4, 2, 12, 9, 21, 0|];
   ```
 */
 let removeEach:

--- a/src/data/Relude_List.rei
+++ b/src/data/Relude_List.rei
@@ -19,145 +19,22 @@ module IsoArray: Relude_IsoArray.ISO_ARRAY with type t('a) = list('a);
 /**
  * The following functions come from List's membership in Semigroup and Monoid
  */
-
-/**
-  `concat(xs, ys)` returns a list with the elements of `xs` followed
-  by the elements of `ys`.
-  
-  ## Example
-  ```re
-  concat(["a", "b"], ["c", "d"]) == ["a", "b", "c", "d"];
-  concat([ ], ["a", "b"]) == ["a", "b"];
-  concat(["a", "b"], [ ]) == ["a", "b"];
-  ```
- */
 let concat: (list('a), list('a)) => list('a);
-
-
-/**
-  `empty` returns a new, empty list.
- */
 let empty: list('a);
 
 /**
  * The following functions come for free because List is a member of Functor,
  * Apply, Applicative, and Monad
  */
-
-/**
-   `map(f, xs)` creates a new list by applying `f` to
-   each element of `xs`.
-   
-   ### Example
-   ```re
-   let f = (x) => {Js.String.length(x)};
-   map(f, ["ReasonML", "OCaml"]) == [8, 5];
-   ```
- */
 let map: ('a => 'b, list('a)) => list('b);
-
-/**
-   `void(xs)` returns a list of the same length as `xs`,
-   with each element equal to unit `()`.
-  
-   ### Example
-   ```re
-   void([100, 101, 102]) == [(), (), ()];
-   ```
- */
 let void: list('a) => list(unit);
-
-
-/**
-  `apply(fs, xs)` takes a list of functions and a list of values and creates
-  a list whose contents are the result of applying the first function of `fs`
-  to all the elements of `xs`, the second function of
-  `fs` to all the elements of `xs`, and so on. All the functions in `fs` must
-  have the same result type.
-  
-  ### Example
-  ```re
-  let square = (x) => {x * x};
-  let cube = (x) => {x * x * x};
-  apply([square, cube], [10, 11, 12]) == [100, 121, 144, 1000, 1331, 1728];
-  ```
- */
 let apply: (list('a => 'b), list('a)) => list('b);
-
-/**
-  `flap(fs, x)` creates a list whose contents are the result of applying every
-  function in `fs` to `x`.
-  
-  ### Example
-  ```re
-  let square = (x) => {x * x};
-  let cube = (x) => {x * x * x};
-  flap([square, cube], 10) == [100, 1000];
-  ```
-*/
 let flap: (list('a => 'b), 'a) => list('b);
-
-/**
-  `map2(f, xs, ys)` has a function that takes two arguments
-  as its first parameter. It returns a list with the results
-  of all the `f(x, y)` combinations, iterating through `ys` first,
-  then `xs`.
-  
-  ### Example
-  ```re
-  let phrase = (str, n) => { str ++ " " ++ string_of_int(n) };
-  map2(phrase, ["cat", "dog"], [1, 2, 3]) ==
-    ["cat 1", "cat 2", "cat 3", "dog 1", "dog 2", "dog 3"];
-  ```
-*/
 let map2: (('a, 'b) => 'c, list('a), list('b)) => list('c);
-
-/**
-  `map3(f, xs, ys, zs)` has a function that takes three arguments
-  as its first parameter. It returns a list with the results
-  of all the `f(x, y, z)` combinations, iterating through `zs` first,
-  then `ys`, then `xs`.
-  
-  ### Example
-  ```re
-  let together = (x, y, z) => {x ++ y ++ z};
-  map3(together, ["a", "b", "c"], ["d", "e"], ["f"]) ==
-    ["adf", "aef", "bdf", "bef", "cdf", "cef"];
-  ```
-*/
 let map3: (('a, 'b, 'c) => 'd, list('a), list('b), list('c)) => list('d);
-
-/**
-  `map4(f, xs, ys, zs, ws)` has a function that takes four arguments
-  as its first parameter. It returns a list with the results
-  of all the `f(x, y, z, w)` combinations, iterating through `ws` first,
-  then `zs`, then `ys`, then `xs`.
-  
-  ### Example
-  ```re
-  let together = (x, y, z, w) => {x ++ y ++ z ++ w};
-  map4(together, ["a", "b"], ["c", "d"], ["e", "f"], ["g", "h"]) ==
-    ["aceg", "aceh", "acfg", "acfh", "adeg", "adeh", "adfg", "adfh",
-      "bceg", "bceh", "bcfg", "bcfh", "bdeg", "bdeh", "bdfg", "bdfh"];
-  ```
-*/
 let map4:
   (('a, 'b, 'c, 'd) => 'e, list('a), list('b), list('c), list('d)) =>
   list('e);
-
-/**
-  `map5(f, xs, ys, zs, ws, qs)` has a function that takes five arguments
-  as its first parameter. It returns a list with the results
-  of all the `f(x, y, z, w, q)` combinations, iterating through `qs` first,
-  then `ws`, then `zs`, then `ys`, then `xs`.
-  
-  ### Example
-  ```re
-  let together = (x, y, z, w, q) => {x ++ y ++ z ++ w ++ q};
-  map5(together, ["a", "b"], ["c"], ["d", "e"], ["f"], ["g", "h"]) ==
-    ["acdfg", "acdfh", "acefg", "acefh", "bcdfg", "bcdfh", "bcefg", "bcefh"];
-  ```
-*/
 let map5:
   (
     ('a, 'b, 'c, 'd, 'e) => 'f,
@@ -168,374 +45,34 @@ let map5:
     list('e)
   ) =>
   list('f);
-  
-/**
-  `pure(item)` returns a list containing the given item.
-
-  ## Example
-  ```re
-  pure("single") == ["single"];
-  ```
-*/
 let pure: 'a => list('a);
-
-/**
-  In `bind(xs, f)`, `f` is a function that takes an element
-  of the type in `xs` and returns a list. The result of `bind`
-  is the concatenation of all the list produced by applying
-  `f()` to the elements of `xs`.
-  
-  ### Example
-  ```re
-  let f = (x) => [ x - 5, x + 5 ];
-  bind([100, 101, 102], f) == [95, 105, 96, 106, 97, 107];
-  bind([ ], f) == [ ];
-  ```
-*/
 let bind: (list('a), 'a => list('b)) => list('b);
-
-/**
-  In `flatMap(f, xs)`, `f` is a function that takes an element
-  of the type in `xs` and returns a list. The result of `bind`
-  is the concatenation of all the lists produced by applying
-  `f()` to the elements of `xs`.
-  
-  ### Example
-  ```re
-  let f = (x) => [ x - 5, x + 5 ];
-  flatMap(f, [100, 101, 102]) == [95, 105, 96, 106, 97, 107];
-  flatMap(f, [ ]) == [ ];
-  ```
-*/
 let flatMap: ('a => list('b), list('a)) => list('b);
-
-/**
-  `flatten(xs_of_xs)` takes a list of lists as its argument
-  and returns a list with all the sub-lists concatenated.
-  
-  ### Example
-  ```re
-  flatten([ ["a", "b"], [ ], ["c"], ["d", "e", "f"] ]) ==
-    ["a", "b", "c", "d", "e", "f"];
-  ```
-*/
 let flatten: list(list('a)) => list('a);
 
 /**
  * The following functions come for free because List is a member of Foldable
  */
-
-/**
-  `foldLeft(f, init, xs)` accumulates a value. Starting with `init`,
-  as the initial value of the accumulator, `foldLeft` applies function
-  `f` to the accumulator and the first element in the list `xs`. The result
-  becomes the new value of the accumulator, and `f` is applied to that value
-  and the next element in `xs`. This process continues until all elements in
-  `xs` are processed. The final value of the accumulator is returned.
-
-  ## Example
-  ```re
-  foldLeft((acc, item) => append(item, acc), [ ], [1, 2, 3]) == [1, 2, 3];
-  foldLeft((acc, item) => acc + item, 2, [ ]) == 2;
-  ```
-*/
 let foldLeft: (('b, 'a) => 'b, 'b, list('a)) => 'b;
-
-/**
-  `foldRight(f, init, xs)` accumulates a value. Starting with `init`,
-  as the initial value of the accumulator, `foldRight` applies function
-  `f` to the last element in the list `xs` and the accumulator. The result
-  becomes the new value of the accumulator, and `f` is applied to that value
-  and the preceding element in `xs`. This process continues until all elements in
-  `xs` are processed. The final value of the accumulator is returned.
-
-  ## Example
-  ```re
-  foldRight((item, acc) => append(item, acc), [ ], [1, 2, 3]) == [3, 2, 1];
-  foldRight((item, acc) => acc + item, 2, [ ]) == 2;
-  ```
-*/
 let foldRight: (('a, 'b) => 'b, 'b, list('a)) => 'b;
-
-/**
-  In `any(pred, xs)`, `pred` is a function that takes an item of the type in the
-  list and returns a boolean value.  The `any()` function returns `true` if
-  `pred(x)` returns true for any item `x` in the list, `false` otherwise.
-  
-  ### Example
-  ```re
-  any( (x) => {x < 0}, [100, -101, 102]) == true;
-  any( (x) => {x < 0}, [100, 101, 102]) == false;
-  ```
-*/
 let any: ('a => bool, list('a)) => bool;
-
-/**
-  In `all(pred, xs)`, `pred` is a function that takes an item of the type in the
-  list and returns a boolean value.  The `all()` function returns `true` if
-  `pred(x)` returns true for every item `x` in the list, `false` otherwise.
-  
-  ### Example
-  ```re
-  all( (x) => {x < 0}, [-100, -101, -102]) == true;
-  all( (x) => {x < 0}, [-100, 101, -102]) == false;
-  ```
-*/
 let all: ('a => bool, list('a)) => bool;
-
-
-/**
-  In `containsBy(f, value, xs)`, the function `f` takes two items
-  of the type in the list and returns a predicate function `p()`
-  by calling `f(value)`.
-  
-  `containsBy() returns `true` if any item in `xs` satisfies this
-  new predicate function `p()`.
-  
-  ### Example
-  ```re
-  let aboveLimit = (limit, x) => { x > limit };
-  containsBy(aboveLimit, 50, [30, 70, 20]) == true;
-  containsBy(aboveLimit, 90, [30, 70, 20]) == false;
-  ```
-*/
 let containsBy: (('a, 'a) => bool, 'a, list('a)) => bool;
-
-/**
-  In `indexOfBy(f, value, xs)`, the function `f` takes two items
-  of the type in the list and returns a predicate function `p()`
-  by calling `f(value)`.
-  
-  `indexOfBy() returns `Some(position)` where `position` is the index
-  of the first item in `xs` that satisfies this new predicate function `p()`,
-  or `None` if no item in `xs` satisfies the predicate.
-  
-  ### Example
-  ```re
-  let aboveLimit = (limit, x) => { x > limit };
-  indexOfBy(aboveLimit, 50, [30, 70, 20, 80]) == Some(1);
-  indexOfBy(aboveLimit, 90, [30, 70, 20, 80]) == None;
-  ```
-*/
 let indexOfBy: (('a, 'a) => bool, 'a, list('a)) => option(int);
-
-/**
-  `minBy(f, xs)` returns the minimum value in list `xs` as
-  `Some(val)`. It uses function `f` to compare values in the list.
-  Function `f` takes two parameters of the type in the list and
-  returns a value of ` `less_than `, ` `equal_to `, or ` `greater_than `,
-  depending on the relationship of the values.
-  
-  If given an empty list, `minBy()` returns `None`.
-  
-  ### Example
-  ```re
-  let clockCompare = (a, b) => {
-    if (a mod 12 < b mod 12) {
-      `less_than
-    } else if (a mod 12 > b mod 12) {
-      `greater_than
-    } else {
-      `equal_to
-    }
-  };
-  
-  minBy(clockCompare, [5, 3, 17, 14, 9]) == Some(14);
-  minBy(clockCompare, [5, 17]) == Some(5);
-  minBy(clockCompare, [ ]) == None;
-  ```
-*/
 let minBy:
   (('a, 'a) => BsAbstract.Interface.ordering, list('a)) => option('a);
-
-/**
-  `maxBy(f, xs)` returns the maximum value in list `xs` as
-  `Some(val)`. It uses function `f` to compare values in the list.
-  Function `f` takes two parameters of the type in the list and
-  returns a value of ` `less_than `, ` `equal_to `, or ` `greater_than `,
-  depending on the relationship of the values.
-  
-  If given an empty array, `maxBy()` returns `None`.
-  
-  ### Example
-  ```re
-  let clockCompare = (a, b) => {
-    if (a mod 12 < b mod 12) {
-      `less_than
-    } else if (a mod 12 > b mod 12) {
-      `greater_than
-    } else {
-      `equal_to
-    }
-  };
-  
-  maxBy(clockCompare, [5, 3, 17, 14, 9]) == Some(9);
-  maxBy(clockCompare, [5, 17]) == Some(5);
-  maxBy(clockCompare, [ ]) == None;
-  ```
-*/
 let maxBy:
   (('a, 'a) => BsAbstract.Interface.ordering, list('a)) => option('a);
-
-/**
-  `countBy(countFcn, xs)` returns the number of items `x` in list `xs`
-  for which `countFcn(x)` returns `true`.
-  
-  ### Example
-  ```re
-  let isOdd = (x) => {x mod 2 == 1};
-  countBy(isOdd, [33, 22, 55, 11, 44, 66]) == 3;
-  countBy(isOdd, [22, 44, 66]) == 0;
-  countBy(isOdd, [ ]) == 0;
-  ```
-*/
 let countBy: ('a => bool, list('a)) => int;
-
-/**
-  `length(xs)` returns the number of items in `xs`.
-
-  ## Example
-  ```re
-  length(["a", "b", "c"]) == 3;
-  length([ ]) == 0;
-  ```
-*/
 let length: list('a) => int;
-
-/**
-  In `forEach(f, xs)`, `f()` is a function that takes an element
-  of `xs` and returns `unit`. `forEach()` applies this function to
-  each element of `xs`. You use `forEach()` when you are interested in
-  the side effects rather than the result of a function.
-  
-  ### Example
-  ```re
-  forEach(Js.log, ["a", "b", "c"]) == (); // prints a, b, and c
-  ```
-*/
 let forEach: ('a => unit, list('a)) => unit;
-
-/**
-  In `forEachWithIndex(f, xs)`, `f()` is a function that takes an element
-  of `xs` and an integer and returns `unit`. `forEach()` applies this function to
-  each element of `xs`, passing the element and its index number (starting
-  at zero). You use `forEachWithIndex()` when you are interested in
-  the side effects rather than the result of a function.
-  
-  ### Example
-  ```re
-  let debug = (x, i) => {Js.log(string_of_int(i) ++ " " ++ x)};
-  forEachWithIndex(debug, ["a", "b", "c"]) == (); // prints 0 a, 1 b, and 2 c
-  ```
-*/
 let forEachWithIndex: (('a, int) => unit, list('a)) => unit;
-
-/**
-  `find(pred, xs)` returns `Some(x)` for the first value in `xs`
-  for which the predicate function `pred(x)` returns `true`.
-  If no value in the list satisfies `pred()`, `find()` returns `None`.
-  
-  ### Example
-  ```re
-  find((x) => {x mod 2 == 0}, [3, 7, 4, 2, 5]) == Some(4);
-  find((x) => {x mod 2 == 0}, [3, 7, 5]) == None;
-  ```
-*/
 let find: ('a => bool, list('a)) => option('a);
-
-/**
-  `findWithIndex(pred, xs)` calls `pred()` with two arguments: an element
-  of `xs` and its index value (zero-based). If `pred()` returns `true`,
-  the element is returned as `Some(x)`.  If no element in the list satisfies
-  `pred()`, `findWithIndex()` returns `None`.
-
-  
-  ### Example
-  ```re
-  let bothEven = (x, i) => {x mod 2 == 0 && i mod 2 == 0};
-  findWithIndex(bothEven, [3, 6, 4, 7, 5]) == Some(4);
-  findWithIndex(bothEven, [3, 6, 7, 8, 5]) == None;
-  findWithIndex(bothEven, [3, 7, 5]) == None;
-  ```
-*/
 let findWithIndex: (('a, int) => bool, list('a)) => option('a);
-
-/**
-  `fold((module M), xs)` concatenates the elements of `xs` as specified by
-  the given module. The module you provide must define the following:
-  
-  - a type specification
-  - an `append()` function which takes two items of the type and appends them
-    to one another
-  - an “empty” element
-  
-  Appending the empty element and an item must be commutative;
-  `append(x, empty) == append(empty, x)`
-  
-  ### Example
-  ```re
-  module CapString = {
-    type t = string;
-    let append(a, b) = Js.String.toUpperCase(a) ++ Js.String.toUpperCase(b);
-    let empty = "";
-  };
-  
-  fold((module CapString), ["it ", "works!"]) == "IT WORKS!";
-  ```
-*/
 let fold:
   ((module BsAbstract.Interface.MONOID with type t = 'a), list('a)) => 'a;
-
-/**
-  `intercalate((module M), delim, xs)` concatenates the elements of `xs` as specified by
-  the given module, with `delim` between all the elements. The module you provide
-  must define:
-  
-  - a type `t`
-  - an `append()` function which takes two items of the type and appends them
-    to one another
-  - an “empty” element
-  
-  Appending the empty element and an item must be commutative;
-  `append(x, empty) == append(empty, x)`
-  
-  ### Example
-  ```re
-  module LowerString = {
-    type t = string;
-    let append(a, b) = Js.String.toLowerCase(a) ++ Js.String.toLowerCase(b);
-    let empty = "";
-  };
-  
-  intercalate((module LowerString), "--", ["2019", "MAY", "5"]) == "2019--may--5";
-  ```
-*/
 let intercalate:
   ((module BsAbstract.Interface.MONOID with type t = 'a), 'a, list('a)) => 'a;
-
-/**
-  `contains((module M), val, xs)` returns `true` if any element of `xs` equals
-  `val`, as determined by the module. It returns `false` if no element equals
-  `val`.  The module you provide must define:
-  
-  - a type `t`
-  - a function `eq()` which takes two items of type `t` and returns `true` if
-    they are to be considered equal, `false` otherwise.
-    
-  ### Example
-  ```re
-  module Pair = {
-    type t = (string, int);
-    let eq = ((pair1First, pair1Second), (pair2First, pair2Second)) => {
-      pair1First == pair2First && pair1Second == pair2Second
-    };
-  };
-  
-  contains((module Pair), ("c", 5), [("a", 1), ("b", 3), ("c", 5), ("d", 7)]) == true;
-  contains((module Pair), ("c", 5), [("c", 1), ("b", 5)]) == false;
-  contains((module Pair), ("c", 5), [ ]) == false;
-  ```
-*/
 let contains:
   ((module BsAbstract.Interface.EQ with type t = 'a), 'a, list('a)) => bool;
 let indexOf:
@@ -794,7 +331,7 @@ module Infix: {
   let (=<<): ('a => list('b), list('a)) => list('b);
   let (>=>): ('a => list('b), 'b => list('c), 'a) => list('c);
   let (<=<): ('a => list('b), 'c => list('a), 'c) => list('b);
-  let (<>): (list('a), list('a)) => list('a);
+  let (<|>): (list('a), list('a)) => list('a);
   let (<$>): ('a => 'b, list('a)) => list('b);
   let (<#>): (list('a), 'a => 'b) => list('b);
   let (<*>): (list('a => 'b), list('a)) => list('b);

--- a/src/data/Relude_List.rei
+++ b/src/data/Relude_List.rei
@@ -19,22 +19,145 @@ module IsoArray: Relude_IsoArray.ISO_ARRAY with type t('a) = list('a);
 /**
  * The following functions come from List's membership in Semigroup and Monoid
  */
+
+/**
+  `concat(xs, ys)` returns a list with the elements of `xs` followed
+  by the elements of `ys`.
+  
+  ## Example
+  ```re
+  concat(["a", "b"], ["c", "d"]) == ["a", "b", "c", "d"];
+  concat([ ], ["a", "b"]) == ["a", "b"];
+  concat(["a", "b"], [ ]) == ["a", "b"];
+  ```
+ */
 let concat: (list('a), list('a)) => list('a);
+
+
+/**
+  `empty` returns a new, empty list.
+ */
 let empty: list('a);
 
 /**
  * The following functions come for free because List is a member of Functor,
  * Apply, Applicative, and Monad
  */
+
+/**
+   `map(f, xs)` creates a new list by applying `f` to
+   each element of `xs`.
+   
+   ### Example
+   ```re
+   let f = (x) => {Js.String.length(x)};
+   map(f, ["ReasonML", "OCaml"]) == [8, 5];
+   ```
+ */
 let map: ('a => 'b, list('a)) => list('b);
+
+/**
+   `void(xs)` returns a list of the same length as `xs`,
+   with each element equal to unit `()`.
+  
+   ### Example
+   ```re
+   void([100, 101, 102]) == [(), (), ()];
+   ```
+ */
 let void: list('a) => list(unit);
+
+
+/**
+  `apply(fs, xs)` takes a list of functions and a list of values and creates
+  a list whose contents are the result of applying the first function of `fs`
+  to all the elements of `xs`, the second function of
+  `fs` to all the elements of `xs`, and so on. All the functions in `fs` must
+  have the same result type.
+  
+  ### Example
+  ```re
+  let square = (x) => {x * x};
+  let cube = (x) => {x * x * x};
+  apply([square, cube], [10, 11, 12]) == [100, 121, 144, 1000, 1331, 1728];
+  ```
+ */
 let apply: (list('a => 'b), list('a)) => list('b);
+
+/**
+  `flap(fs, x)` creates a list whose contents are the result of applying every
+  function in `fs` to `x`.
+  
+  ### Example
+  ```re
+  let square = (x) => {x * x};
+  let cube = (x) => {x * x * x};
+  flap([square, cube], 10) == [100, 1000];
+  ```
+*/
 let flap: (list('a => 'b), 'a) => list('b);
+
+/**
+  `map2(f, xs, ys)` has a function that takes two arguments
+  as its first parameter. It returns a list with the results
+  of all the `f(x, y)` combinations, iterating through `ys` first,
+  then `xs`.
+  
+  ### Example
+  ```re
+  let phrase = (str, n) => { str ++ " " ++ string_of_int(n) };
+  map2(phrase, ["cat", "dog"], [1, 2, 3]) ==
+    ["cat 1", "cat 2", "cat 3", "dog 1", "dog 2", "dog 3"];
+  ```
+*/
 let map2: (('a, 'b) => 'c, list('a), list('b)) => list('c);
+
+/**
+  `map3(f, xs, ys, zs)` has a function that takes three arguments
+  as its first parameter. It returns a list with the results
+  of all the `f(x, y, z)` combinations, iterating through `zs` first,
+  then `ys`, then `xs`.
+  
+  ### Example
+  ```re
+  let together = (x, y, z) => {x ++ y ++ z};
+  map3(together, ["a", "b", "c"], ["d", "e"], ["f"]) ==
+    ["adf", "aef", "bdf", "bef", "cdf", "cef"];
+  ```
+*/
 let map3: (('a, 'b, 'c) => 'd, list('a), list('b), list('c)) => list('d);
+
+/**
+  `map4(f, xs, ys, zs, ws)` has a function that takes four arguments
+  as its first parameter. It returns a list with the results
+  of all the `f(x, y, z, w)` combinations, iterating through `ws` first,
+  then `zs`, then `ys`, then `xs`.
+  
+  ### Example
+  ```re
+  let together = (x, y, z, w) => {x ++ y ++ z ++ w};
+  map4(together, ["a", "b"], ["c", "d"], ["e", "f"], ["g", "h"]) ==
+    ["aceg", "aceh", "acfg", "acfh", "adeg", "adeh", "adfg", "adfh",
+      "bceg", "bceh", "bcfg", "bcfh", "bdeg", "bdeh", "bdfg", "bdfh"];
+  ```
+*/
 let map4:
   (('a, 'b, 'c, 'd) => 'e, list('a), list('b), list('c), list('d)) =>
   list('e);
+
+/**
+  `map5(f, xs, ys, zs, ws, qs)` has a function that takes five arguments
+  as its first parameter. It returns a list with the results
+  of all the `f(x, y, z, w, q)` combinations, iterating through `qs` first,
+  then `ws`, then `zs`, then `ys`, then `xs`.
+  
+  ### Example
+  ```re
+  let together = (x, y, z, w, q) => {x ++ y ++ z ++ w ++ q};
+  map5(together, ["a", "b"], ["c"], ["d", "e"], ["f"], ["g", "h"]) ==
+    ["acdfg", "acdfh", "acefg", "acefh", "bcdfg", "bcdfh", "bcefg", "bcefh"];
+  ```
+*/
 let map5:
   (
     ('a, 'b, 'c, 'd, 'e) => 'f,
@@ -45,34 +168,374 @@ let map5:
     list('e)
   ) =>
   list('f);
+  
+/**
+  `pure(item)` returns a list containing the given item.
+
+  ## Example
+  ```re
+  pure("single") == ["single"];
+  ```
+*/
 let pure: 'a => list('a);
+
+/**
+  In `bind(xs, f)`, `f` is a function that takes an element
+  of the type in `xs` and returns a list. The result of `bind`
+  is the concatenation of all the list produced by applying
+  `f()` to the elements of `xs`.
+  
+  ### Example
+  ```re
+  let f = (x) => [ x - 5, x + 5 ];
+  bind([100, 101, 102], f) == [95, 105, 96, 106, 97, 107];
+  bind([ ], f) == [ ];
+  ```
+*/
 let bind: (list('a), 'a => list('b)) => list('b);
+
+/**
+  In `flatMap(f, xs)`, `f` is a function that takes an element
+  of the type in `xs` and returns a list. The result of `bind`
+  is the concatenation of all the lists produced by applying
+  `f()` to the elements of `xs`.
+  
+  ### Example
+  ```re
+  let f = (x) => [ x - 5, x + 5 ];
+  flatMap(f, [100, 101, 102]) == [95, 105, 96, 106, 97, 107];
+  flatMap(f, [ ]) == [ ];
+  ```
+*/
 let flatMap: ('a => list('b), list('a)) => list('b);
+
+/**
+  `flatten(xs_of_xs)` takes a list of lists as its argument
+  and returns a list with all the sub-lists concatenated.
+  
+  ### Example
+  ```re
+  flatten([ ["a", "b"], [ ], ["c"], ["d", "e", "f"] ]) ==
+    ["a", "b", "c", "d", "e", "f"];
+  ```
+*/
 let flatten: list(list('a)) => list('a);
 
 /**
  * The following functions come for free because List is a member of Foldable
  */
+
+/**
+  `foldLeft(f, init, xs)` accumulates a value. Starting with `init`,
+  as the initial value of the accumulator, `foldLeft` applies function
+  `f` to the accumulator and the first element in the list `xs`. The result
+  becomes the new value of the accumulator, and `f` is applied to that value
+  and the next element in `xs`. This process continues until all elements in
+  `xs` are processed. The final value of the accumulator is returned.
+
+  ## Example
+  ```re
+  foldLeft((acc, item) => append(item, acc), [ ], [1, 2, 3]) == [1, 2, 3];
+  foldLeft((acc, item) => acc + item, 2, [ ]) == 2;
+  ```
+*/
 let foldLeft: (('b, 'a) => 'b, 'b, list('a)) => 'b;
+
+/**
+  `foldRight(f, init, xs)` accumulates a value. Starting with `init`,
+  as the initial value of the accumulator, `foldRight` applies function
+  `f` to the last element in the list `xs` and the accumulator. The result
+  becomes the new value of the accumulator, and `f` is applied to that value
+  and the preceding element in `xs`. This process continues until all elements in
+  `xs` are processed. The final value of the accumulator is returned.
+
+  ## Example
+  ```re
+  foldRight((item, acc) => append(item, acc), [ ], [1, 2, 3]) == [3, 2, 1];
+  foldRight((item, acc) => acc + item, 2, [ ]) == 2;
+  ```
+*/
 let foldRight: (('a, 'b) => 'b, 'b, list('a)) => 'b;
+
+/**
+  In `any(pred, xs)`, `pred` is a function that takes an item of the type in the
+  list and returns a boolean value.  The `any()` function returns `true` if
+  `pred(x)` returns true for any item `x` in the list, `false` otherwise.
+  
+  ### Example
+  ```re
+  any( (x) => {x < 0}, [100, -101, 102]) == true;
+  any( (x) => {x < 0}, [100, 101, 102]) == false;
+  ```
+*/
 let any: ('a => bool, list('a)) => bool;
+
+/**
+  In `all(pred, xs)`, `pred` is a function that takes an item of the type in the
+  list and returns a boolean value.  The `all()` function returns `true` if
+  `pred(x)` returns true for every item `x` in the list, `false` otherwise.
+  
+  ### Example
+  ```re
+  all( (x) => {x < 0}, [-100, -101, -102]) == true;
+  all( (x) => {x < 0}, [-100, 101, -102]) == false;
+  ```
+*/
 let all: ('a => bool, list('a)) => bool;
+
+
+/**
+  In `containsBy(f, value, xs)`, the function `f` takes two items
+  of the type in the list and returns a predicate function `p()`
+  by calling `f(value)`.
+  
+  `containsBy() returns `true` if any item in `xs` satisfies this
+  new predicate function `p()`.
+  
+  ### Example
+  ```re
+  let aboveLimit = (limit, x) => { x > limit };
+  containsBy(aboveLimit, 50, [30, 70, 20]) == true;
+  containsBy(aboveLimit, 90, [30, 70, 20]) == false;
+  ```
+*/
 let containsBy: (('a, 'a) => bool, 'a, list('a)) => bool;
+
+/**
+  In `indexOfBy(f, value, xs)`, the function `f` takes two items
+  of the type in the list and returns a predicate function `p()`
+  by calling `f(value)`.
+  
+  `indexOfBy() returns `Some(position)` where `position` is the index
+  of the first item in `xs` that satisfies this new predicate function `p()`,
+  or `None` if no item in `xs` satisfies the predicate.
+  
+  ### Example
+  ```re
+  let aboveLimit = (limit, x) => { x > limit };
+  indexOfBy(aboveLimit, 50, [30, 70, 20, 80]) == Some(1);
+  indexOfBy(aboveLimit, 90, [30, 70, 20, 80]) == None;
+  ```
+*/
 let indexOfBy: (('a, 'a) => bool, 'a, list('a)) => option(int);
+
+/**
+  `minBy(f, xs)` returns the minimum value in list `xs` as
+  `Some(val)`. It uses function `f` to compare values in the list.
+  Function `f` takes two parameters of the type in the list and
+  returns a value of ` `less_than `, ` `equal_to `, or ` `greater_than `,
+  depending on the relationship of the values.
+  
+  If given an empty list, `minBy()` returns `None`.
+  
+  ### Example
+  ```re
+  let clockCompare = (a, b) => {
+    if (a mod 12 < b mod 12) {
+      `less_than
+    } else if (a mod 12 > b mod 12) {
+      `greater_than
+    } else {
+      `equal_to
+    }
+  };
+  
+  minBy(clockCompare, [5, 3, 17, 14, 9]) == Some(14);
+  minBy(clockCompare, [5, 17]) == Some(5);
+  minBy(clockCompare, [ ]) == None;
+  ```
+*/
 let minBy:
   (('a, 'a) => BsAbstract.Interface.ordering, list('a)) => option('a);
+
+/**
+  `maxBy(f, xs)` returns the maximum value in list `xs` as
+  `Some(val)`. It uses function `f` to compare values in the list.
+  Function `f` takes two parameters of the type in the list and
+  returns a value of ` `less_than `, ` `equal_to `, or ` `greater_than `,
+  depending on the relationship of the values.
+  
+  If given an empty array, `maxBy()` returns `None`.
+  
+  ### Example
+  ```re
+  let clockCompare = (a, b) => {
+    if (a mod 12 < b mod 12) {
+      `less_than
+    } else if (a mod 12 > b mod 12) {
+      `greater_than
+    } else {
+      `equal_to
+    }
+  };
+  
+  maxBy(clockCompare, [5, 3, 17, 14, 9]) == Some(9);
+  maxBy(clockCompare, [5, 17]) == Some(5);
+  maxBy(clockCompare, [ ]) == None;
+  ```
+*/
 let maxBy:
   (('a, 'a) => BsAbstract.Interface.ordering, list('a)) => option('a);
+
+/**
+  `countBy(countFcn, xs)` returns the number of items `x` in list `xs`
+  for which `countFcn(x)` returns `true`.
+  
+  ### Example
+  ```re
+  let isOdd = (x) => {x mod 2 == 1};
+  countBy(isOdd, [33, 22, 55, 11, 44, 66]) == 3;
+  countBy(isOdd, [22, 44, 66]) == 0;
+  countBy(isOdd, [ ]) == 0;
+  ```
+*/
 let countBy: ('a => bool, list('a)) => int;
+
+/**
+  `length(xs)` returns the number of items in `xs`.
+
+  ## Example
+  ```re
+  length(["a", "b", "c"]) == 3;
+  length([ ]) == 0;
+  ```
+*/
 let length: list('a) => int;
+
+/**
+  In `forEach(f, xs)`, `f()` is a function that takes an element
+  of `xs` and returns `unit`. `forEach()` applies this function to
+  each element of `xs`. You use `forEach()` when you are interested in
+  the side effects rather than the result of a function.
+  
+  ### Example
+  ```re
+  forEach(Js.log, ["a", "b", "c"]) == (); // prints a, b, and c
+  ```
+*/
 let forEach: ('a => unit, list('a)) => unit;
+
+/**
+  In `forEachWithIndex(f, xs)`, `f()` is a function that takes an element
+  of `xs` and an integer and returns `unit`. `forEach()` applies this function to
+  each element of `xs`, passing the element and its index number (starting
+  at zero). You use `forEachWithIndex()` when you are interested in
+  the side effects rather than the result of a function.
+  
+  ### Example
+  ```re
+  let debug = (x, i) => {Js.log(string_of_int(i) ++ " " ++ x)};
+  forEachWithIndex(debug, ["a", "b", "c"]) == (); // prints 0 a, 1 b, and 2 c
+  ```
+*/
 let forEachWithIndex: (('a, int) => unit, list('a)) => unit;
+
+/**
+  `find(pred, xs)` returns `Some(x)` for the first value in `xs`
+  for which the predicate function `pred(x)` returns `true`.
+  If no value in the list satisfies `pred()`, `find()` returns `None`.
+  
+  ### Example
+  ```re
+  find((x) => {x mod 2 == 0}, [3, 7, 4, 2, 5]) == Some(4);
+  find((x) => {x mod 2 == 0}, [3, 7, 5]) == None;
+  ```
+*/
 let find: ('a => bool, list('a)) => option('a);
+
+/**
+  `findWithIndex(pred, xs)` calls `pred()` with two arguments: an element
+  of `xs` and its index value (zero-based). If `pred()` returns `true`,
+  the element is returned as `Some(x)`.  If no element in the list satisfies
+  `pred()`, `findWithIndex()` returns `None`.
+
+  
+  ### Example
+  ```re
+  let bothEven = (x, i) => {x mod 2 == 0 && i mod 2 == 0};
+  findWithIndex(bothEven, [3, 6, 4, 7, 5]) == Some(4);
+  findWithIndex(bothEven, [3, 6, 7, 8, 5]) == None;
+  findWithIndex(bothEven, [3, 7, 5]) == None;
+  ```
+*/
 let findWithIndex: (('a, int) => bool, list('a)) => option('a);
+
+/**
+  `fold((module M), xs)` concatenates the elements of `xs` as specified by
+  the given module. The module you provide must define the following:
+  
+  - a type specification
+  - an `append()` function which takes two items of the type and appends them
+    to one another
+  - an “empty” element
+  
+  Appending the empty element and an item must be commutative;
+  `append(x, empty) == append(empty, x)`
+  
+  ### Example
+  ```re
+  module CapString = {
+    type t = string;
+    let append(a, b) = Js.String.toUpperCase(a) ++ Js.String.toUpperCase(b);
+    let empty = "";
+  };
+  
+  fold((module CapString), ["it ", "works!"]) == "IT WORKS!";
+  ```
+*/
 let fold:
   ((module BsAbstract.Interface.MONOID with type t = 'a), list('a)) => 'a;
+
+/**
+  `intercalate((module M), delim, xs)` concatenates the elements of `xs` as specified by
+  the given module, with `delim` between all the elements. The module you provide
+  must define:
+  
+  - a type `t`
+  - an `append()` function which takes two items of the type and appends them
+    to one another
+  - an “empty” element
+  
+  Appending the empty element and an item must be commutative;
+  `append(x, empty) == append(empty, x)`
+  
+  ### Example
+  ```re
+  module LowerString = {
+    type t = string;
+    let append(a, b) = Js.String.toLowerCase(a) ++ Js.String.toLowerCase(b);
+    let empty = "";
+  };
+  
+  intercalate((module LowerString), "--", ["2019", "MAY", "5"]) == "2019--may--5";
+  ```
+*/
 let intercalate:
   ((module BsAbstract.Interface.MONOID with type t = 'a), 'a, list('a)) => 'a;
+
+/**
+  `contains((module M), val, xs)` returns `true` if any element of `xs` equals
+  `val`, as determined by the module. It returns `false` if no element equals
+  `val`.  The module you provide must define:
+  
+  - a type `t`
+  - a function `eq()` which takes two items of type `t` and returns `true` if
+    they are to be considered equal, `false` otherwise.
+    
+  ### Example
+  ```re
+  module Pair = {
+    type t = (string, int);
+    let eq = ((pair1First, pair1Second), (pair2First, pair2Second)) => {
+      pair1First == pair2First && pair1Second == pair2Second
+    };
+  };
+  
+  contains((module Pair), ("c", 5), [("a", 1), ("b", 3), ("c", 5), ("d", 7)]) == true;
+  contains((module Pair), ("c", 5), [("c", 1), ("b", 5)]) == false;
+  contains((module Pair), ("c", 5), [ ]) == false;
+  ```
+*/
 let contains:
   ((module BsAbstract.Interface.EQ with type t = 'a), 'a, list('a)) => bool;
 let indexOf:
@@ -331,7 +794,7 @@ module Infix: {
   let (=<<): ('a => list('b), list('a)) => list('b);
   let (>=>): ('a => list('b), 'b => list('c), 'a) => list('c);
   let (<=<): ('a => list('b), 'c => list('a), 'c) => list('b);
-  let (<|>): (list('a), list('a)) => list('a);
+  let (<>): (list('a), list('a)) => list('a);
   let (<$>): ('a => 'b, list('a)) => list('b);
   let (<#>): (list('a), 'a => 'b) => list('b);
   let (<*>): (list('a => 'b), list('a)) => list('b);


### PR DESCRIPTION
Rewrote documentation for `Relude_Array` to take account of use of `ORD`, `EQ`, `MONOID`, and `SHOW` modules for some of the functions. This required discussing each of them in a long comment at the beginning of the module. 

`module Validation` is as yet undocumented, as I am not sure what it does / how it works / what part of it *needs* to be documented.