### PR TITLE
TreeZipper type and tests

### DIFF
--- a/__tests__/Relude_TreeZipper_test.re
+++ b/__tests__/Relude_TreeZipper_test.re
@@ -1,0 +1,1125 @@
+open Jest;
+open Expect;
+open Relude.Globals;
+open Relude.TreeZipper;
+
+let testTree1 =
+  Tree.make(
+    1,
+    [
+      Tree.make(
+        2,
+        [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      ),
+      Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+      Tree.make(4, []),
+    ],
+  );
+
+describe("TreeZipper", () => {
+  test("pure", () => {
+    expect(TreeZipper.pure(42))
+    |> toEqual({
+         ancestors: [],
+         leftSiblings: [],
+         focus: 42,
+         rightSiblings: [],
+         children: [],
+       })
+  });
+
+  test("make", () => {
+    expect(
+      TreeZipper.make(
+        [([Tree.pure(1)], 2, [Tree.pure(3)])],
+        [Tree.pure(4)],
+        5,
+        [Tree.pure(6)],
+        [Tree.pure(7)],
+      ),
+    )
+    |> toEqual({
+         ancestors: [([Tree.pure(1)], 2, [Tree.pure(3)])],
+         leftSiblings: [Tree.pure(4)],
+         focus: 5,
+         rightSiblings: [Tree.pure(6)],
+         children: [Tree.pure(7)],
+       })
+  });
+
+  test("makeWithLabels", () => {
+    expect(
+      TreeZipper.makeWithLabels(
+        ~ancestors=[([Tree.pure(1)], 2, [Tree.pure(3)])],
+        ~leftSiblings=[Tree.pure(4)],
+        ~focus=5,
+        ~rightSiblings=[Tree.pure(6)],
+        ~children=[Tree.pure(7)],
+      ),
+    )
+    |> toEqual({
+         ancestors: [([Tree.pure(1)], 2, [Tree.pure(3)])],
+         leftSiblings: [Tree.pure(4)],
+         focus: 5,
+         rightSiblings: [Tree.pure(6)],
+         children: [Tree.pure(7)],
+       })
+  });
+
+  test("fromTree", () => {
+    let actual = TreeZipper.fromTree(testTree1);
+    let expected = {
+      ancestors: [],
+      leftSiblings: [],
+      focus: testTree1 |> Tree.getValue,
+      rightSiblings: [],
+      children: testTree1 |> Tree.getChildren,
+    };
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("getAncestors", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> moveDownTimes(3)
+      |> Option.map(TreeZipper.getAncestors);
+    let expected =
+      Some([
+        ([], 21, [Tree.pure(22), Tree.pure(23)]),
+        (
+          [],
+          2,
+          [
+            Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+            Tree.pure(4),
+          ],
+        ),
+        ([], 1, []),
+      ]);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("getFocusValue", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> moveDownTimes(3)
+      |> Option.map(TreeZipper.getFocusValue);
+    let expected = Some(211);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("tapFocusValue", () => {
+    let r = ref(None);
+    testTree1
+    |> TreeZipper.fromTree
+    |> TreeZipper.tapFocusValue(a => r := Some(a))
+    |> ignore;
+    let actual = r^;
+    let expected = Some(1);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("setFocusValue", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> moveDownTimes(3)
+      |> Option.map(setFocusValue(42));
+    let expected =
+      Some({
+        ancestors: [
+          ([], 21, [Tree.pure(22), Tree.pure(23)]),
+          (
+            [],
+            2,
+            [
+              Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+              Tree.pure(4),
+            ],
+          ),
+          ([], 1, []),
+        ],
+        leftSiblings: [],
+        focus: 42,
+        rightSiblings: [Tree.pure(212)],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("modifyFocusValue", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> moveDownTimes(3)
+      |> Option.map(modifyFocusValue(a => a + 42));
+    let expected =
+      Some({
+        ancestors: [
+          ([], 21, [Tree.pure(22), Tree.pure(23)]),
+          (
+            [],
+            2,
+            [
+              Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+              Tree.pure(4),
+            ],
+          ),
+          ([], 1, []),
+        ],
+        leftSiblings: [],
+        focus: 211 + 42,
+        rightSiblings: [Tree.pure(212)],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("getFocusTree", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> moveDown
+      |> Option.flatMap(moveRight)
+      |> Option.map(TreeZipper.getFocusTree);
+    let expected: option(Tree.t(int)) =
+      Some({value: 3, children: [Tree.make(31, [Tree.pure(311)])]});
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("getLeftSiblings", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(TreeZipper.moveRightTimes(2))
+      |> Option.map(TreeZipper.getLeftSiblings);
+    let expected =
+      Some([
+        Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+        Tree.make(
+          2,
+          [
+            Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+            Tree.pure(22),
+            Tree.pure(23),
+          ],
+        ),
+      ]);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("getLeftSiblingsInOrder", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(TreeZipper.moveRightTimes(2))
+      |> Option.map(TreeZipper.getLeftSiblingsInOrder);
+    let expected =
+      Some([
+        Tree.make(
+          2,
+          [
+            Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+            Tree.pure(22),
+            Tree.pure(23),
+          ],
+        ),
+        Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+      ]);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("setLeftSiblings", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(
+           TreeZipper.setLeftSiblings([Tree.pure(42), Tree.pure(43)]),
+         );
+
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [Tree.pure(42), Tree.pure(43)],
+        focus: 2,
+        rightSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      });
+
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("setLeftSiblingsFromInOrder", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(
+           TreeZipper.setLeftSiblingsFromInOrder([
+             Tree.pure(43),
+             Tree.pure(42),
+           ]),
+         );
+
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [Tree.pure(42), Tree.pure(43)],
+        focus: 2,
+        rightSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      });
+
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("getRightSiblings", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.map(TreeZipper.getRightSiblings);
+    let expected =
+      Some([
+        Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+        Tree.pure(4),
+      ]);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("setRightSiblings", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(
+           TreeZipper.setRightSiblings([Tree.pure(42), Tree.pure(43)]),
+         );
+
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 2,
+        rightSiblings: [Tree.pure(42), Tree.pure(43)],
+        children: [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      });
+
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("getChildren", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.map(TreeZipper.getChildren);
+    let expected =
+      Some([
+        Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+        Tree.pure(22),
+        Tree.pure(23),
+      ]);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("setChildren", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.setChildren([Tree.pure(42), Tree.pure(43)]);
+    let expected = {
+      ancestors: [],
+      leftSiblings: [],
+      focus: 1,
+      rightSiblings: [],
+      children: [Tree.pure(42), Tree.pure(43)],
+    };
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveLeft None", () => {
+    let actual = testTree1 |> TreeZipper.fromTree |> TreeZipper.moveLeft;
+    let expected = None;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveLeft", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(TreeZipper.moveRight)
+      |> Option.flatMap(TreeZipper.moveLeft);
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 2,
+        rightSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveLeftWithClamp", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveLeftWithClamp;
+    let expected = testTree1 |> TreeZipper.fromTree;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveLeftToStart", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(TreeZipper.moveRightTimes(2))
+      |> Option.map(TreeZipper.moveLeftToStart);
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 2,
+        rightSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveLeftTimes", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(TreeZipper.moveRightTimes(2))
+      |> Option.flatMap(TreeZipper.moveLeftTimes(2));
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 2,
+        rightSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveLeftTimes negative", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveLeftTimes(-1);
+    let expected = None;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveLeftTimesWithClamp", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(TreeZipper.moveRightTimes(2))
+      |> Option.map(TreeZipper.moveLeftTimesWithClamp(5));
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 2,
+        rightSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveRight None", () => {
+    let actual = testTree1 |> TreeZipper.fromTree |> TreeZipper.moveRight;
+    let expected = None;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveRight", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(TreeZipper.moveRight);
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.pure(22),
+              Tree.pure(23),
+            ],
+          ),
+        ],
+        focus: 3,
+        rightSiblings: [Tree.make(4, [])],
+        children: [Tree.make(31, [Tree.pure(311)])],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveRightWithClamp", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveRightWithClamp;
+    let expected = testTree1 |> TreeZipper.fromTree;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveRightTimes", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(TreeZipper.moveRightTimes(2));
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.pure(22),
+              Tree.pure(23),
+            ],
+          ),
+        ],
+        focus: 4,
+        rightSiblings: [],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveRightTimes negative", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveRightTimes(-1);
+    let expected = None;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveRightTimesWithClamp", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.map(TreeZipper.moveRightTimesWithClamp(4));
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.pure(22),
+              Tree.pure(23),
+            ],
+          ),
+        ],
+        focus: 4,
+        rightSiblings: [],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveRightToEnd", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.map(TreeZipper.moveRightToEnd);
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.pure(22),
+              Tree.pure(23),
+            ],
+          ),
+        ],
+        focus: 4,
+        rightSiblings: [],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveUp None", () => {
+    let actual = testTree1 |> TreeZipper.fromTree |> TreeZipper.moveUp;
+    let expected = None;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveUpWithClamp", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveUpWithClamp;
+    let expected = testTree1 |> TreeZipper.fromTree;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveUpTimes", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDownTimes(2)
+      |> Option.flatMap(TreeZipper.moveUpTimes(2));
+    let expected = Some(testTree1 |> TreeZipper.fromTree);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveUpTimes negative", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveUpTimes(-1);
+    let expected = None;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveUpTimesWithClamp", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDownTimes(2)
+      |> Option.map(TreeZipper.moveUpTimesWithClamp(5));
+    let expected = Some(testTree1 |> TreeZipper.fromTree);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveUpToTop", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDownTimes(2)
+      |> Option.map(TreeZipper.moveUpToTop);
+    let expected = Some(testTree1 |> TreeZipper.fromTree);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveDown", () => {
+    let actual = testTree1 |> TreeZipper.fromTree |> TreeZipper.moveDown;
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 2,
+        rightSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveDownWithClamp", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDownTimes(3)
+      |> Option.map(TreeZipper.moveDownWithClamp);
+    let expected =
+      Some({
+        ancestors: [
+          ([], 21, [Tree.pure(22), Tree.pure(23)]),
+          (
+            [],
+            2,
+            [
+              Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+              Tree.pure(4),
+            ],
+          ),
+          ([], 1, []),
+        ],
+        leftSiblings: [],
+        focus: 211,
+        rightSiblings: [Tree.pure(212)],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveDownToBottom", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveDownToBottom;
+    let expected = {
+      ancestors: [
+        ([], 21, [Tree.pure(22), Tree.pure(23)]),
+        (
+          [],
+          2,
+          [
+            Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+            Tree.pure(4),
+          ],
+        ),
+        ([], 1, []),
+      ],
+      leftSiblings: [],
+      focus: 211,
+      rightSiblings: [Tree.pure(212)],
+      children: [],
+    };
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveDownTimes", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveDownTimes(3);
+    let expected =
+      Some({
+        ancestors: [
+          ([], 21, [Tree.pure(22), Tree.pure(23)]),
+          (
+            [],
+            2,
+            [
+              Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+              Tree.pure(4),
+            ],
+          ),
+          ([], 1, []),
+        ],
+        leftSiblings: [],
+        focus: 211,
+        rightSiblings: [Tree.pure(212)],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveDownTimes negative", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveDownTimes(-1);
+    let expected = None;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveDownTimesWithClamp", () => {
+    let actual =
+      testTree1 |> TreeZipper.fromTree |> TreeZipper.moveDownTimesWithClamp(5);
+    let expected = {
+      ancestors: [
+        ([], 21, [Tree.pure(22), Tree.pure(23)]),
+        (
+          [],
+          2,
+          [
+            Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+            Tree.pure(4),
+          ],
+        ),
+        ([], 1, []),
+      ],
+      leftSiblings: [],
+      focus: 211,
+      rightSiblings: [Tree.pure(212)],
+      children: [],
+    };
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("moveBy", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveBy([
+           `Down(1),
+           `Right(1),
+           `Left(1),
+           `Up(1),
+           `DownWithClamp(1),
+           `RightWithClamp(1),
+           `LeftWithClamp(1),
+           `UpWithClamp(1),
+           `DownToBottom,
+           `UpToTop,
+           `RightToEnd,
+           `LeftToStart,
+           `Down(1),
+           `Right(1),
+           `Down(1),
+         ]);
+    let expected =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(moveRight)
+      |> Option.flatMap(moveDown);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("foldBy", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> foldBy(
+           [
+             `Down(1),
+             `Right(1),
+             `Left(1),
+             `Up(1),
+             `DownWithClamp(1),
+             `RightWithClamp(1),
+             `LeftWithClamp(1),
+             `UpWithClamp(1),
+             `DownToBottom,
+             `UpToTop,
+             `RightToEnd,
+             `LeftToStart,
+             `Down(1),
+             `Right(1),
+             `Down(1),
+           ],
+           (l, v) => l |> Relude_List.append(v),
+           [],
+         );
+    let expectedZipper =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(moveRight)
+      |> Option.flatMap(moveDown);
+    expect(actual)
+    |> toEqual(
+         expectedZipper
+         |> Option.map(z =>
+              (z, [2, 3, 2, 1, 2, 3, 2, 1, 211, 1, 1, 1, 2, 3, 31])
+            ),
+       );
+  });
+
+  test("map", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveDown
+      |> Option.flatMap(TreeZipper.moveRight)
+      |> Option.map(TreeZipper.map(string_of_int));
+    let expected =
+      Some({
+        ancestors: [([], "1", [])],
+        leftSiblings: [
+          Tree.make(
+            "2",
+            [
+              Tree.make("21", [Tree.pure("211"), Tree.pure("212")]),
+              Tree.pure("22"),
+              Tree.pure("23"),
+            ],
+          ),
+        ],
+        focus: "3",
+        rightSiblings: [Tree.make("4", [])],
+        children: [Tree.make("31", [Tree.pure("311")])],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("findLeft", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(moveRight)
+      |> Option.flatMap(findLeft(a => a == 2));
+    let expected = testTree1 |> fromTree |> moveDown;
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("findRight", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(findRight(a => a == 4));
+    let expected =
+      testTree1 |> fromTree |> moveDown |> Option.flatMap(moveRightTimes(2));
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("findUp", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveDownTimes(3)
+      |> Option.flatMap(moveRight)
+      |> Option.flatMap(findUp(a => a == 1));
+    let expected = Some(testTree1 |> fromTree);
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("findDown", () => {
+    let actual = testTree1 |> fromTree |> findDown(a => a == 311);
+    let expected =
+      testTree1
+      |> fromTree  // 1
+      |> moveDown  // 2
+      |> Option.flatMap(moveRight)  // 3
+      |> Option.flatMap(moveDownTimes(2)); // 31, 311
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("find", () => {
+    let actual =
+      testTree1 |> fromTree |> moveDown |> Option.flatMap(find(a => a == 311));
+    let expected =
+      testTree1
+      |> fromTree  // 1
+      |> moveDown  // 2
+      |> Option.flatMap(moveRight)  // 3
+      |> Option.flatMap(moveDownTimes(2)); // 31, 311
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("insertTreeWithPushLeft", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(
+           insertTreeWithPushLeft(Tree.make(42, [Tree.pure(43)])),
+         );
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.pure(22),
+              Tree.pure(23),
+            ],
+          ),
+        ],
+        focus: 42,
+        rightSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [Tree.pure(43)],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("insertWithPushLeft", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(insertWithPushLeft(42));
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.pure(22),
+              Tree.pure(23),
+            ],
+          ),
+        ],
+        focus: 42,
+        rightSiblings: [
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("insertTreeWithPushRight", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(
+           insertTreeWithPushRight(Tree.make(42, [Tree.pure(43)])),
+         );
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 42,
+        rightSiblings: [
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.pure(22),
+              Tree.pure(23),
+            ],
+          ),
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [Tree.pure(43)],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("insertWithPushRight", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(insertWithPushRight(42));
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 42,
+        rightSiblings: [
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.pure(22),
+              Tree.pure(23),
+            ],
+          ),
+          Tree.make(3, [Tree.make(31, [Tree.pure(311)])]),
+          Tree.make(4, []),
+        ],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("deleteWithPullLeft", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(moveRight)
+      |> Option.flatMap(deleteWithPullLeft);
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 2,
+        rightSiblings: [Tree.make(4, [])],
+        children: [
+          Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+          Tree.pure(22),
+          Tree.pure(23),
+        ],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("deleteWithPullRight", () => {
+    let actual =
+      testTree1
+      |> fromTree
+      |> moveDown
+      |> Option.flatMap(moveRight)
+      |> Option.flatMap(deleteWithPullRight);
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.pure(22),
+              Tree.pure(23),
+            ],
+          ),
+        ],
+        focus: 4,
+        rightSiblings: [],
+        children: [],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+
+  test("delete", () => {
+    let actual = testTree1 |> fromTree |> moveDown |> Option.flatMap(delete);
+    let expected =
+      Some({
+        ancestors: [([], 1, [])],
+        leftSiblings: [],
+        focus: 3,
+        rightSiblings: [Tree.pure(4)],
+        children: [Tree.make(31, [Tree.pure(311)])],
+      });
+    expect(actual) |> toEqual(expected);
+  });
+});

--- a/__tests__/Relude_Tree_test.re
+++ b/__tests__/Relude_Tree_test.re
@@ -217,11 +217,14 @@ describe("Tree", () => {
     let f = tree => tree |> Tree.foldLeft((+), 0);
     let actual = Tree.extend(f, testTree2);
     let expected =
-      Tree.make(199, [
-        Tree.make(45, [Tree.pure(21), Tree.pure(22)]),
-        Tree.make(66, [Tree.pure(31), Tree.pure(32)]),
-        Tree.make(87, [Tree.pure(41), Tree.pure(42)]),
-      ]);
+      Tree.make(
+        199,
+        [
+          Tree.make(45, [Tree.pure(21), Tree.pure(22)]),
+          Tree.make(66, [Tree.pure(31), Tree.pure(32)]),
+          Tree.make(87, [Tree.pure(41), Tree.pure(42)]),
+        ],
+      );
     expect(actual) |> toEqual(expected);
   });
 
@@ -336,6 +339,43 @@ describe("Tree", () => {
     module Show = Tree.Show(Relude_Int.Show);
     expect(testTree1 |> Show.show)
     |> toEqual("Tree 1 [Tree 2 [], Tree 3 []]");
+  });
+
+  test("showPrettyBy", () => {
+    let tree =
+      Tree.make(
+        1,
+        [
+          Tree.make(
+            2,
+            [
+              Tree.make(21, [Tree.pure(211), Tree.pure(212)]),
+              Tree.make(22, []),
+            ],
+          ),
+          Tree.make(
+            3,
+            [
+              Tree.pure(31),
+              Tree.make(32, [Tree.pure(321), Tree.pure(322)]),
+            ],
+          ),
+        ],
+      );
+    let actual = tree |> showPrettyBy(string_of_int);
+    let expected = "1
+|- 2
+   |- 21
+      |- 211
+      |- 212
+   |- 22
+|- 3
+   |- 31
+   |- 32
+      |- 321
+      |- 322
+";
+    expect(actual) |> toEqual(expected);
   });
 
   test("eqBy", () => {

--- a/src/Relude.re
+++ b/src/Relude.re
@@ -47,6 +47,7 @@ module StringMap = Relude_StringMap;
 module Throttle = Relude_Throttle;
 module Timer = Relude_Timer;
 module Tree = Relude_Tree;
+module TreeZipper = Relude_TreeZipper;
 module Tuple = Relude_Tuple;
 module Unsafe = Relude_Unsafe;
 module Validation = Relude_Validation;

--- a/src/Relude_Globals.re
+++ b/src/Relude_Globals.re
@@ -65,6 +65,7 @@ module StateT = Relude_StateT;
 module String = Relude_String;
 module StringMap = Relude_StringMap;
 module Tree = Relude_Tree;
+module TreeZipper = Relude_TreeZipper;
 module Tuple = Relude_Tuple;
 module Validation = Relude_Validation;
 module Void = Relude_Void;

--- a/src/Relude_Tree.re
+++ b/src/Relude_Tree.re
@@ -374,6 +374,32 @@ module Show: SHOW_F =
     let show = tree => showBy(ShowA.show, tree);
   };
 
+let showPrettyBy: 'a. ('a => string, t('a)) => string =
+  (showA, tree) => {
+    let rec showPrettyByWithIndent: 'a. (int, 'a => string, t('a)) => string =
+      (level, showA, tree) => {
+        let indent =
+          if (level > 0) {
+            Relude_String.repeat(level - 1, "   ") ++ "|- ";
+          } else {
+            "";
+          };
+        let childrenStr =
+          tree
+          |> getChildren
+          |> Relude_List.map(showPrettyByWithIndent(level + 1, showA))
+          |> Relude_List.String.joinWith("");
+        indent ++ showA(tree |> getValue) ++ "\n" ++ childrenStr;
+      };
+    showPrettyByWithIndent(0, showA, tree);
+  };
+
+module ShowPretty: SHOW_F =
+  (ShowA: BsAbstract.Interface.SHOW) => {
+    type nonrec t = t(ShowA.t);
+    let show = showPrettyBy(ShowA.show);
+  };
+
 /**
  * Compares two trees for quality using the given function
  */

--- a/src/Relude_TreeZipper.re
+++ b/src/Relude_TreeZipper.re
@@ -1,0 +1,868 @@
+/**
+ * A zipper for a non-empty multi-way/rose tree
+ *
+ * The leftSiblings are stored in reverse order for O(1) sideways movements.
+ *
+ * Based on the ideas/implementation from Tony Morris' talk here:
+ * http://data.tmorris.net/talks/zippers/bd054c210649101b84662c614fc45af3c27a5eef/zippers.pdf
+ */
+type t('a) = {
+  ancestors:
+    list((list(Relude_Tree.t('a)), 'a, list(Relude_Tree.t('a)))),
+  leftSiblings: list(Relude_Tree.t('a)),
+  focus: 'a,
+  rightSiblings: list(Relude_Tree.t('a)),
+  children: list(Relude_Tree.t('a)),
+};
+
+/**
+ * Creates a tree zipper containing a single item
+ */
+let pure: 'a => t('a) =
+  a => {
+    ancestors: [],
+    leftSiblings: [],
+    focus: a,
+    rightSiblings: [],
+    children: [],
+  };
+
+/**
+ * Alias for pure
+ */
+let singleton = pure;
+
+/**
+ * Constructs a tree zipper from parts
+ */
+let make:
+  'a.
+  (
+    list((list(Relude_Tree.t('a)), 'a, list(Relude_Tree.t('a)))),
+    list(Relude_Tree.t('a)),
+    'a,
+    list(Relude_Tree.t('a)),
+    list(Relude_Tree.t('a))
+  ) =>
+  t('a)
+ =
+  (ancestors, leftSiblings, focus, rightSiblings, children) => {
+    ancestors,
+    leftSiblings,
+    focus,
+    rightSiblings,
+    children,
+  };
+
+/**
+ * Constructs a tree zipper from (labelled) parts
+ */
+let makeWithLabels:
+  'a.
+  (
+    ~ancestors: list(
+                  (list(Relude_Tree.t('a)), 'a, list(Relude_Tree.t('a))),
+                ),
+    ~leftSiblings: list(Relude_Tree.t('a)),
+    ~focus: 'a,
+    ~rightSiblings: list(Relude_Tree.t('a)),
+    ~children: list(Relude_Tree.t('a))
+  ) =>
+  t('a)
+ =
+  (~ancestors, ~leftSiblings, ~focus, ~rightSiblings, ~children) => {
+    ancestors,
+    leftSiblings,
+    focus,
+    rightSiblings,
+    children,
+  };
+
+/**
+ * Converts a Tree into a Tree Zipper
+ */
+let fromTree: 'a. Relude_Tree.t('a) => t('a) =
+  ({value, children}) =>
+    makeWithLabels(
+      ~ancestors=[],
+      ~leftSiblings=[],
+      ~focus=value,
+      ~rightSiblings=[],
+      ~children,
+    );
+
+/**
+ * Gets the list of ancestor levels for the given TreeZipper
+ */
+let getAncestors:
+  'a.
+  t('a) => list((list(Relude_Tree.t('a)), 'a, list(Relude_Tree.t('a))))
+ =
+  ({ancestors, leftSiblings: _, focus: _, rightSiblings: _, children: _}) => ancestors;
+
+/**
+ * Gets the value at the focus of the TreeZipper
+ */
+let getFocusValue: 'a. t('a) => 'a =
+  ({ancestors: _, leftSiblings: _, focus, rightSiblings: _, children: _}) => focus;
+
+/**
+ * Applies a side-effect function with the current focus value, and returns the zipper unchanged
+ */
+let tapFocusValue: 'a. ('a => unit, t('a)) => t('a) =
+  (f, zipper) => {
+    f(zipper |> getFocusValue);
+    zipper;
+  };
+
+/**
+ * Overwrites the focus with the given value
+ */
+let setFocusValue: 'a. ('a, t('a)) => t('a) =
+  (newFocus, {ancestors, leftSiblings, focus: _, rightSiblings, children}) => {
+    ancestors,
+    leftSiblings,
+    focus: newFocus,
+    rightSiblings,
+    children,
+  };
+
+/**
+ * Modifies the focus with the given function
+ */
+let modifyFocusValue: 'a. ('a => 'a, t('a)) => t('a) =
+  (f, {ancestors, leftSiblings, focus, rightSiblings, children}) => {
+    ancestors,
+    leftSiblings,
+    focus: f(focus),
+    rightSiblings,
+    children,
+  };
+
+/**
+ * Gets the value and children at the focus of the TreeZipper as a Tree
+ */
+let getFocusTree: 'a. t('a) => Relude_Tree.t('a) =
+  ({ancestors: _, leftSiblings: _, focus, rightSiblings: _, children}) => {
+    value: focus,
+    children,
+  };
+
+/**
+ * Gets the siblings to the left of the focus value, in reverse order.
+ * (the first item of the resulting list is the item that is immediately to the left of the focus).
+ */
+let getLeftSiblings: 'a. t('a) => list(Relude_Tree.t('a)) =
+  ({ancestors: _, leftSiblings, focus: _, rightSiblings: _, children: _}) => leftSiblings;
+
+/**
+ * Gets the siblings to the left of the focus value, in order.
+ * (the first item of the resulting list is the item that is the leftmost sibling (furthest from focus))
+ */
+let getLeftSiblingsInOrder: 'a. t('a) => list(Relude_Tree.t('a)) =
+  tree => tree |> getLeftSiblings |> Relude_List.reverse;
+
+/**
+ * Sets the left siblings from a reversed list (where the first item of the list should be closest to the focus)
+ */
+let setLeftSiblings: 'a. (list(Relude_Tree.t('a)), t('a)) => option(t('a)) =
+  (
+    newLeftSiblings,
+    {ancestors, leftSiblings: _, focus, rightSiblings, children},
+  ) =>
+    if (ancestors |> Relude_List.isNotEmpty) {
+      Some({
+        ancestors,
+        leftSiblings: newLeftSiblings,
+        focus,
+        rightSiblings,
+        children,
+      });
+    } else {
+      None;
+    };
+
+/**
+ * Sets the left siblings from an in-order list (where the first item of the list should be farthest from the focus)
+ */
+let setLeftSiblingsFromInOrder:
+  'a.
+  (list(Relude_Tree.t('a)), t('a)) => option(t('a))
+ =
+  (
+    newLeftSiblingsInOrder,
+    {ancestors, leftSiblings: _, focus, rightSiblings, children},
+  ) =>
+    if (ancestors |> Relude_List.isNotEmpty) {
+      Some({
+        ancestors,
+        leftSiblings: newLeftSiblingsInOrder |> Relude_List.reverse,
+        focus,
+        rightSiblings,
+        children,
+      });
+    } else {
+      None;
+    };
+
+/**
+ * Gets the siblings to the right of the current focus
+ */
+let getRightSiblings: 'a. t('a) => list(Relude_Tree.t('a)) =
+  ({ancestors: _, leftSiblings: _, focus: _, rightSiblings, children: _}) => rightSiblings;
+
+/**
+ * Sets the right siblings from a reversed list (where the first item of the list should be closest to the focus)
+ */
+let setRightSiblings:
+  'a.
+  (list(Relude_Tree.t('a)), t('a)) => option(t('a))
+ =
+  (
+    newRightSiblings,
+    {ancestors, leftSiblings, focus, rightSiblings: _, children},
+  ) =>
+    if (ancestors |> Relude_List.isNotEmpty) {
+      Some({
+        ancestors,
+        leftSiblings,
+        focus,
+        rightSiblings: newRightSiblings,
+        children,
+      });
+    } else {
+      None;
+    };
+
+/**
+ * Gets the children sub-trees of the current focus
+ */
+let getChildren: 'a. t('a) => list(Relude_Tree.t('a)) =
+  ({ancestors: _, leftSiblings: _, focus: _, rightSiblings: _, children}) => children;
+
+/**
+ * Sets the children
+ */
+let setChildren: 'a. (list(Relude_Tree.t('a)), t('a)) => t('a) =
+  (newChildren, {ancestors, leftSiblings, focus, rightSiblings, children: _}) => {
+    {ancestors, leftSiblings, focus, rightSiblings, children: newChildren};
+  };
+
+/**
+ * Moves the focus one sibling to the left (if possible)
+ */
+let moveLeft: 'a. t('a) => option(t('a)) =
+  ({ancestors, leftSiblings, focus, rightSiblings, children}) => {
+    leftSiblings
+    |> Relude_List.uncons
+    |> Relude_Option.map(((leftHead, leftTail)) => {
+         {
+           ancestors,
+           leftSiblings: leftTail,
+           focus: leftHead |> Relude_Tree.getValue,
+           rightSiblings: [
+             Relude_Tree.make(focus, children),
+             ...rightSiblings,
+           ],
+           children: leftHead |> Relude_Tree.getChildren,
+         }
+       });
+  };
+
+/**
+ * Moves to the left, unless we are already at the leftmost item
+ */
+let moveLeftWithClamp: 'a. t('a) => t('a) =
+  zipper => zipper |> moveLeft |> Relude_Option.getOrElse(zipper);
+
+/**
+ * Moves the focus as far as possible to the left
+ */
+let rec moveLeftToStart: 'a. t('a) => t('a) =
+  zipper =>
+    zipper
+    |> moveLeft
+    |> Relude_Option.foldLazy(() => zipper, moveLeftToStart);
+
+/**
+ * Moves left a number of times
+ */
+let rec moveLeftTimes: 'a. (int, t('a)) => option(t('a)) =
+  (times, zipper) =>
+    if (times < 0) {
+      None;
+    } else if (times == 0) {
+      Some(zipper);
+    } else {
+      zipper |> moveLeft |> Relude_Option.flatMap(moveLeftTimes(times - 1));
+    };
+
+/**
+ * Move the focus to the left a number of times, stopping if the leftmost sibling is reached
+ */
+let moveLeftTimesWithClamp: 'a. (int, t('a)) => t('a) =
+  (times, zipper) => {
+    zipper
+    |> moveLeftTimes(times)
+    |> Relude_Option.getOrElseLazy(() => zipper |> moveLeftToStart);
+  };
+
+/**
+ * Moves the focus one sibling to the right (if possible)
+ */
+let moveRight: 'a. t('a) => option(t('a)) =
+  ({ancestors, leftSiblings, focus, rightSiblings, children}) => {
+    rightSiblings
+    |> Relude_List.uncons
+    |> Relude_Option.map(((rightHead, rightTail)) => {
+         {
+           ancestors,
+           leftSiblings: [
+             Relude_Tree.make(focus, children),
+             ...leftSiblings,
+           ],
+           focus: rightHead |> Relude_Tree.getValue,
+           rightSiblings: rightTail,
+           children: rightHead |> Relude_Tree.getChildren,
+         }
+       });
+  };
+
+/**
+ * Moves the zipper to the right one time, unless we are already at the rightmost item
+ */
+let moveRightWithClamp: 'a. t('a) => t('a) =
+  zipper => zipper |> moveRight |> Relude_Option.getOrElse(zipper);
+
+/**
+ * Moves the focus as far as possible to the right
+ */
+let rec moveRightToEnd: 'a. t('a) => t('a) =
+  zipper =>
+    zipper
+    |> moveRight
+    |> Relude_Option.foldLazy(() => zipper, moveRightToEnd);
+
+/**
+ * Moves right a number of times
+ */
+let rec moveRightTimes: 'a. (int, t('a)) => option(t('a)) =
+  (times, zipper) =>
+    if (times < 0) {
+      None;
+    } else if (times == 0) {
+      Some(zipper);
+    } else {
+      zipper |> moveRight |> Relude_Option.flatMap(moveRightTimes(times - 1));
+    };
+
+/**
+ * Move the focus to the right a number of times, stopping if the rightmost sibling is reached
+ */
+let moveRightTimesWithClamp: 'a. (int, t('a)) => t('a) =
+  (times, zipper) => {
+    zipper
+    |> moveRightTimes(times)
+    |> Relude_Option.getOrElseLazy(() => zipper |> moveRightToEnd);
+  };
+
+/**
+ * Moves the focus up one level to the parent (if possible)
+ */
+let moveUp: 'a. t('a) => option(t('a)) =
+  ({ancestors, leftSiblings, focus, rightSiblings, children}) => {
+    ancestors
+    |> Relude_List.uncons
+    |> Relude_Option.map(
+         (
+           (
+             (ancestorsHeadLeft, ancestorsHeadFocus, ancestorsHeadRight),
+             ancestorsTail,
+           ),
+         ) => {
+         {
+           ancestors: ancestorsTail,
+           leftSiblings: ancestorsHeadLeft,
+           focus: ancestorsHeadFocus,
+           rightSiblings: ancestorsHeadRight,
+           children:
+             Relude_List.flatten([
+               leftSiblings,
+               [Relude_Tree.make(focus, children)],
+               rightSiblings,
+             ]),
+         }
+       });
+  };
+
+/**
+ * Moves the zipper up a level, unless it's already at the top
+ */
+let moveUpWithClamp: 'a. t('a) => t('a) =
+  zipper => zipper |> moveUp |> Relude_Option.getOrElse(zipper);
+
+/**
+ * Moves the zipper to focus the top of the tree
+ */
+let rec moveUpToTop: 'a. t('a) => t('a) =
+  zipper =>
+    zipper |> moveUp |> Relude_Option.foldLazy(() => zipper, moveUpToTop);
+
+/**
+ * Moves the zipper up a number of times (if possible)
+ */
+let rec moveUpTimes: 'a. (int, t('a)) => option(t('a)) =
+  (times, zipper) =>
+    if (times < 0) {
+      None;
+    } else if (times == 0) {
+      Some(zipper);
+    } else {
+      zipper |> moveUp |> Relude_Option.flatMap(moveUpTimes(times - 1));
+    };
+
+/**
+ * Moves the zipper up a number of times, stopping if the top is reached
+ */
+let moveUpTimesWithClamp: 'a. (int, t('a)) => t('a) =
+  (times, zipper) => {
+    zipper
+    |> moveUpTimes(times)
+    |> Relude_Option.getOrElseLazy(() => zipper |> moveUpToTop);
+  };
+
+/**
+ * Moves the focus down to the first child (if possible)
+ */
+let moveDown: 'a. t('a) => option(t('a)) =
+  ({ancestors, leftSiblings, focus, rightSiblings, children}) => {
+    children
+    |> Relude_List.uncons
+    |> Relude_Option.map(((childrenHead, childrenTail)) => {
+         {
+           ancestors: [(leftSiblings, focus, rightSiblings), ...ancestors],
+           leftSiblings: [],
+           focus: childrenHead |> Relude_Tree.getValue,
+           rightSiblings: childrenTail,
+           children: childrenHead |> Relude_Tree.getChildren,
+         }
+       });
+  };
+
+/**
+ * Moves the zipper down one time, unless there are no children
+ */
+let moveDownWithClamp: 'a. t('a) => t('a) =
+  zipper => zipper |> moveDown |> Relude_Option.getOrElse(zipper);
+
+/**
+ * Moves the zipper to focus the bottom of the tree (on the left-most child branches)
+ */
+let rec moveDownToBottom: 'a. t('a) => t('a) =
+  zipper =>
+    zipper
+    |> moveDown
+    |> Relude_Option.foldLazy(() => zipper, moveDownToBottom);
+
+/**
+ * Moves the focus down a number of times (if possible)
+ */
+let rec moveDownTimes: 'a. (int, t('a)) => option(t('a)) =
+  (times, zipper) =>
+    if (times < 0) {
+      None;
+    } else if (times == 0) {
+      Some(zipper);
+    } else {
+      zipper |> moveDown |> Relude_Option.flatMap(moveDownTimes(times - 1));
+    };
+
+/**
+ * Moves the zipper down a number of times, stopping when we get as low as we can,
+ * staying on the left-most child branches.
+ */
+let moveDownTimesWithClamp: 'a. (int, t('a)) => t('a) =
+  (times, zipper) => {
+    zipper
+    |> moveDownTimes(times)
+    |> Relude_Option.getOrElseLazy(() => zipper |> moveDownToBottom);
+  };
+
+/**
+ * Types of movements we can make in a TreeZipper
+ */
+type movement = [
+  | `Up(int)
+  | `UpWithClamp(int)
+  | `UpToTop
+  | `Down(int)
+  | `DownWithClamp(int)
+  | `DownToBottom
+  | `Left(int)
+  | `LeftWithClamp(int)
+  | `LeftToStart
+  | `Right(int)
+  | `RightWithClamp(int)
+  | `RightToEnd
+];
+
+/**
+ * Applies a single movement command to a zipper
+ */
+let moveOnceBy: 'a. (movement, t('a)) => option(t('a)) =
+  (move, zipper) => {
+    switch (move) {
+    | `Up(n) => zipper |> moveUpTimes(n)
+    | `UpWithClamp(n) => Some(zipper |> moveUpTimesWithClamp(n))
+    | `UpToTop => Some(zipper |> moveUpToTop)
+    | `Down(n) => zipper |> moveDownTimes(n)
+    | `DownWithClamp(n) => Some(zipper |> moveDownTimesWithClamp(n))
+    | `DownToBottom => Some(zipper |> moveDownToBottom)
+    | `Left(n) => zipper |> moveLeftTimes(n)
+    | `LeftWithClamp(n) => Some(zipper |> moveLeftTimesWithClamp(n))
+    | `LeftToStart => Some(zipper |> moveLeftToStart)
+    | `Right(n) => zipper |> moveRightTimes(n)
+    | `RightWithClamp(n) => Some(zipper |> moveRightTimesWithClamp(n))
+    | `RightToEnd => Some(zipper |> moveRightToEnd)
+    };
+  };
+
+/**
+ * Applies a list of movement commands to a zipper
+ */
+let moveBy: 'a. (list(movement), t('a)) => option(t('a)) =
+  (moves, zipper) => {
+    moves
+    |> Relude_List.foldLeft(
+         (zipperOpt, move) =>
+           zipperOpt |> Relude_Option.flatMap(moveOnceBy(move)),
+         Some(zipper),
+       );
+  };
+
+/**
+ * Applies a list of movement commands to a zipper and collects an accumulated value when visiting each new focus
+ */
+let foldBy:
+  'a 'b.
+  (list(movement), ('b, 'a) => 'b, 'b, t('a)) => option((t('a), 'b))
+ =
+  (moves, f, init, zipper) => {
+    moves
+    |> Relude_List.foldLeft(
+         (zipperAccOpt, move) =>
+           zipperAccOpt
+           |> Relude_Option.flatMap(((zipper, acc)) => {
+                zipper
+                |> moveOnceBy(move)
+                |> Relude_Option.map(nextZipper => {
+                     (nextZipper, f(acc, nextZipper |> getFocusValue))
+                   })
+              }),
+         Some((zipper, init)),
+       );
+  };
+
+/**
+ * Converts a zipper of 'a to a zipper of 'b using a pure function
+ */
+let map: 'a 'b. ('a => 'b, t('a)) => t('b) =
+  (aToB, {ancestors, leftSiblings, focus, rightSiblings, children}) => {
+    {
+      ancestors:
+        ancestors
+        |> Relude_List.map(((left, focus, right)) =>
+             (
+               left |> Relude_List.map(Relude_Tree.map(aToB)),
+               aToB(focus),
+               right |> Relude_List.map(Relude_Tree.map(aToB)),
+             )
+           ),
+      leftSiblings: leftSiblings |> Relude_List.map(Relude_Tree.map(aToB)),
+      focus: aToB(focus),
+      rightSiblings: rightSiblings |> Relude_List.map(Relude_Tree.map(aToB)),
+      children: children |> Relude_List.map(Relude_Tree.map(aToB)),
+    };
+  };
+
+module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+  type nonrec t('a) = t('a);
+  let map = map;
+};
+include Relude_Extensions_Functor.FunctorExtensions(Functor);
+
+// TODO: could implement Apply/Applicative/Monad/Comonad/etc.
+
+/**
+ * Finds a value in the curernt focus and recursively the children
+ */
+let rec findInFocusAndChildren: 'a. ('a => bool, t('a)) => option(t('a)) =
+  (pred, zipper) =>
+    if (pred(zipper |> getFocusValue)) {
+      Some(zipper);
+    } else {
+      zipper
+      |> moveDown
+      |> Relude_Option.flatMap(childZipper => {
+           childZipper
+           |> findInFocusAndChildren(pred)
+           |> Relude_Option.orElseLazy(~fallback=() =>
+                childZipper
+                |> moveRight
+                |> Relude_Option.flatMap(findInFocusAndChildren(pred))
+              )
+         });
+    }
+
+/**
+ * Attempts to find a value by searching the current focus and left siblings
+ */
+and findLeft: 'a. (~checkFocus: bool=?, 'a => bool, t('a)) => option(t('a)) =
+  (~checkFocus=true, pred, zipper) =>
+    if (checkFocus) {
+      findInFocusAndChildren(pred, zipper)
+      |> Relude_Option.orElseLazy(~fallback=() => {
+           zipper |> moveLeft |> Relude_Option.flatMap(findLeft(pred))
+         });
+    } else {
+      zipper |> moveLeft |> Relude_Option.flatMap(findLeft(pred));
+    }
+
+/**
+ * Attempts to find a value by searching the current focus and right siblings
+ */
+and findRight: 'a. (~checkFocus: bool=?, 'a => bool, t('a)) => option(t('a)) =
+  (~checkFocus=true, pred, zipper) =>
+    if (checkFocus) {
+      findInFocusAndChildren(pred, zipper)
+      |> Relude_Option.orElseLazy(~fallback=() => {
+           zipper |> moveRight |> Relude_Option.flatMap(findRight(pred))
+         });
+    } else {
+      zipper |> moveRight |> Relude_Option.flatMap(findRight(pred));
+    }
+
+/**
+ * Attempts to find a value by searching the current focus, then the left siblings
+ * from the focus outward, then the right siblings from the focus outward.
+ */
+and findLeftOrRight:
+  'a.
+  (~checkFocus: bool=?, 'a => bool, t('a)) => option(t('a))
+ =
+  (~checkFocus=true, pred, zipper) => {
+    zipper
+    |> findLeft(~checkFocus, pred)
+    |> Relude_Option.orElseLazy(~fallback=() =>
+         zipper |> findRight(~checkFocus=false, pred)
+       );
+  }
+
+/**
+ * Attempts to find a value by moving up a level, then searching left and right on the parent level,
+ * then progressing upward.
+ */
+and findUp: 'a. ('a => bool, t('a)) => option(t('a)) =
+  (pred, zipper) =>
+    zipper
+    |> moveUp
+    |> Relude_Option.flatMap(parentZipper => {
+         parentZipper
+         |> findLeftOrRight(pred)  // TODO: I think this is repeatedly searching some of the same values as we move up
+         |> Relude_Option.orElseLazy(~fallback=() =>
+              parentZipper |> findUp(pred)
+            )
+       })
+
+/**
+ * Attempts to find a value by moving down a level, then searching left and right on the child level,
+ * then progressing downward.
+ */
+and findDown: 'a. ('a => bool, t('a)) => option(t('a)) =
+  (pred, zipper) => {
+    zipper
+    |> moveDown
+    |> Relude_Option.flatMap(childZipper => {
+         childZipper
+         |> findRight(pred)
+         |> Relude_Option.orElseLazy(~fallback=() =>
+              childZipper |> findDown(pred)
+            )
+       });
+  }
+
+/**
+ * Attempts to find a value anywhere in the zipper, left/right/up/down
+ */
+and find: 'a. ('a => bool, t('a)) => option(t('a)) =
+  (pred, zipper) => {
+    zipper
+    |> findLeftOrRight(pred)
+    |> Relude_Option.orElseLazy(~fallback=() => zipper |> findUp(pred))
+    |> Relude_Option.orElseLazy(~fallback=() => zipper |> findDown(pred));
+  };
+
+/**
+ * Inserts a new tree, and pushes the current focus to the left
+ */
+let insertTreeWithPushLeft: 'a. (Relude_Tree.t('a), t('a)) => option(t('a)) =
+  (newTree, {ancestors, leftSiblings, focus, rightSiblings, children}) =>
+    if (ancestors |> Relude_List.isNotEmpty) {
+      Some({
+        ancestors,
+        leftSiblings: [{value: focus, children}, ...leftSiblings],
+        focus: newTree |> Relude_Tree.getValue,
+        rightSiblings,
+        children: newTree |> Relude_Tree.getChildren,
+      });
+    } else {
+      None;
+    };
+
+/**
+ * Inserts a new value (singleton tree), and pushes the current focus to the left
+ */
+let insertWithPushLeft: 'a. ('a, t('a)) => option(t('a)) =
+  (newFocus, tree) =>
+    insertTreeWithPushLeft(Relude_Tree.pure(newFocus), tree);
+
+/**
+ * Inserts a new tree, and pushes the current focus to the right
+ */
+let insertTreeWithPushRight:
+  'a.
+  (Relude_Tree.t('a), t('a)) => option(t('a))
+ =
+  (newTree, {ancestors, leftSiblings, focus, rightSiblings, children}) =>
+    if (ancestors |> Relude_List.isNotEmpty) {
+      Some({
+        ancestors,
+        leftSiblings,
+        focus: newTree |> Relude_Tree.getValue,
+        rightSiblings: [{value: focus, children}, ...rightSiblings],
+        children: newTree |> Relude_Tree.getChildren,
+      });
+    } else {
+      None;
+    };
+
+/**
+ * Inserts a new value (singleton tree), and pushes the current focus to the right
+ */
+let insertWithPushRight: 'a. ('a, t('a)) => option(t('a)) =
+  (newFocus, tree) =>
+    insertTreeWithPushRight(Relude_Tree.pure(newFocus), tree);
+
+/**
+ * Deletes the tree at the focus, and pulls the left sibling into focus (if possible)
+ */
+let deleteWithPullLeft: 'a. t('a) => option(t('a)) =
+  ({ancestors, leftSiblings, focus: _, rightSiblings, children: _}) =>
+    if (ancestors |> Relude_List.isNotEmpty) {
+      leftSiblings
+      |> Relude_List.uncons
+      |> Relude_Option.map(((leftHead, leftTail)) => {
+           {
+             ancestors,
+             leftSiblings: leftTail,
+             focus: leftHead |> Relude_Tree.getValue,
+             rightSiblings,
+             children: leftHead |> Relude_Tree.getChildren,
+           }
+         });
+    } else {
+      None;
+    };
+
+/**
+ * Deletes the tree at the focus, and pulls the right sibling into focus (if possible)
+ */
+let deleteWithPullRight: 'a. t('a) => option(t('a)) =
+  ({ancestors, leftSiblings, focus: _, rightSiblings, children: _}) =>
+    if (ancestors |> Relude_List.isNotEmpty) {
+      rightSiblings
+      |> Relude_List.uncons
+      |> Relude_Option.map(((rightHead, rightTail)) => {
+           {
+             ancestors,
+             leftSiblings,
+             focus: rightHead |> Relude_Tree.getValue,
+             rightSiblings: rightTail,
+             children: rightHead |> Relude_Tree.getChildren,
+           }
+         });
+    } else {
+      None;
+    };
+
+/**
+ * Attempts to delete by deleting and pulling from the left.  If there is no item on the left,
+ * it tries to pull from the right.  If there is no item on the right, it moves the focus up a level,
+ * discarding the current focus and children.
+ */
+let delete: 'a. t('a) => option(t('a)) =
+  zipper =>
+    zipper
+    |> deleteWithPullLeft
+    |> Relude_Option.orElseLazy(~fallback=() => zipper |> deleteWithPullRight)
+    |> Relude_Option.orElseLazy(~fallback=() =>
+         zipper
+         |> getAncestors
+         |> Relude_List.uncons
+         |> Relude_Option.map(
+              (
+                (
+                  (parentLeftSiblings, parentFocus, parentRightSiblings),
+                  ancestorsTail,
+                ),
+              ) => {
+              {
+                ancestors: ancestorsTail,
+                leftSiblings: parentLeftSiblings,
+                focus: parentFocus,
+                rightSiblings: parentRightSiblings,
+                children: [],
+              }
+            })
+       );
+
+let showBy: 'a. ('a => string, t('a)) => string =
+  (showA, {ancestors, leftSiblings, focus, rightSiblings, children}) => {
+    let ancestorsStr =
+      ancestors
+      |> Relude_List.showBy(
+           Relude_Tuple.showBy3(
+             Relude_List.showBy(Relude_Tree.showBy(showA)),
+             showA,
+             Relude_List.showBy(Relude_Tree.showBy(showA)),
+           ),
+         );
+
+    let leftSiblingsStr =
+      leftSiblings |> Relude_List.showBy(Relude_Tree.showBy(showA));
+
+    let focusStr = showA(focus);
+
+    let rightSiblingsStr =
+      rightSiblings |> Relude_List.showBy(Relude_Tree.showBy(showA));
+
+    let childrenStr =
+      children |> Relude_List.showBy(Relude_Tree.showBy(showA));
+
+    "TreeZipper"
+    ++ "\n"
+    ++ "ancestors = "
+    ++ ancestorsStr
+    ++ "\n"
+    ++ "leftSiblings = "
+    ++ leftSiblingsStr
+    ++ "\n"
+    ++ "focus = "
+    ++ focusStr
+    ++ "\n"
+    ++ "rightSiblings = "
+    ++ rightSiblingsStr
+    ++ "\n"
+    ++ "children = "
+    ++ childrenStr;
+  };

--- a/src/Relude_Tuple.re
+++ b/src/Relude_Tuple.re
@@ -1,49 +1,51 @@
 /**
  * Constructs a tuple-2 from 2 values
  */
-let make = (a, b) => (a, b);
+let make: 'a 'b. ('a, 'b) => ('a, 'b) = (a, b) => (a, b);
 
 /**
  * Constructs a tuple-2 from 2 values
- * 
+ *
  * Alias of `make`
  */
-let make2 = make;
+let make2: 'a 'b. ('a, 'b) => ('a, 'b) = make;
 
 /**
  * Constructs a tuple-3 from 3 values
  */
-let make3 = (a, b, c) => (a, b, c);
+let make3: 'a 'b 'c. ('a, 'b, 'c) => ('a, 'b, 'c) = (a, b, c) => (a, b, c);
 
 /**
  * Constructs a tuple-4 from 4 values
  */
-let make4 = (a, b, c, d) => (a, b, c, d);
+let make4: 'a 'b 'c 'd. ('a, 'b, 'c, 'd) => ('a, 'b, 'c, 'd) =
+  (a, b, c, d) => (a, b, c, d);
 
 /**
  * Constructs a tuple-5 from 5 values
  */
-let make5 = (a, b, c, d, e) => (a, b, c, d, e);
+let make5: 'a 'b 'c 'd 'e. ('a, 'b, 'c, 'd, 'e) => ('a, 'b, 'c, 'd, 'e) =
+  (a, b, c, d, e) => (a, b, c, d, e);
 
 /**
  * Constructs a tuple-2 from an array of exactly 2 values
  */
-let fromArray =
+let fromArray: 'a. array('a) => option(('a, 'a)) =
   fun
   | [|a, b|] => Some((a, b))
   | _ => None;
 
 /**
  * Constructs a tuple-2 from an array of exactly 2 values
- * 
+ *
  * Alias of `fromArray`
  */
-let fromArray2 = fromArray;
+let fromArray2: 'a. array('a) => option(('a, 'a)) = fromArray;
 
 /**
  * Constructs a tuple-3 from an array of exactly 3 values
  */
-let fromArray3 =
+let fromArray3: 'a. array('a) => option(('a, 'a, 'a)) =
   fun
   | [|a, b, c|] => Some((a, b, c))
   | _ => None;
@@ -51,7 +53,7 @@ let fromArray3 =
 /**
  * Constructs a tuple-4 from an array of exactly 4 values
  */
-let fromArray4 =
+let fromArray4: 'a. array('a) => option(('a, 'a, 'a, 'a)) =
   fun
   | [|a, b, c, d|] => Some((a, b, c, d))
   | _ => None;
@@ -59,7 +61,7 @@ let fromArray4 =
 /**
  * Constructs a tuple-5 from an array of exactly 5 values
  */
-let fromArray5 =
+let fromArray5: 'a. array('a) => option(('a, 'a, 'a, 'a, 'a)) =
   fun
   | [|a, b, c, d, e|] => Some((a, b, c, d, e))
   | _ => None;
@@ -67,22 +69,26 @@ let fromArray5 =
 /**
  * Constructs a tuple-2 from an array of at least 2 values
  */
-let fromArrayAtLeast2 = xs => Relude_Array.take(2, xs) |> fromArray;
+let fromArrayAtLeast2: 'a. array('a) => option(('a, 'a)) =
+  xs => Relude_Array.take(2, xs) |> fromArray;
 
 /**
  * Constructs a tuple-3 from an array of at least 3 values
  */
-let fromArrayAtLeast3 = xs => Relude_Array.take(3, xs) |> fromArray3;
+let fromArrayAtLeast3: 'a. array('a) => option(('a, 'a, 'a)) =
+  xs => Relude_Array.take(3, xs) |> fromArray3;
 
 /**
  * Constructs a tuple-4 from an array of at least 4 values
  */
-let fromArrayAtLeast4 = xs => Relude_Array.take(4, xs) |> fromArray4;
+let fromArrayAtLeast4: 'a. array('a) => option(('a, 'a, 'a, 'a)) =
+  xs => Relude_Array.take(4, xs) |> fromArray4;
 
 /**
  * Constructs a tuple-5 from an array of at least 5 values
  */
-let fromArrayAtLeast5 = xs => Relude_Array.take(5, xs) |> fromArray5;
+let fromArrayAtLeast5: 'a. array('a) => option(('a, 'a, 'a, 'a, 'a)) =
+  xs => Relude_Array.take(5, xs) |> fromArray5;
 
 // Pattern matching on lists leads to deeply nested conditional branches in the
 // JS code, which is hard to read and painful to test exhaustively. Instead, we
@@ -94,49 +100,57 @@ let fromArrayAtLeast5 = xs => Relude_Array.take(5, xs) |> fromArray5;
 /**
  * Constructs a tuple-2 from a list of exactly 2 values
  */
-let fromList = xs => Relude_List.(take(3, xs) |> toArray) |> fromArray;
+let fromList: 'a. list('a) => option(('a, 'a)) =
+  xs => Relude_List.(take(3, xs) |> toArray) |> fromArray;
 
 /**
  * Constructs a tuple-2 from a list of exactly 2 values
- * 
+ *
  * Alias of `fromList`
  */
-let fromList2 = fromList;
+let fromList2: 'a. list('a) => option(('a, 'a)) = fromList;
 
 /**
  * Constructs a tuple-3 from a list of exactly 3 values
  */
-let fromList3 = xs => Relude_List.(take(4, xs) |> toArray) |> fromArray3;
+let fromList3: 'a. list('a) => option(('a, 'a, 'a)) =
+  xs => Relude_List.(take(4, xs) |> toArray) |> fromArray3;
 
 /**
  * Constructs a tuple-4 from a list of exactly 4 values
  */
-let fromList4 = xs => Relude_List.(take(5, xs) |> toArray) |> fromArray4;
+let fromList4: 'a. list('a) => option(('a, 'a, 'a, 'a)) =
+  xs => Relude_List.(take(5, xs) |> toArray) |> fromArray4;
 
 /**
  * Constructs a tuple-5 from a list of exactly 5 values
  */
-let fromList5 = xs => Relude_List.(take(6, xs) |> toArray) |> fromArray5;
+let fromList5: 'a. list('a) => option(('a, 'a, 'a, 'a, 'a)) =
+  xs => Relude_List.(take(6, xs) |> toArray) |> fromArray5;
 
 /**
  * Constructs a tuple-2 from a list of at least 2 values
  */
-let fromListAtLeast2 = xs => Relude_List.take(2, xs) |> fromList;
+let fromListAtLeast2: 'a. list('a) => option(('a, 'a)) =
+  xs => Relude_List.take(2, xs) |> fromList;
 
 /**
  * Constructs a tuple-3 from a list of at least 3 values
  */
-let fromListAtLeast3 = xs => Relude_List.take(3, xs) |> fromList3;
+let fromListAtLeast3: 'a. list('a) => option(('a, 'a, 'a)) =
+  xs => Relude_List.take(3, xs) |> fromList3;
 
 /**
  * Constructs a tuple-4 from a list of at least 4 values
  */
-let fromListAtLeast4 = xs => Relude_List.take(4, xs) |> fromList4;
+let fromListAtLeast4: 'a. list('a) => option(('a, 'a, 'a, 'a)) =
+  xs => Relude_List.take(4, xs) |> fromList4;
 
 /**
  * Constructs a tuple-5 from a list of at least 5 values
  */
-let fromListAtLeast5 = xs => Relude_List.take(5, xs) |> fromList5;
+let fromListAtLeast5: 'a. list('a) => option(('a, 'a, 'a, 'a, 'a)) =
+  xs => Relude_List.take(5, xs) |> fromList5;
 
 /**
  * Applies a normal 2-argument function to arguments contained in a tuple-2
@@ -164,3 +178,60 @@ let apply5:
   (('a, 'b, 'c, 'd, 'e) => 'f, ('a, 'b, 'c, 'd, 'e)) => 'f
  =
   (f, (a, b, c, d, e)) => f(a, b, c, d, e);
+
+let showBy2: 'a 'b. ('a => string, 'b => string, ('a, 'b)) => string =
+  (showA, showB, (a, b)) => "(" ++ showA(a) ++ ", " ++ showB(b) ++ ")";
+
+let showBy3:
+  'a 'b 'c.
+  ('a => string, 'b => string, 'c => string, ('a, 'b, 'c)) => string
+ =
+  (showA, showB, showC, (a, b, c)) =>
+    "(" ++ showA(a) ++ ", " ++ showB(b) ++ ", " ++ showC(c) ++ ")";
+
+let showBy4:
+  'a 'b 'c 'd.
+  (
+    'a => string,
+    'b => string,
+    'c => string,
+    'd => string,
+    ('a, 'b, 'c, 'd)
+  ) =>
+  string
+ =
+  (showA, showB, showC, showD, (a, b, c, d)) =>
+    "("
+    ++ showA(a)
+    ++ ", "
+    ++ showB(b)
+    ++ ", "
+    ++ showC(c)
+    ++ ", "
+    ++ showD(d)
+    ++ ")";
+
+let showBy5:
+  'a 'b 'c 'd 'e.
+  (
+    'a => string,
+    'b => string,
+    'c => string,
+    'd => string,
+    'e => string,
+    ('a, 'b, 'c, 'd, 'e)
+  ) =>
+  string
+ =
+  (showA, showB, showC, showD, showE, (a, b, c, d, e)) =>
+    "("
+    ++ showA(a)
+    ++ ", "
+    ++ showB(b)
+    ++ ", "
+    ++ showC(c)
+    ++ ", "
+    ++ showD(d)
+    ++ ", "
+    ++ showE(e)
+    ++ ")";


### PR DESCRIPTION
- Adds a `TreeZipper` - similar to `ListZipper`, but for a multi-way "rose" tree, like `Relude_Tree`
- Allows you to "navigate" within a Tree and manipulate the values around you
- See Tony Morris' presentation here for more info: http://data.tmorris.net/talks/zippers/bd054c210649101b84662c614fc45af3c27a5eef/zippers.pdf
- I have not implemented all the typeclasses (Apply/Applicative/Monad/Comonad/Foldbale/etc.) at this time, but that can be done in the future.