### PR TITLE
Make List.replicate() return [] for non-positive n.

### DIFF
--- a/__tests__/Relude_Array_test.re
+++ b/__tests__/Relude_Array_test.re
@@ -399,6 +399,16 @@ describe("Array", () => {
     |> toEqual([|"a", "b", "c", "a", "b", "c", "a", "b", "c"|])
   );
 
+  test("replicate zero", () =>
+    expect(Array.replicate(0, [|"a", "b", "c"|]))
+    |> toEqual([| |])
+  );
+
+  test("replicate negative", () =>
+    expect(Array.replicate(-3, [|"a", "b", "c"|]))
+    |> toEqual([| |])
+  );
+
   test("zip same length array", () =>
     expect(Array.zip([|1, 2, 3|], [|"4", "5", "6"|]))
     |> toEqual([|(1, "4"), (2, "5"), (3, "6")|])

--- a/__tests__/Relude_List_test.re
+++ b/__tests__/Relude_List_test.re
@@ -378,8 +378,12 @@ describe("List", () => {
     expect(List.replicate(1, ["foo"])) |> toEqual(["foo"])
   );
 
+  test("replicate zero", () =>
+    expect(List.replicate(0, ["none"])) |> toEqual([ ])
+  );
+
   test("replicate negative", () =>
-    expect(List.replicate(-1, [0])) |> toEqual([0])
+    expect(List.replicate(-1, [0])) |> toEqual([])
   );
 
   test("replicate empty list", () =>

--- a/src/data/list/Relude_List_Base.re
+++ b/src/data/list/Relude_List_Base.re
@@ -162,7 +162,11 @@ let replicate: 'a. (int, list('a)) => list('a) =
   (i, xs) => {
     let rec go = (count, acc) =>
       count <= 1 ? acc : go(count - 1, Relude_List_Types.concat(xs, acc));
-    go(i, xs);
+    if (i <= 0) {
+      [ ]
+    } else {
+      go(i, xs);
+    }
   };
 
 let zip: 'a 'b. (list('a), list('b)) => list(('a, 'b)) = Belt.List.zip;


### PR DESCRIPTION
Fix problem noted in https://github.com/reazen/relude/issues/85 so that `Array.replicate()` and `List.replicate()` return the empty array/list when the count is zero or negative.