### PR TITLE
Add `Named` comparison operators for ORD typeclass

### DIFF
--- a/__tests__/Relude_Float_test.re
+++ b/__tests__/Relude_Float_test.re
@@ -128,6 +128,45 @@ describe("Float", () => {
     expect(Float.greaterThanOrEq(1.0, 2.0)) |> toEqual(false)
   );
 
+  test("named lessThan (smaller)", () =>
+    expect(Float.Named.lessThan(~compareTo=3.15, 3.14)) |> toEqual(true)
+  );
+
+  test("named lessThan (equal)", () =>
+    expect(Float.Named.lessThan(~compareTo=3.14, 3.14)) |> toEqual(false)
+  );
+
+  test("named lessThanOrEq (smaller)", () =>
+    expect(Float.Named.lessThanOrEq(~compareTo=2.0, 1.0)) |> toEqual(true)
+  );
+
+  test("named lessThanOrEq (larger)", () =>
+    expect(Float.Named.lessThanOrEq(~compareTo=0.0, 3.0)) |> toEqual(false)
+  );
+
+  test("named greaterThan (larger)", () =>
+    expect(Float.Named.greaterThan(~compareTo=0.1, 1.0)) |> toEqual(true)
+  );
+
+  test("named greaterThan (equal)", () =>
+    expect(Float.Named.greaterThan(~compareTo=1.0, 1.0)) |> toEqual(false)
+  );
+
+  test("named greaterThanOrEq (eq)", () =>
+    expect(Float.Named.greaterThanOrEq(~compareTo=0.0, 0.0))
+    |> toEqual(true)
+  );
+
+  test("named greaterThanOrEq (larger)", () =>
+    expect(Float.Named.greaterThanOrEq(~compareTo=0.0, 1.0))
+    |> toEqual(true)
+  );
+
+  test("named greaterThanOrEq (smaller)", () =>
+    expect(Float.Named.greaterThanOrEq(~compareTo=2.0, 1.0))
+    |> toEqual(false)
+  );
+
   test("clamp (in range)", () =>
     expect(Float.clamp(~min=1.1, ~max=1.5, 1.3)) |> toEqual(1.3)
   );

--- a/src/extensions/Relude_Extensions_Ord.re
+++ b/src/extensions/Relude_Extensions_Ord.re
@@ -231,6 +231,20 @@ module OrdExtensions = (O: ORD) => {
     let abs = v => abs((module O), (module R), v);
     let signum = v => signum((module O), (module R), v);
   };
+
+  module Named = {
+    let lessThan = (~compareTo, a) => lessThanBy(O.compare, a, compareTo);
+    let lessThanOrEq = (~compareTo, a) =>
+      lessThanOrEqBy(O.compare, a, compareTo);
+    let greaterThan = (~compareTo, a) =>
+      greaterThanBy(O.compare, a, compareTo);
+    let greaterThanOrEq = (~compareTo, a) =>
+      greaterThanOrEqBy(O.compare, a, compareTo);
+    let lt = lessThan;
+    let lte = lessThanOrEq;
+    let gt = greaterThan;
+    let gte = greaterThanOrEq;
+  };
 };
 
 module OrdInfix = (O: ORD) => {


### PR DESCRIPTION
When using comparison operators for ORD typeclasses, it's somewhat
ambiguous which one is being compared to which.

For example if you want to see 2 is less than 3 then you have to know
that with using the `OrdExtensions` methods that 2 has to come before
3 in the arg order. Also, when partially applying or when using `|>`
things don't read very well (e.g. `3.0 |> Float.lessThan(2.0)`).

By using a named parameter, the thought is that this can help clear that
up by making it explicit what is being compared to (e.g.
`2.0 |> Float.Named.lessThan(~compareTo=3.0)`)

The new functions are in a submodule called `Named` which was the done
to keep backwards compatibility. I'm not 100% on the naming of things
but I wanted to open this and start a conversation about what would be a
way forward that everybody can agree on.