### PR TITLE
Possible implementation of Monadic Lazy module

### DIFF
--- a/src/Relude_Lazy.re
+++ b/src/Relude_Lazy.re
@@ -1,0 +1,90 @@
+
+type t('a) =
+  | Thunk('a)
+  | Deferred(unit => 'a)
+  | DeferredU((. unit) => 'a);
+
+let pure: 'a => t('a) = (value) => Thunk(value);
+
+let defer: (unit => 'a) => t('a) = (fn) => Deferred(fn);
+
+let deferU: ((. unit) => 'a) => t('a) = (fn) => DeferredU(fn);
+
+let identity: t('a) => t('a) = value => value;
+
+let force: t('a) => 'a = fun
+    | Thunk(v) => v
+    | Deferred(fn) => fn()
+    | DeferredU(fn) => fn(. );
+
+let forceIdentity: t('a) => t('a) = fun
+    | Thunk(v) => Thunk(v)
+    | Deferred(fn) => Thunk(fn())
+    | DeferredU(fn) => Thunk(fn(. ));
+
+let join: t(t('a)) => t('a) = force;
+
+let map: ('a => 'b, t('a)) => t('b) = (aToB, mA) => deferU((. ) => aToB(force(mA)));
+
+let mapU: ((. 'a) => 'b, t('a)) => t('b) = (aToB, mA) => deferU((. ) => aToB(. force(mA)));
+
+let forceMap: ('a => 'b, t('a)) => t('b) = (aToB, mA) => pure(aToB(force(mA)));
+
+let forceMapU: ((. 'a) => 'b, t('a)) => t('b) = (aToB, mA) => pure(aToB(. force(mA)));
+
+// let map2: (('a, 'b) => 'c, t('a), t('b)) => t('c) = (abToC, mA, mB) => deferU((. ) => abToC(force(mA), force(mB)));
+
+let forceMap2: (('a, 'b) => 'c, t('a), t('b)) => t('c) = (abToC, mA, mB) => pure(abToC(force(mA), force(mB)));
+
+let apply: (t('a => 'b), t('a)) => t('b) = (mAtoB, mA) => deferU((. ) => force(mAtoB)(force(mA)));
+
+let applyU: (t((. 'a) => 'b), t('a)) => t('b) = (mAtoB, mA) => deferU((. ) => force(mAtoB)(. force(mA)));
+
+let forceApply: (t('a => 'b), t('a)) => t('b) = (mAtoB, mA) => pure(force(mAtoB)(force(mA)));
+
+let forceApplyU: (t((. 'a) => 'b), t('a)) => t('b) = (mAtoB, mA) => pure(force(mAtoB)(. force(mA)));
+
+// let flatMap: ('a => t('b), t('a)) => t('b) = (aToMB, mA) => deferU((. ) => force(aToMB(force(mA))));
+
+let flatMapU: ((. 'a) => t('b), t('a)) => t('b) = (aToMB, mA) => deferU((. ) => force(aToMB(. force(mA))));
+
+let forceFlatMap: ('a => t('b), t('a)) => t('b) = (aToMB, mA) => aToMB(force(mA));
+
+let forceFlatMapU: ((. 'a) => t('b), t('a)) => t('b) = (aToMB, mA) => aToMB(. force(mA));
+
+let bind: (t('a), 'a => t('b)) => t('b) = (mA, aToMB) => deferU((. ) => force(aToMB(force(mA))));
+
+let bindU: (t('a), (. 'a) => t('b)) => t('b) = (mA, aToMB) => deferU((. ) => force(aToMB(. force(mA))));
+
+let forceBind: (t('a), 'a => t('b)) => t('b) = (mA, aToMB) => aToMB(force(mA));
+
+let forceBindU: (t('a), (. 'a) => t('b)) => t('b) = (mA, aToMB) => aToMB(. force(mA));
+
+module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+  type nonrec t('a) = t('a);
+  let map = map;
+};
+let map = Functor.map;
+include Relude_Extensions_Functor.FunctorExtensions(Functor);
+
+module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+  include Functor;
+  let apply = apply;
+};
+let apply = Apply.apply;
+include Relude_Extensions_Apply.ApplyExtensions(Apply);
+
+module Applicative:
+  BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+  include Apply;
+  let pure = pure;
+};
+let pure = Applicative.pure;
+include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
+
+module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+  include Applicative;
+  let flat_map = bind;
+};
+let bind = Monad.flat_map;
+include Relude_Extensions_Monad.MonadExtensions(Monad);

--- a/src/Relude_Lazy2.re
+++ b/src/Relude_Lazy2.re
@@ -1,0 +1,38 @@
+/**
+ * For demonstration purposes.
+ * 
+ * This monadic interface could make use of OCaml's built-in Lazy module, as
+ * shown below.
+ * 
+ * The upside is that it would interoperate with existing uses of
+ * that Lazy module, which allows use of the `lazy` keyword.
+ * 
+ * The downside is that it doesn't really fit neatly into the Relude way
+ * of doing error handling, since sever functions can throw exceptions, and
+ * it also handles propogated exceptions in its own unique way (exceptions
+ * are rethrown each time a lazy value is forced, if it threw an exception
+ * the last time it was forced). That behavior may or may not be desireable.
+ */
+
+
+type t('a) = Lazy.t('a);
+
+let force: t('a) => 'a = Lazy.force;
+
+let pure_: 'a => t('a) = Lazy.from_val;
+
+let defer: (unit => 'a) => t('a) = Lazy.from_fun;
+
+let identity: t('a) => t('a) = a => a;
+
+let map: ('a => 'b, t('a)) => t('b) = (aToB, a) => lazy(aToB(force(a)));
+
+let join: t(t('a)) => t('a) = force;
+
+let apply: (t('a => 'b), t('a)) => t('b) = (mAtoB, mA) => defer(() => force(mAtoB)(force(mA)));
+
+let flatMap: ('a => t('b), t('a)) => t('b) = (aToMB, mA) => defer(() => force(aToMB(force(mA))));
+
+let bind: (t('a), 'a => t('b)) => t('b) = (mA, aToMB) => defer(() => force(aToMB(force(mA))));
+
+

--- a/src/Relude_Lazy2.re
+++ b/src/Relude_Lazy2.re
@@ -8,7 +8,7 @@
  * that Lazy module, which allows use of the `lazy` keyword.
  * 
  * The downside is that it doesn't really fit neatly into the Relude way
- * of doing error handling, since sever functions can throw exceptions, and
+ * of doing error handling, since several functions can throw exceptions, and
  * it also handles propogated exceptions in its own unique way (exceptions
  * are rethrown each time a lazy value is forced, if it threw an exception
  * the last time it was forced). That behavior may or may not be desireable.


### PR DESCRIPTION
I just wanted to create this PR in case this was a desirable module. I'm still not sure if lazy evaluation makes sense as a monad, since the `join` operation essentially forces the evaluation of a lazy computation. But perhaps that is precisely what `join` and `bind` *should* mean in this context. I would appreciate any feedback on this.

The main reason I question the semantics is that most of the standard type-class functions (`map`, `bind`, `pure`, `apply`, etc.) can have alternate implementations where the computation is evaluated eagerly and then lifted back into the monadic context:
```ocaml
let map: ('a => 'b, t('a)) => t('b) = (aToB, mA) => pure(aToB(join(mA)));
```
I think this breaks some fundamental assumptions about the meaning of these functions, which is why I refrain from implementing the normal functions in that way, and instead provide alternative functions (with the same type signature), which DO force eager evaluation.

That's fine, we can have lazily evaluated monadic operations, alongside their eager counterparts. But it begs the question: is this really a monad?

I think the problem is that the `join` operation logically makes sense for both `t(t('a)) => t('a)` as well as `t('a) => 'a`. This is what allows the implicit `pure << join` operation to work inside the other functions, and this is not necessarily achievable with other monads. I would think taking advantage of the latter type to eagerly evaluate computations inside of `apply`, `map`, etc. would actually break the monad laws, right?

If so, then the answer might just be: "don't do that." But Idk...

Here is a relevant discussion on StackOverflow on this topic:
https://stackoverflow.com/questions/44289542/can-lazy-evaluation-be-implemented-by-a-monadic-type

