### PR TITLE
Remove operator and module aliases

### DIFF
--- a/src/Relude_RIO.re
+++ b/src/Relude_RIO.re
@@ -1,10 +1,7 @@
-let (>>) = Relude_Function.Infix.(>>);
-let (<<) = Relude_Function.Infix.(<<);
-
-module IO = Relude_IO;
+open Relude_Function.Infix;
 
 module WithError = (ERR: BsAbstract.Interface.TYPE) => {
-  module IOE = IO.WithError(ERR);
+  module IOE = Relude_IO.WithError(ERR);
   module M = IOE.MonadError;
   type t('r, 'a) =
     | RIO('r => M.t('a));

--- a/src/Relude_ReaderT.re
+++ b/src/Relude_ReaderT.re
@@ -1,5 +1,4 @@
-let (>>) = Relude_Function.Infix.(>>);
-let (<<) = Relude_Function.Infix.(<<);
+open Relude_Function.Infix;
 
 // TODO: not sure whether to just make this functor include the "Env" type R here along with the Monad, or
 // have it nested inside.  I have a convenience variant called WithMonadAndEnv, but maybe that should

--- a/src/Relude_Result.re
+++ b/src/Relude_Result.re
@@ -1,5 +1,4 @@
-let (<<) = Relude_Function.Infix.(<<);
-let (>>) = Relude_Function.Infix.(>>);
+open Relude_Function.Infix;
 
 type t('a, 'e) = Belt.Result.t('a, 'e);
 
@@ -683,7 +682,7 @@ let eqBy:
 */
 let tries: 'a. (unit => 'a) => t('a, exn) =
   fn =>
-    try (Ok(fn())) {
+    try(Ok(fn())) {
     | exn => Error(exn)
     };
 

--- a/src/Relude_ResultT.re
+++ b/src/Relude_ResultT.re
@@ -1,33 +1,31 @@
-module Result = Relude_Result;
-
 /**
  * Creates a ResultT Monad with the given outer Monad module.
  */
 module WithMonad = (M: BsAbstract.Interface.MONAD) => {
   type t('a, 'e) =
-    | ResultT(M.t(Result.t('a, 'e)));
+    | ResultT(M.t(Belt.Result.t('a, 'e)));
 
-  let make: 'a 'e. M.t(Result.t('a, 'e)) => t('a, 'e) =
+  let make: 'a 'e. M.t(Belt.Result.t('a, 'e)) => t('a, 'e) =
     mResult => ResultT(mResult);
 
-  let runResultT: 'a 'e. t('a, 'e) => M.t(Result.t('a, 'e)) =
+  let runResultT: 'a 'e. t('a, 'e) => M.t(Belt.Result.t('a, 'e)) =
     (ResultT(mResult)) => mResult;
 
   let withResultT: 'a 'e1 'e2. ('e1 => 'e2, t('a, 'e1)) => t('a, 'e2) =
     (e1ToE2, ResultT(mResultE1)) =>
       ResultT(
-        M.map(resultE1 => Result.mapError(e1ToE2, resultE1), mResultE1),
+        M.map(resultE1 => Relude_Result.mapError(e1ToE2, resultE1), mResultE1),
       );
 
   let mapResultT:
     'a 'b 'e.
-    (M.t(Result.t('a, 'e)) => M.t(Result.t('b, 'e)), t('a, 'e)) =>
+    (M.t(Belt.Result.t('a, 'e)) => M.t(Belt.Result.t('b, 'e)), t('a, 'e)) =>
     t('b, 'e)
    =
     (mResultAToMResultB, ResultT(mResultA)) =>
       ResultT(mResultAToMResultB(mResultA));
 
-  let fromResult: 'a 'e. Result.t('a, 'e) => t('a, 'e) =
+  let fromResult: 'a 'e. Belt.Result.t('a, 'e) => t('a, 'e) =
     result => ResultT(M.pure(result));
 
   let liftF: 'a 'e. M.t('a) => t('a, 'e) =
@@ -35,21 +33,21 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
 
   let map: 'a 'b 'e. ('a => 'b, t('a, 'e)) => t('b, 'e) =
     (aToB, ResultT(mResultA)) =>
-      ResultT(M.map(resultA => Result.map(aToB, resultA), mResultA));
+      ResultT(M.map(resultA => Relude_Result.map(aToB, resultA), mResultA));
 
-  let subflatMap: 'a 'b 'e. ('a => Result.t('b, 'e),  t('a, 'e)) => t('b, 'e) =
+  let subflatMap: 'a 'b 'e. ('a => Belt.Result.t('b, 'e),  t('a, 'e)) => t('b, 'e) =
     (aToB, ResultT(mResultA)) =>
-      ResultT(M.map(resultA => Result.flatMap(aToB, resultA), mResultA));
+      ResultT(M.map(resultA => Relude_Result.flatMap(aToB, resultA), mResultA));
       
   let cond: 'a 'e. ('a => bool, 'a, 'e,  t('a, 'e)) => t('a, 'e) =
     (aToBool, success, err, ResultT(mResultA)) =>
-      ResultT(M.map(resultA => Result.flatMap(a => 
-        aToBool(a) ? Result.pure(success) : Result.error(err), resultA), mResultA));
+      ResultT(M.map(resultA => Relude_Result.flatMap(a => 
+        aToBool(a) ? Relude_Result.pure(success) : Relude_Result.error(err), resultA), mResultA));
 
   let condError: 'a 'b 'e. ('a => bool, 'e,  t('a, 'e)) => t('a, 'e) =
     (aToBool, err, ResultT(mResultA)) =>
-      ResultT(M.map(resultA => Result.flatMap(a => 
-        aToBool(a) ? Result.pure(a) : Result.error(err), resultA), mResultA));
+      ResultT(M.map(resultA => Relude_Result.flatMap(a => 
+        aToBool(a) ? Relude_Result.pure(a) : Relude_Result.error(err), resultA), mResultA));
 
   let mapError: 'a 'e1 'e2. ('e1 => 'e2, t('a, 'e1)) => t('a, 'e2) = withResultT;
 
@@ -57,7 +55,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
     (aToB, e1ToE2, ResultT(mResultAE1)) => {
       ResultT(
         M.map(
-          resultAE1 => Result.bimap(aToB, e1ToE2, resultAE1),
+          resultAE1 => Relude_Result.bimap(aToB, e1ToE2, resultAE1),
           mResultAE1,
         ),
       );
@@ -68,14 +66,14 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
       ResultT(
         M.apply(
           M.map(
-            (resultAToB, resultA) => Result.apply(resultAToB, resultA),
+            (resultAToB, resultA) => Relude_Result.apply(resultAToB, resultA),
             mResultAToB,
           ),
           mResultA,
         ),
       );
 
-  let pure: 'a 'e. 'a => t('a, 'e) = a => ResultT(M.pure(Result.ok(a)));
+  let pure: 'a 'e. 'a => t('a, 'e) = a => ResultT(M.pure(Relude_Result.ok(a)));
 
   let bind: 'a 'b 'e. (t('a, 'e), 'a => t('b, 'e)) => t('b, 'e) =
     (ResultT(mResultA), aToResultTB) => {

--- a/src/Relude_SequenceZipper.re
+++ b/src/Relude_SequenceZipper.re
@@ -1,5 +1,3 @@
-let id = Relude_Function.id;
-
 /**
  * Creates a Zipper using the given SEQUENCE as the backing implementation
  *
@@ -150,7 +148,7 @@ module WithSequence = (S: Relude_Interface.SEQUENCE) => {
    */
   let apply: 'a 'b. (t('a => 'b), t('a)) => t('b) =
     (Zipper(l1, f1, r1), Zipper(l2, f2, r2)) =>
-      Zipper(S.zipWith(id, l1, l2), f1(f2), S.zipWith(id, r1, r2));
+      Zipper(S.zipWith(a => a, l1, l2), f1(f2), S.zipWith(a => a, r1, r2));
 
   module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
     include Functor;

--- a/src/Relude_Set.re
+++ b/src/Relude_Set.re
@@ -1,5 +1,4 @@
-let flip = Relude_Function.flip;
-let (>>) = Relude_Function.Infix.(>>);
+open Relude_Function.Infix;
 
 module type SET = {
   type value;
@@ -52,11 +51,11 @@ module WithOrd = (M: BsAbstract.Interface.ORD) : (SET with type value = M.t) => 
   let fromArray = Belt.Set.fromArray(_, ~id=(module Comparable));
   let fromList = Belt.List.toArray >> fromArray;
   let isEmpty = Belt.Set.isEmpty;
-  let contains = flip(Belt.Set.has);
-  let add = flip(Belt.Set.add);
-  let mergeMany = flip(Belt.Set.mergeMany);
-  let remove = flip(Belt.Set.remove);
-  let removeMany = flip(Belt.Set.removeMany);
+  let contains = Relude_Function.flip(Belt.Set.has);
+  let add = Relude_Function.flip(Belt.Set.add);
+  let mergeMany = Relude_Function.flip(Belt.Set.mergeMany);
+  let remove = Relude_Function.flip(Belt.Set.remove);
+  let removeMany = Relude_Function.flip(Belt.Set.removeMany);
   let update = entry => remove(entry) >> add(entry);
   let union = Belt.Set.union;
   let intersect = Belt.Set.intersect;
@@ -64,19 +63,19 @@ module WithOrd = (M: BsAbstract.Interface.ORD) : (SET with type value = M.t) => 
   let subset = Belt.Set.subset;
   let compare = Belt.Set.cmp;
   let eq = Belt.Set.eq;
-  let forEach = flip(Belt.Set.forEach);
+  let forEach = Relude_Function.flip(Belt.Set.forEach);
   let foldLeft = (fn, acc) => Belt.Set.reduce(_, acc, fn);
-  let all = flip(Belt.Set.every);
-  let any = flip(Belt.Set.some);
-  let filter = flip(Belt.Set.keep);
-  let partition = flip(Belt.Set.partition);
+  let all = Relude_Function.flip(Belt.Set.every);
+  let any = Relude_Function.flip(Belt.Set.some);
+  let filter = Relude_Function.flip(Belt.Set.keep);
+  let partition = Relude_Function.flip(Belt.Set.partition);
   let length = Belt.Set.size;
   let toArray = Belt.Set.toArray;
   let toList = Belt.Set.toList;
   let minimum = Belt.Set.minimum;
   let maximum = Belt.Set.maximum;
-  let get = flip(Belt.Set.get);
+  let get = Relude_Function.flip(Belt.Set.get);
   let getOrElse = (value, default, t) =>
     t |> get(value) |> Relude_Option_Base.getOrElse(default);
-  let split = flip(Belt.Set.split);
+  let split = Relude_Function.flip(Belt.Set.split);
 };

--- a/src/Relude_StateT.re
+++ b/src/Relude_StateT.re
@@ -1,4 +1,4 @@
-let (<<) = Relude_Function.Infix.(<<);
+open Relude_Function.Infix;
 
 module WithMonad = (M: BsAbstract.Interface.MONAD) => {
   /**

--- a/src/js/Relude_Js.re
+++ b/src/js/Relude_Js.re
@@ -1,4 +1,5 @@
 
+module Animation = Relude_Js_Animation;
 module Console = Relude_Js_Console;
 module Exn = Relude_Js_Exn;
 module Json = Relude_Js_Json;

--- a/src/js/Relude_Js_Json.re
+++ b/src/js/Relude_Js_Json.re
@@ -2,15 +2,7 @@
  * Relude.Js.Json contains helper functions for dealing with Js.Json.t values
  */;
 
-module Array = Relude_Array;
-module List = Relude_List;
-module NonEmptyList = Relude_NonEmpty.List;
-module NonEmptyArray = Relude_NonEmpty.Array;
-module Option = Relude_Option;
-module Result = Relude_Result;
-module Validation = Relude_Validation;
-let (>>) = Relude_Function.Infix.(>>);
-let (<<) = Relude_Function.Infix.(<<);
+ open Relude_Function.Infix;
 
 /**
 Type alias for Js.Json.t.
@@ -112,13 +104,13 @@ let fromArrayOfJsonBy: 'a. ('a => json, array('a)) => json =
 /**
 Creates a Js.Json.t array value from an list of Js.Json.t values
 */
-let fromListOfJson: list(json) => json = List.toArray >> fromArrayOfJson;
+let fromListOfJson: list(json) => json = Relude_List.toArray >> fromArrayOfJson;
 
 /**
 Creates a Js.Json.t array value from an list of values that can be converted to Js.Json.t values with the given function
 */
 let fromListOfJsonBy: 'a. ('a => json, list('a)) => json =
-  (f, items) => List.map(f, items) |> fromListOfJson;
+  (f, items) => Relude_List.map(f, items) |> fromListOfJson;
 
 /**
 Creates a Js.Json.t object value from a Js.Dict containing Js.Json.t values.
@@ -134,7 +126,7 @@ let fromArrayOfDictOfJson: array(dict) => json = Js.Json.objectArray;
 Creates a Js.Json.t array value from an list of Js.Dict.t(Js.Json.t) values.
 */
 let fromListOfDictOfJson: list(dict) => json =
-  List.toArray >> Js.Json.objectArray;
+  Relude_List.toArray >> Js.Json.objectArray;
 
 /**
 Creates a Js.Json.t object value from an array of key/value (string/Js.Json.t) tuples.
@@ -162,7 +154,7 @@ let fromListOfKeyValueTuples: list((Js.Dict.key, json)) => json =
 Attempts to decode the given Js.Json.t value as a null.  Returns `Some(())` if it is a `null`, otherwise `None`.
 */
 let toNull: json => option(unit) =
-  json => json |> Js.Json.decodeNull |> Option.void;
+  json => json |> Js.Json.decodeNull |> Relude_Option.void;
 
 /**
 Attempts to decode the given `Js.Json.t` value as a `boolean`
@@ -178,7 +170,7 @@ let toString: json => option(string) = Js.Json.decodeString;
 Attempts to decode the given `Js.Json.t` value as an `int`
 */
 let toInt: json => option(int) =
-  json => json |> Js.Json.decodeNumber |> Option.map(int_of_float);
+  json => json |> Js.Json.decodeNumber |> Relude_Option.map(int_of_float);
 
 /**
 Attempts to decode the given `Js.Json.t` value as a `float`
@@ -194,7 +186,7 @@ let toArrayOfJson: json => option(array(json)) = Js.Json.decodeArray;
 Attempts to decode the given `Js.Json.t` value as an array of `Js.Json.t` values, with a fallback.
 */
 let toArrayOfJsonOrElse: (array(json), json) => array(json) =
-  (default, json) => json |> toArrayOfJson |> Option.getOrElse(default);
+  (default, json) => json |> toArrayOfJson |> Relude_Option.getOrElse(default);
 
 /**
 Attempts to decode the given `Js.Json.t` value as an array of `Js.Json.t` values, with a fallback of an empty array.
@@ -205,13 +197,13 @@ let toArrayOfJsonOrEmpty = toArrayOfJsonOrElse([||]);
 Attempts to decode the given `Js.Json.t` value as a list of `Js.Json.t` values.
 */
 let toListOfJson: json => option(list(json)) =
-  json => json |> toArrayOfJson |> Option.map(Array.toList);
+  json => json |> toArrayOfJson |> Relude_Option.map(Relude_Array.toList);
 
 /**
 Attempts to decode the given `Js.Json.t` value as an list of `Js.Json.t` values, with a fallback.
 */
 let toListOfJsonOrElse = (default, json) =>
-  json |> toListOfJson |> Option.getOrElse(default);
+  json |> toListOfJson |> Relude_Option.getOrElse(default);
 
 /**
 Attempts to decode the given `Js.Json.t` value as a list of `Js.Json.t` values, with a fallback of an empty list.
@@ -227,7 +219,7 @@ let toDictOfJson: json => option(dict) = Js.Json.decodeObject;
 Attempts to decode the given `Js.Json.t` value as a `Js.Dict.t(Js.Json.t)` with a fallback.
  */
 let toDictOfJsonOrElse = (default, json) =>
-  json |> toDictOfJson |> Option.getOrElse(default);
+  json |> toDictOfJson |> Relude_Option.getOrElse(default);
 
 /**
 Attempts to decode the given `Js.Json.t` value as a `Js.Dict.t(Js.Json.t)` with a fallback of an empty `Js.Dict`.
@@ -264,18 +256,18 @@ module Error = {
 
 module Errors = {
   // I'm standardizing on NonEmptyArray as the error collector type... this was an arbitrary decision between List and Array
-  type t = NonEmptyArray.t(Error.t);
+  type t = Relude_NonEmpty.Array.t(Error.t);
 
-  let pure = NonEmptyArray.pure;
-  let make = NonEmptyArray.make;
-  let map = Validation.mapErrorsNea;
+  let pure = Relude_NonEmpty.Array.pure;
+  let make = Relude_NonEmpty.Array.make;
+  let map = Relude_Validation.mapErrorsNea;
 
-  module SemigroupAny = NonEmptyArray.SemigroupAny;
+  module SemigroupAny = Relude_NonEmpty.Array.SemigroupAny;
 };
 
-module ValidationE = Validation.WithErrors(Errors.SemigroupAny, Error.Type);
+module ValidationE = Relude_Validation.WithErrors(Errors.SemigroupAny, Error.Type);
 module ArrayValidationE =
-  Array.Validation.WithErrors(Errors.SemigroupAny, Error.Type);
+  Relude_Array.Validation.WithErrors(Errors.SemigroupAny, Error.Type);
 module TraversableE = ArrayValidationE.Traversable;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -285,50 +277,50 @@ module TraversableE = ArrayValidationE.Traversable;
 /**
  * Validates that the given Js.Json.t value is a null
  */
-let validateNull: json => Validation.t(unit, Errors.t) =
+let validateNull: json => Relude_Validation.t(unit, Errors.t) =
   json =>
     toNull(json)
-    |> Validation.fromOptionLazy(_ =>
+    |> Relude_Validation.fromOptionLazy(_ =>
          Errors.pure("JSON value is not a null: " ++ show(json))
        );
 
 /**
  * Validates that the given Js.Json.t value is a bool
  */
-let validateBool: json => Validation.t(bool, Errors.t) =
+let validateBool: json => Relude_Validation.t(bool, Errors.t) =
   json =>
     toBool(json)
-    |> Validation.fromOptionLazy(_ =>
+    |> Relude_Validation.fromOptionLazy(_ =>
          Errors.pure("JSON value is not a bool: " ++ show(json))
        );
 
 /**
  * Validates that the given Js.Json.t value is a string
  */
-let validateString: json => Validation.t(string, Errors.t) =
+let validateString: json => Relude_Validation.t(string, Errors.t) =
   json =>
     toString(json)
-    |> Validation.fromOptionLazy(_ =>
+    |> Relude_Validation.fromOptionLazy(_ =>
          Errors.pure("JSON value is not a string: " ++ show(json))
        );
 
 /**
  * Validates that the given Js.Json.t value is an int
  */
-let validateInt: json => Validation.t(int, Errors.t) =
+let validateInt: json => Relude_Validation.t(int, Errors.t) =
   json =>
     toInt(json)
-    |> Validation.fromOptionLazy(_ =>
+    |> Relude_Validation.fromOptionLazy(_ =>
          Errors.pure("JSON value is not an int: " ++ show(json))
        );
 
 /**
  * Validates that the given Js.Json.t value is a float
  */
-let validateFloat: json => Validation.t(float, Errors.t) =
+let validateFloat: json => Relude_Validation.t(float, Errors.t) =
   json =>
     toFloat(json)
-    |> Validation.fromOptionLazy(_ =>
+    |> Relude_Validation.fromOptionLazy(_ =>
          Errors.pure("JSON value is not a float: " ++ show(json))
        );
 
@@ -340,20 +332,20 @@ let validateFloat: json => Validation.t(float, Errors.t) =
 let validateOptional =
     (
       ~errorAsNone=false,
-      validate: json => Validation.t('a, Errors.t),
+      validate: json => Relude_Validation.t('a, Errors.t),
       json: json,
     )
-    : Validation.t(option('a), Errors.t) =>
+    : Relude_Validation.t(option('a), Errors.t) =>
   switch (validateNull(json)) {
   | VOk () => VOk(None)
   | VError(_) =>
     // It was not a null, so try the real validation function
     switch (validate(json)) {
-    | VOk(a) => Validation.pure(Some(a))
+    | VOk(a) => Relude_Validation.pure(Some(a))
     | VError(_) as e =>
       // The value was not null, and the real validation failed - decide if we ignore the error or return it
       if (errorAsNone) {
-        Validation.pure(None);
+        Relude_Validation.pure(None);
       } else {
         e;
       }
@@ -370,7 +362,7 @@ let validateOptional =
  */
 let getJsonAtIndex: (int, json) => option(json) =
   (index, json) => {
-    toArrayOfJson(json) |> Option.flatMap(Array.at(index));
+    toArrayOfJson(json) |> Relude_Option.flatMap(Relude_Array.at(index));
   };
 
 /**
@@ -378,13 +370,13 @@ let getJsonAtIndex: (int, json) => option(json) =
  * at the given index and validate it with the given validation function.
  */
 let validateJsonAtIndex:
-  (int, json => Validation.t('a, Errors.t), json) =>
-  Validation.t('a, Errors.t) =
+  (int, json => Relude_Validation.t('a, Errors.t), json) =>
+  Relude_Validation.t('a, Errors.t) =
   (index, validateItem, json) => {
     getJsonAtIndex(index, json)
-    |> Option.foldLazy(
+    |> Relude_Option.foldLazy(
          _ =>
-           Validation.error(
+           Relude_Validation.error(
              Errors.pure(
                string_of_int(index)
                ++ " was not found in JSON: "
@@ -398,13 +390,13 @@ let validateJsonAtIndex:
 /**
  * Validates that the given Js.Json.t value is an array with a null at the given index
  */
-let validateNullAtIndex: (int, json) => Validation.t(unit, Errors.t) =
+let validateNullAtIndex: (int, json) => Relude_Validation.t(unit, Errors.t) =
   (index, json) =>
     validateJsonAtIndex(
       index,
       json =>
         validateNull(json)
-        |> Validation.mapErrorsNea(error =>
+        |> Relude_Validation.mapErrorsNea(error =>
              string_of_int(index) ++ ": " ++ error
            ),
       json,
@@ -413,52 +405,52 @@ let validateNullAtIndex: (int, json) => Validation.t(unit, Errors.t) =
 /**
  * Validates that the given Js.Json.t value is an array with a bool at the given index.
  */
-let validateBoolAtIndex: (int, json) => Validation.t(bool, Errors.t) =
+let validateBoolAtIndex: (int, json) => Relude_Validation.t(bool, Errors.t) =
   (index, json) =>
     validateJsonAtIndex(
       index,
       json =>
         validateBool(json)
-        |> Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
+        |> Relude_Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
       json,
     );
 
 /**
  * Validates that the given Js.Json.t value is an array with an int at the given index.
  */
-let validateIntAtIndex: (int, json) => Validation.t(int, Errors.t) =
+let validateIntAtIndex: (int, json) => Relude_Validation.t(int, Errors.t) =
   (index, json) =>
     validateJsonAtIndex(
       index,
       json =>
         validateInt(json)
-        |> Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
+        |> Relude_Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
       json,
     );
 
 /**
  * Validates that the given Js.Json.t value is an array with a float at the given index.
  */
-let validateFloatAtIndex: (int, json) => Validation.t(float, Errors.t) =
+let validateFloatAtIndex: (int, json) => Relude_Validation.t(float, Errors.t) =
   (index, json) =>
     validateJsonAtIndex(
       index,
       json =>
         validateFloat(json)
-        |> Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
+        |> Relude_Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
       json,
     );
 
 /**
  * Validates that the given Js.Json.t value is an array with a string at the given index.
  */
-let validateStringAtIndex: (int, json) => Validation.t(string, Errors.t) =
+let validateStringAtIndex: (int, json) => Relude_Validation.t(string, Errors.t) =
   (index, json) =>
     validateJsonAtIndex(
       index,
       json =>
         validateString(json)
-        |> Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
+        |> Relude_Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
       json,
     );
 
@@ -475,10 +467,10 @@ let validateOptionalAtIndex =
       ~nullAsNone=true,
       ~errorAsNone=false,
       index: int,
-      validate: json => Validation.t('a, Errors.t),
+      validate: json => Relude_Validation.t('a, Errors.t),
       json: json,
     )
-    : Validation.t(option('a), Errors.t) =>
+    : Relude_Validation.t(option('a), Errors.t) =>
   switch (getJsonAtIndex(index, json)) {
   | Some(json) =>
     // We got JSON at the index, see if it's null
@@ -486,9 +478,9 @@ let validateOptionalAtIndex =
     | VOk () =>
       // The value was null, see if we treat that as a None or an error
       if (nullAsNone) {
-        Validation.pure(None);
+        Relude_Validation.pure(None);
       } else {
-        Validation.error(
+        Relude_Validation.error(
           Errors.pure(
             string_of_int(index)
             ++ " had a null value in JSON: "
@@ -499,10 +491,10 @@ let validateOptionalAtIndex =
     | VError(_) =>
       // The value was not null, try to validate it, and see if we treat an error as None or return it
       switch (validate(json)) {
-      | VOk(a) => Validation.pure(Some(a))
+      | VOk(a) => Relude_Validation.pure(Some(a))
       | VError(_) as e =>
         if (errorAsNone) {
-          Validation.pure(None);
+          Relude_Validation.pure(None);
         } else {
           e;
         }
@@ -511,9 +503,9 @@ let validateOptionalAtIndex =
   | None =>
     // There was no JSON at the index, see if we treat this as None or an error
     if (missingAsNone) {
-      Validation.ok(None);
+      Relude_Validation.ok(None);
     } else {
-      Validation.error(
+      Relude_Validation.error(
         Errors.pure(
           "No value was found at index " ++ string_of_int(index) ++ " for JSON: " ++ show(json),
         ),
@@ -527,23 +519,23 @@ let validateOptionalAtIndex =
  */
 let validateArrayOfJson:
   'a 'e.
-  ((int, json) => Validation.t('a, Errors.t), json) =>
-  Validation.t(array('a), Errors.t)
+  ((int, json) => Relude_Validation.t('a, Errors.t), json) =>
+  Relude_Validation.t(array('a), Errors.t)
  =
   (validateItem, json) => {
     json
     |> toArrayOfJson
-    |> Option.foldLazy(
+    |> Relude_Option.foldLazy(
          () =>
-           Validation.error(
+           Relude_Validation.error(
              Errors.pure("JSON value is not an array: " ++ show(json)),
            ),
          jsonValues =>
            jsonValues
-           |> Array.zipWithIndex
+           |> Relude_Array.zipWithIndex
            |> TraversableE.traverse(((json, index)) =>
                 validateItem(index, json)
-                |> Validation.mapErrorsNea(e =>
+                |> Relude_Validation.mapErrorsNea(e =>
                      string_of_int(index) ++ ": " ++ e
                    )
               ),
@@ -556,28 +548,28 @@ let validateArrayOfJson:
  */
 let validateArrayOfJsonAsList:
   'a 'e.
-  ((int, json) => Validation.t('a, Errors.t), json) =>
-  Validation.t(list('a), Errors.t)
+  ((int, json) => Relude_Validation.t('a, Errors.t), json) =>
+  Relude_Validation.t(list('a), Errors.t)
  =
   (validateItem, json) => {
     json
     |> toArrayOfJson
-    |> Option.foldLazy(
+    |> Relude_Option.foldLazy(
          () =>
-           Validation.error(
+           Relude_Validation.error(
              Errors.pure("JSON value is not an array: " ++ show(json)),
            ),
          arrayOfJson =>
            arrayOfJson
-           |> Array.zipWithIndex
+           |> Relude_Array.zipWithIndex
            |> TraversableE.traverse(((json, index)) =>
                 validateItem(index, json)
-                |> Validation.mapErrorsNea(e =>
+                |> Relude_Validation.mapErrorsNea(e =>
                      string_of_int(index) ++ ": " ++ e
                    )
               ),
        )
-    |> Validation.map(Array.toList);
+    |> Relude_Validation.map(Relude_Array.toList);
   };
 
 /**
@@ -586,14 +578,14 @@ let validateArrayOfJsonAsList:
  */
 let validateArrayAtIndex:
   'a.
-  (int, (int, json) => Validation.t('a, Errors.t), json) =>
-  Validation.t(array('a), Errors.t)
+  (int, (int, json) => Relude_Validation.t('a, Errors.t), json) =>
+  Relude_Validation.t(array('a), Errors.t)
  =
   (index, validateItem, json) =>
     getJsonAtIndex(index, json)
-    |> Option.foldLazy(
+    |> Relude_Option.foldLazy(
          _ =>
-           Validation.error(
+           Relude_Validation.error(
              Errors.pure(
                string_of_int(index)
                ++ " was not found in JSON: "
@@ -609,8 +601,8 @@ let validateArrayAtIndex:
  */
 let validateObjectAtIndex:
   'a.
-  (int, json => Validation.t('a, Errors.t), json) =>
-  Validation.t('a, Errors.t)
+  (int, json => Relude_Validation.t('a, Errors.t), json) =>
+  Relude_Validation.t('a, Errors.t)
  = validateJsonAtIndex;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -623,7 +615,7 @@ let validateObjectAtIndex:
  */
 let getJsonForKey: (string, json) => option(json) =
   (key, json) => {
-    toDictOfJson(json) |> Option.flatMap(dict => Js.Dict.get(dict, key));
+    toDictOfJson(json) |> Relude_Option.flatMap(dict => Js.Dict.get(dict, key));
   };
 
 /**
@@ -631,13 +623,13 @@ let getJsonForKey: (string, json) => option(json) =
  * given key using the given validation function.
  */
 let validateJsonForKey:
-  (string, json => Validation.t('a, Errors.t), json) =>
-  Validation.t('a, Errors.t) =
+  (string, json => Relude_Validation.t('a, Errors.t), json) =>
+  Relude_Validation.t('a, Errors.t) =
   (key, validateItem, json) => {
     getJsonForKey(key, json)
-    |> Option.foldLazy(
+    |> Relude_Option.foldLazy(
          _ =>
-           Validation.error(
+           Relude_Validation.error(
              Errors.pure(key ++ " was not found in JSON: " ++ show(json)),
            ),
          json => validateItem(json),
@@ -647,60 +639,60 @@ let validateJsonForKey:
 /**
  * Validates the given Js.Json.t value is an object with a null at the given key.
  */
-let validateNullForKey: (string, json) => Validation.t(unit, Errors.t) =
+let validateNullForKey: (string, json) => Relude_Validation.t(unit, Errors.t) =
   (key, json) =>
     validateJsonForKey(
       key,
       json =>
-        validateNull(json) |> Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateNull(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 
 /**
  * Validates the given Js.Json.t value is an object with a bool at the given key.
  */
-let validateBoolForKey: (string, json) => Validation.t(bool, Errors.t) =
+let validateBoolForKey: (string, json) => Relude_Validation.t(bool, Errors.t) =
   (key, json) =>
     validateJsonForKey(
       key,
       json =>
-        validateBool(json) |> Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateBool(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 
 /**
  * Validates the given Js.Json.t value is an object with an int at the given key.
  */
-let validateIntForKey: (string, json) => Validation.t(int, Errors.t) =
+let validateIntForKey: (string, json) => Relude_Validation.t(int, Errors.t) =
   (key, json) =>
     validateJsonForKey(
       key,
       json =>
-        validateInt(json) |> Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateInt(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 
 /**
  * Validates the given Js.Json.t value is an object with a float at the given key.
  */
-let validateFloatForKey: (string, json) => Validation.t(float, Errors.t) =
+let validateFloatForKey: (string, json) => Relude_Validation.t(float, Errors.t) =
   (key, json) =>
     validateJsonForKey(
       key,
       json =>
-        validateFloat(json) |> Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateFloat(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 
 /**
  * Validates the given Js.Json.t value is an object with a string at the given key.
  */
-let validateStringForKey: (string, json) => Validation.t(string, Errors.t) =
+let validateStringForKey: (string, json) => Relude_Validation.t(string, Errors.t) =
   (key, json) =>
     validateJsonForKey(
       key,
       json =>
-        validateString(json) |> Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateString(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 
@@ -717,10 +709,10 @@ let validateOptionalForKey =
       ~nullAsNone=true,
       ~errorAsNone=false,
       key: string,
-      validate: json => Validation.t('a, Errors.t),
+      validate: json => Relude_Validation.t('a, Errors.t),
       json: json,
     )
-    : Validation.t(option('a), Errors.t) =>
+    : Relude_Validation.t(option('a), Errors.t) =>
   // Try to get the JSON for the key
   switch (getJsonForKey(key, json)) {
   | Some(json) =>
@@ -729,9 +721,9 @@ let validateOptionalForKey =
     | VOk () =>
       // The value was null - see if we treat this as a None or an error
       if (nullAsNone) {
-        Validation.pure(None);
+        Relude_Validation.pure(None);
       } else {
-        Validation.error(
+        Relude_Validation.error(
           Errors.pure(
             key ++ " contained a null value in JSON: " ++ show(json),
           ),
@@ -740,10 +732,10 @@ let validateOptionalForKey =
     | VError(_) =>
       // The value was not null - try to decode and see if we treat an error as None or as an error
       switch (validate(json)) {
-      | VOk(a) => Validation.pure(Some(a))
+      | VOk(a) => Relude_Validation.pure(Some(a))
       | VError(_) as e =>
         if (errorAsNone) {
-          Validation.pure(None);
+          Relude_Validation.pure(None);
         } else {
           e;
         }
@@ -752,9 +744,9 @@ let validateOptionalForKey =
   | None =>
     // No JSON found for key - see if we treat that as a None or an error
     if (missingAsNone) {
-      Validation.ok(None);
+      Relude_Validation.ok(None);
     } else {
-      Validation.error(
+      Relude_Validation.error(
         Errors.pure(key ++ " was not found in JSON: " ++ show(json)),
       );
     }
@@ -766,14 +758,14 @@ let validateOptionalForKey =
  */
 let validateArrayForKey:
   'a.
-  (string, (int, json) => Validation.t('a, Errors.t), json) =>
-  Validation.t(array('a), Errors.t)
+  (string, (int, json) => Relude_Validation.t('a, Errors.t), json) =>
+  Relude_Validation.t(array('a), Errors.t)
  =
   (key, validateItem, json) =>
     getJsonForKey(key, json)
-    |> Option.foldLazy(
+    |> Relude_Option.foldLazy(
          _ =>
-           Validation.error(
+           Relude_Validation.error(
              Errors.pure(key ++ " was not found in JSON: " ++ show(json)),
            ),
          json => validateArrayOfJson(validateItem, json),
@@ -785,14 +777,14 @@ let validateArrayForKey:
  */
 let validateListForKey:
   'a.
-  (string, (int, json) => Validation.t('a, Errors.t), json) =>
-  Validation.t(list('a), Errors.t)
+  (string, (int, json) => Relude_Validation.t('a, Errors.t), json) =>
+  Relude_Validation.t(list('a), Errors.t)
  =
   (key, validateItem, json) =>
     getJsonForKey(key, json)
-    |> Option.foldLazy(
+    |> Relude_Option.foldLazy(
          _ =>
-           Validation.error(
+           Relude_Validation.error(
              Errors.pure(key ++ " was not found in JSON: " ++ show(json)),
            ),
          json => validateArrayOfJsonAsList(validateItem, json),
@@ -804,8 +796,8 @@ let validateListForKey:
  */
 let validateObjectForKey:
   'a.
-  (string, json => Validation.t('a, Errors.t), json) =>
-  Validation.t('a, Errors.t)
+  (string, json => Relude_Validation.t('a, Errors.t), json) =>
+  Relude_Validation.t('a, Errors.t)
  = validateJsonForKey;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -926,27 +918,27 @@ module DSL = {
     /**
      * Validates the given Js.Json.t value is a null
      */
-    let null: json => Validation.t(unit, Errors.t) = validateNull;
+    let null: json => Relude_Validation.t(unit, Errors.t) = validateNull;
 
     /**
      * Validates the given Js.Json.t value is a bool
      */
-    let bool: json => Validation.t(bool, Errors.t) = validateBool;
+    let bool: json => Relude_Validation.t(bool, Errors.t) = validateBool;
 
     /**
      * Validates the given Js.Json.t value as a string
      */
-    let int: json => Validation.t(int, Errors.t) = validateInt;
+    let int: json => Relude_Validation.t(int, Errors.t) = validateInt;
 
     /**
      * Validates the given Js.Json.t value as a float
      */
-    let float: json => Validation.t(float, Errors.t) = validateFloat;
+    let float: json => Relude_Validation.t(float, Errors.t) = validateFloat;
 
     /**
      * Validates the given Js.Json.t value as a string
      */
-    let string: json => Validation.t(string, Errors.t) = validateString;
+    let string: json => Relude_Validation.t(string, Errors.t) = validateString;
 
     /**
      * Validates that the given Js.Json.t value is either null or can be validated using the given function.
@@ -957,10 +949,10 @@ module DSL = {
     let opt =
         (
           ~errorAsNone=false,
-          validate: json => Validation.t('a, Errors.t),
+          validate: json => Relude_Validation.t('a, Errors.t),
           json: json,
         )
-        : Validation.t(option('a), Errors.t) =>
+        : Relude_Validation.t(option('a), Errors.t) =>
       validateOptional(~errorAsNone, validate, json);
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -977,34 +969,34 @@ module DSL = {
     */
     let jsonAt:
       'a.
-      (int, json => Validation.t('a, Errors.t), json) =>
-      Validation.t('a, Errors.t)
+      (int, json => Relude_Validation.t('a, Errors.t), json) =>
+      Relude_Validation.t('a, Errors.t)
      = validateJsonAtIndex;
 
     /**
      * Validates a null value at the given index of a Js.Json.t array value
     */
-    let nullAt: (int, json) => Validation.t(unit, Errors.t) = validateNullAtIndex;
+    let nullAt: (int, json) => Relude_Validation.t(unit, Errors.t) = validateNullAtIndex;
 
     /**
      * Validates a bool value at the given index of a Js.Json.t array value
      */
-    let boolAt: (int, json) => Validation.t(bool, Errors.t) = validateBoolAtIndex;
+    let boolAt: (int, json) => Relude_Validation.t(bool, Errors.t) = validateBoolAtIndex;
 
     /**
      * Validates a string value at the given index of a Js.Json.t array value
      */
-    let stringAt: (int, json) => Validation.t(string, Errors.t) = validateStringAtIndex;
+    let stringAt: (int, json) => Relude_Validation.t(string, Errors.t) = validateStringAtIndex;
 
     /**
      * Validates an int value at the given index of a Js.Json.t array value
      */
-    let intAt: (int, json) => Validation.t(int, Errors.t) = validateIntAtIndex;
+    let intAt: (int, json) => Relude_Validation.t(int, Errors.t) = validateIntAtIndex;
 
     /**
      * Validates a float value at the given index of a Js.Json.t array value
      */
-    let floatAt: (int, json) => Validation.t(float, Errors.t) = validateFloatAtIndex;
+    let floatAt: (int, json) => Relude_Validation.t(float, Errors.t) = validateFloatAtIndex;
 
     /**
      * Validates that the Js.Json.t value at the given index is either null or can be validated using the given function.
@@ -1019,10 +1011,10 @@ module DSL = {
           ~nullAsNone=true,
           ~errorAsNone=false,
           index: int,
-          validate: json => Validation.t('a, Errors.t),
+          validate: json => Relude_Validation.t('a, Errors.t),
           json: json,
         )
-        : Validation.t(option('a), Errors.t) =>
+        : Relude_Validation.t(option('a), Errors.t) =>
       validateOptionalAtIndex(
         ~missingAsNone,
         ~nullAsNone,
@@ -1037,8 +1029,8 @@ module DSL = {
      */
     let arrayAt:
       'a.
-      (int, (int, json) => Validation.t('a, Errors.t), json) =>
-      Validation.t(array('a), Errors.t)
+      (int, (int, json) => Relude_Validation.t('a, Errors.t), json) =>
+      Relude_Validation.t(array('a), Errors.t)
      = validateArrayAtIndex;
 
     /**
@@ -1046,8 +1038,8 @@ module DSL = {
      */
     let objectAt:
       'a.
-      (int, json => Validation.t('a, Errors.t), json) =>
-      Validation.t('a, Errors.t)
+      (int, json => Relude_Validation.t('a, Errors.t), json) =>
+      Relude_Validation.t('a, Errors.t)
      = validateObjectAtIndex;
 
     /**
@@ -1055,8 +1047,8 @@ module DSL = {
      */
     let array:
       'a.
-      ((int, json) => Validation.t('a, Errors.t), json) =>
-      Validation.t(array('a), Errors.t)
+      ((int, json) => Relude_Validation.t('a, Errors.t), json) =>
+      Relude_Validation.t(array('a), Errors.t)
      = validateArrayOfJson;
 
     /**
@@ -1064,8 +1056,8 @@ module DSL = {
      */
     let list:
       'a.
-      ((int, json) => Validation.t('a, Errors.t), json) =>
-      Validation.t(list('a), Errors.t)
+      ((int, json) => Relude_Validation.t('a, Errors.t), json) =>
+      Relude_Validation.t(list('a), Errors.t)
      = validateArrayOfJsonAsList;
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -1082,34 +1074,34 @@ module DSL = {
      */
     let jsonFor:
       'a.
-      (string, json => Validation.t('a, Errors.t), json) =>
-      Validation.t('a, Errors.t)
+      (string, json => Relude_Validation.t('a, Errors.t), json) =>
+      Relude_Validation.t('a, Errors.t)
      = validateJsonForKey;
 
     /**
      * Validates a null for the given key of a Js.Json.t object value
      */
-    let nullFor: (string, json) => Validation.t(unit, Errors.t) = validateNullForKey;
+    let nullFor: (string, json) => Relude_Validation.t(unit, Errors.t) = validateNullForKey;
 
     /**
      * Validates a bool for the given key of a Js.Json.t object value
      */
-    let boolFor: (string, json) => Validation.t(bool, Errors.t) = validateBoolForKey;
+    let boolFor: (string, json) => Relude_Validation.t(bool, Errors.t) = validateBoolForKey;
 
     /**
      * Validates a string for the given key of a Js.Json.t object value
      */
-    let stringFor: (string, json) => Validation.t(string, Errors.t) = validateStringForKey;
+    let stringFor: (string, json) => Relude_Validation.t(string, Errors.t) = validateStringForKey;
 
     /**
      * Validates an int for the given key of a Js.Json.t object value
      */
-    let intFor: (string, json) => Validation.t(int, Errors.t) = validateIntForKey;
+    let intFor: (string, json) => Relude_Validation.t(int, Errors.t) = validateIntForKey;
 
     /**
      * Validates a float for the given key of a Js.Json.t object value
      */
-    let floatFor: (string, json) => Validation.t(float, Errors.t) = validateFloatForKey;
+    let floatFor: (string, json) => Relude_Validation.t(float, Errors.t) = validateFloatForKey;
 
     /**
      * Validates that the Js.Json.t value at the given key is either null or can be validated using the given function.
@@ -1124,10 +1116,10 @@ module DSL = {
           ~nullAsNone=true,
           ~errorAsNone=false,
           key: string,
-          validate: json => Validation.t('a, Errors.t),
+          validate: json => Relude_Validation.t('a, Errors.t),
           json: json,
         )
-        : Validation.t(option('a), Errors.t) =>
+        : Relude_Validation.t(option('a), Errors.t) =>
       validateOptionalForKey(
         ~missingAsNone,
         ~nullAsNone,
@@ -1142,8 +1134,8 @@ module DSL = {
      */
     let arrayFor:
       'a.
-      (string, (int, json) => Validation.t('a, Errors.t), json) =>
-      Validation.t(array('a), Errors.t)
+      (string, (int, json) => Relude_Validation.t('a, Errors.t), json) =>
+      Relude_Validation.t(array('a), Errors.t)
      = validateArrayForKey;
 
     /**
@@ -1151,8 +1143,8 @@ module DSL = {
      */
     let listFor:
       'a.
-      (string, (int, json) => Validation.t('a, Errors.t), json) =>
-      Validation.t(list('a), Errors.t)
+      (string, (int, json) => Relude_Validation.t('a, Errors.t), json) =>
+      Relude_Validation.t(list('a), Errors.t)
      = validateListForKey;
 
     /**

--- a/src/option/Relude_Option_Instances.re
+++ b/src/option/Relude_Option_Instances.re
@@ -1,5 +1,4 @@
-let (<<) = Relude_Function.Infix.(<<);
-let (>>) = Relude_Function.Infix.(>>);
+open Relude_Function.Infix;
 
 let compose:
   'a 'b 'c.


### PR DESCRIPTION
- Closes #205 (hopefully)
- The re-aliased `(>>)`/`(<<)` operators were causing shadowing warnings
in certain contexts - see #205 for example
- I went ahead and removed a few places where we had module aliases too.
It's unfortunate that we can't "import" (alias) our own modules and not cause
shadowing issues.