### PR TITLE
Tail recursive intersperse

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.re linguist-language=Reason
+*.rei linguist-language=Reason

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 npm-debug.log
 /node_modules/
 
+# Jest
+/coverage/
+
 # OCaml/BuckleScript/ReasonML
 .merlin
 .bsb.lock

--- a/__tests__/Relude_Array_test.re
+++ b/__tests__/Relude_Array_test.re
@@ -411,9 +411,17 @@ describe("Array", () => {
     |> toEqual([|0, 0, 0, 1, 0, 2|])
   );
 
+  test("prependToAll (empty array)", () =>
+    expect(Array.prependToAll(0, [||])) |> toEqual([||])
+  );
+
   test("intersperse", () =>
     expect(Array.intersperse(",", [|"a", "b", "c"|]))
     |> toEqual([|"a", ",", "b", ",", "c"|])
+  );
+
+  test("intersperse (empty array)", () =>
+    expect(Array.intersperse(",", [||])) |> toEqual([||])
   );
 
   test("replicate", () =>

--- a/__tests__/Relude_List_test.re
+++ b/__tests__/Relude_List_test.re
@@ -391,6 +391,11 @@ describe("List", () => {
     |> toEqual(["a", ",", "b", ",", "c"])
   );
 
+  test("intersperse is tail recursive", () =>
+    expect(List.(repeat(20000, 0) |> intersperse(1) |> length))
+    |> toEqual(39999)
+  );
+
   test("replicate", () =>
     expect(List.replicate(3, ["a", "b", "c"]))
     |> toEqual(["a", "b", "c", "a", "b", "c", "a", "b", "c"])

--- a/src/array/Relude_Array_Base.re
+++ b/src/array/Relude_Array_Base.re
@@ -165,16 +165,8 @@ let splitAt: (int, array('a)) => option((array('a), array('a))) =
       ));
     };
 
-let rec prependToAll: ('a, array('a)) => array('a) =
-  (delim, xs) =>
-    switch (head(xs)) {
-    | None => [||]
-    | Some(x) =>
-      Relude_Array_Instances.concat(
-        [|delim, x|],
-        prependToAll(delim, tailOrEmpty(xs)),
-      )
-    };
+let prependToAll: ('a, array('a)) => array('a) =
+  (delim, xs) => Relude_Array_Instances.flatMap(v => [|delim, v|], xs);
 
 let intersperse: ('a, array('a)) => array('a) =
   (delim, xs) =>

--- a/src/list/Relude_List_Base.re
+++ b/src/list/Relude_List_Base.re
@@ -148,12 +148,15 @@ let partition: 'a. ('a => bool, list('a)) => (list('a), list('a)) =
 let splitAt: 'a. (int, list('a)) => option((list('a), list('a))) =
   (i, xs) => Belt.List.splitAt(xs, i);
 
-let rec prependToAll: 'a. ('a, list('a)) => list('a) =
-  (delim, xs) =>
-    switch (xs) {
-    | [] => []
-    | [y, ...ys] => [delim, y, ...prependToAll(delim, ys)]
-    };
+let prependToAll: 'a. ('a, list('a)) => list('a) =
+  (delim, xs) => {
+    let rec go = acc =>
+      fun
+      | [] => acc
+      | [y, ...ys] => go([y, delim, ...acc], ys);
+
+    go([], xs) |> reverse;
+  };
 
 let intersperse: 'a. ('a, list('a)) => list('a) =
   (delim, xs) =>


### PR DESCRIPTION
Bucklescript's OCaml version doesn't yet support `[@tailcall]` so for now I just made a huge list in a test to ensure tail recursion. The test was failing prior to the change to `prependToAll`.