### PR TITLE
Fix AsyncResult.toIdle

### DIFF
--- a/src/Relude_AsyncResult.re
+++ b/src/Relude_AsyncResult.re
@@ -235,7 +235,7 @@ let toBusy = Relude_AsyncData.toBusy;
 /**
  * Indicates if the AsyncResult is in a non-working state (Init or Complete)
  */
-let toIdle = Relude_AsyncData.toBusy;
+let toIdle = Relude_AsyncData.toIdle;
 
 /**
  * Maps a pure function over the value in a Reloading(Ok(_)) or Complete(Ok(_)) value


### PR DESCRIPTION
I'm assuming this `Relude_AsyncResult.toIdle` should correspond to `Relude_AsyncData.toIdle`, in the same way as `Relude_AsyncResult.toBusy` corresponds to `Relude_AsyncData.toBusy`?