### PR TITLE
Fix `IO.summonError`

### DIFF
--- a/src/Relude_IO.re
+++ b/src/Relude_IO.re
@@ -543,7 +543,10 @@ let rec summonError: 'a 'e. t('a, 'e) => t(Result.t('a, 'e), Void.t) =
               | Ok(r0) =>
                 r0ToIOA(r0)
                 |> summonError
-                |> tap(resA => onDoneMat(Result.ok(resA)))
+                |> bitap(
+                     resA => onDoneMat(Result.ok(resA)),
+                     resA => onDoneMat(Result.error(resA)),
+                   )
                 |> ignore,
             ),
         )


### PR DESCRIPTION
When an `IO` with an `Async` constructor is sent through a `flatMap`
which we then `summonError` on, the `onDone` of `Async` constructor is
never called which means that the IO will never resolve.

It seems that switching the `tap` to a `bitap` fixes this issue.