### PR TITLE
Add Array.insertAt and List.insertAt

### DIFF
--- a/__tests__/Relude_Array_test.re
+++ b/__tests__/Relude_Array_test.re
@@ -552,6 +552,26 @@ describe("Array", () => {
     |> toEqual([|1, 2, 100, 4, 5|])
   );
 
+  test("insertAt first", () =>
+    expect(Array.insertAt(0, 100, [|1, 2, 3, 4, 5|]))
+    |> toEqual([|100, 1, 2, 3, 4, 5|])
+  );
+
+  test("insertAt within range", () =>
+    expect(Array.insertAt(2, 100, [|1, 2, 3, 4, 5|]))
+    |> toEqual([|1, 2, 100, 3, 4, 5|])
+  );
+
+  test("insertAt last", () =>
+    expect(Array.insertAt(5, 100, [|1, 2, 3, 4, 5|]))
+    |> toEqual([|1, 2, 3, 4, 5, 100|])
+  );
+
+  test("insertAt out of range", () =>
+    expect(Array.insertAt(6, 100, [|1, 2, 3, 4, 5|]))
+    |> toEqual([|1, 2, 3, 4, 5|])
+  );
+
   test("map", () =>
     expect(Array.map(a => a + 2, [|1, 2, 3|])) |> toEqual([|3, 4, 5|])
   );

--- a/__tests__/Relude_List_test.re
+++ b/__tests__/Relude_List_test.re
@@ -620,6 +620,26 @@ describe("List", () => {
     |> toEqual([1, 2, 100, 4, 5])
   );
 
+  test("insertAt first", () =>
+    expect(List.insertAt(0, 100, [1, 2, 3, 4, 5]))
+    |> toEqual([100, 1, 2, 3, 4, 5])
+  );
+
+  test("insertAt within range", () =>
+    expect(List.insertAt(2, 100, [1, 2, 3, 4, 5]))
+    |> toEqual([1, 2, 100, 3, 4, 5])
+  );
+
+  test("insertAt last", () =>
+    expect(List.insertAt(5, 100, [1, 2, 3, 4, 5]))
+    |> toEqual([1, 2, 3, 4, 5, 100])
+  );
+
+  test("insertAt out of range", () =>
+    expect(List.insertAt(6, 100, [1, 2, 3, 4, 5]))
+    |> toEqual([1, 2, 3, 4, 5])
+  );
+
   test("distinctBy", () =>
     expect(List.distinctBy(Int.eq, [6, 1, 1, 2, 1, 3, 2, 3, 2, 4, 5, 5]))
     |> toEqual([6, 1, 2, 3, 4, 5])

--- a/src/array/Relude_Array_Base.re
+++ b/src/array/Relude_Array_Base.re
@@ -496,3 +496,19 @@ let scanRight: (('a, 'b) => 'b, 'b, array('a)) => array('b) =
         xs,
       ),
     );
+
+/**
+ * Creates a new array that inserts the given value at the given index.
+ * If the index is out of range, no insertion is made.
+ */
+let insertAt: 'a. (int, 'a, array('a)) => array('a) =
+  (targetIndex, newX, xs) => {
+    switch (splitAt(targetIndex, xs)) {
+    | Some((before, after)) =>
+      Relude_Array_Instances.concat(
+        before,
+        Relude_Array_Instances.concat([|newX|], after),
+      )
+    | None => xs
+    };
+  };

--- a/src/list/Relude_List_Base.re
+++ b/src/list/Relude_List_Base.re
@@ -456,3 +456,16 @@ let scanRight: (('a, 'b) => 'b, 'b, list('a)) => list('b) =
       xs,
     )
     |> snd;
+
+/**
+ * Creates a new list that inserts the given value at the given index.
+ * If the index is out of range, no insertion is made.
+ */
+let insertAt: 'a. (int, 'a, list('a)) => list('a) =
+  (targetIndex, newX, xs) => {
+    switch (splitAt(targetIndex, xs)) {
+    | Some((before, after)) =>
+      Relude_List_Instances.concat(before, [newX, ...after])
+    | None => xs
+    };
+  };


### PR DESCRIPTION
There's `replaceAt` but no `insertAt` at the moment for both Array and List.

Would you be ok if I open another pull request with `updateAt : int -> ('a -> 'a) -> list('a) -> list('a)`?