### PR TITLE
Cond methods for IO and ResultT

### DIFF
--- a/__tests__/Relude_IO_test.re
+++ b/__tests__/Relude_IO_test.re
@@ -829,6 +829,28 @@ describe("IO examples", () => {
          | Error(_) => onDone(fail("Failed")),
        )
   );
+
+  testAsync("example cond", onDone =>
+    IO.pure("hello")
+    |> IO.cond(a => a |> String.length == 5, "is five", "boom explosions")
+    |> IO.map(a => expect(a) |> toEqual("is five"))
+    |> IO.unsafeRunAsync(
+         fun
+         | Ok(assertion) => onDone(assertion)
+         | _ => onDone(fail("fail")),
+       )
+  );
+
+  testAsync("condError", onDone =>
+    IO.pure("hello world")
+    |> IO.condError(a => a |> String.length == 5, "string is too long")
+    |> IO.mapError(a => expect(a) |> toEqual("string is too long"))
+    |> IO.unsafeRunAsync(
+         fun
+         | Ok(_) => onDone(fail("fail"))
+         | Error(assertion)=> onDone(assertion)
+       )
+  );
 });
 
 let testFilePath = FS.testFilePath("Eff_test.txt");

--- a/src/Relude_IO.re
+++ b/src/Relude_IO.re
@@ -156,6 +156,20 @@ let apply: 'a 'b 'e. (t('a => 'b, 'e), t('a, 'e)) => t('b, 'e) =
   (ioF, ioA) => ioF |> flatMap(f => ioA |> map(f));
 
 /**
+ Conditional map.
+ If the condition is satisfied, return the given `'a` in lifted into a successful IO, otherwise,
+ return the given `e` Lifted to the error side.
+ */
+let cond: 'a 'e. ('a => bool, 'a, 'e, t('a, 'e)) => t('a, 'e) =
+  (f, newA, err, ioA) => flatMap(a => f(a)? pure(newA) : throw(err), ioA);
+
+/**
+ As `cond`, but only maps the 'e side when the condition fails.
+ */
+let condError: 'a 'e. ('a => bool, 'e, t('a, 'e)) => t('a, 'e) =
+  (f, err, ioA) => flatMap(a => f(a)? pure(a) : throw(err), ioA);
+
+/**
 Unsafely runs the `IO.t('a, 'e)` to produce a final `Result.t('a, 'e)`, which is provided to the caller via
 a callback of type `Result.t('a, 'e) => unit`.
 

--- a/src/Relude_ResultT.re
+++ b/src/Relude_ResultT.re
@@ -39,7 +39,17 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
 
   let subflatMap: 'a 'b 'e. ('a => Result.t('b, 'e),  t('a, 'e)) => t('b, 'e) =
     (aToB, ResultT(mResultA)) =>
-      ResultT(M.map(optionA => Result.flatMap(aToB, optionA), mResultA));
+      ResultT(M.map(resultA => Result.flatMap(aToB, resultA), mResultA));
+      
+  let cond: 'a 'e. ('a => bool, 'a, 'e,  t('a, 'e)) => t('a, 'e) =
+    (aToBool, success, err, ResultT(mResultA)) =>
+      ResultT(M.map(resultA => Result.flatMap(a => 
+        aToBool(a) ? Result.pure(success) : Result.error(err), resultA), mResultA));
+
+  let condError: 'a 'b 'e. ('a => bool, 'e,  t('a, 'e)) => t('a, 'e) =
+    (aToBool, err, ResultT(mResultA)) =>
+      ResultT(M.map(resultA => Result.flatMap(a => 
+        aToBool(a) ? Result.pure(a) : Result.error(err), resultA), mResultA));
 
   let mapError: 'a 'e1 'e2. ('e1 => 'e2, t('a, 'e1)) => t('a, 'e2) = withResultT;
 
@@ -93,6 +103,8 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
     let liftF = liftF;
     let subflatMap = subflatMap;
     let semiflatMap = semiflatMap;
+    let cond = cond;
+    let condError = condError;
 
     module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a, E.t) = {
       type nonrec t('a) = t('a, E.t);


### PR DESCRIPTION
More useful methods lifted from cats, based on: https://github.com/typelevel/cats/blob/c56edd78e6accfc276bfffad15d08d309a76076e/core/src/main/scala/cats/data/EitherT.scala#L739-L754

If you're happy to add these, then I'll cover them with tests and rebase tomorrow.