### PR TITLE
Fix incorrect type signature for `Map.groupBy`

### DIFF
--- a/src/Relude_Map.re
+++ b/src/Relude_Map.re
@@ -49,8 +49,8 @@ module type MAP = {
     ((key, 'value) => bool, t('value)) => (t('value), t('value));
   let map: ('v1 => 'v2, t('v1)) => t('v2);
   let mapWithKey: ((key, 'v1) => 'v2, t('v1)) => t('v2);
-  let groupListBy: ('a => Comparable.t, list('a)) => t(list('a));
-  let groupArrayBy: ('a => Comparable.t, array('a)) => t(array('a));
+  let groupListBy: ('a => key, list('a)) => t(list('a));
+  let groupArrayBy: ('a => key, array('a)) => t(array('a));
 };
 
 module WithOrd = (M: BsAbstract.Interface.ORD) : (MAP with type key = M.t) => {


### PR DESCRIPTION
Currently, the `Map.groupBy` wants a `Map.Comparable.t` instead of the `Map.key`. These types should be the same but that isn't explicit in the module definition and it's opaque to consumers so the type signature of this needs to switch to be explicitly the key of the map.
