### PR TITLE
Helpers for dealing with charCodes and NaN floats

### DIFF
--- a/__tests__/Relude_Float_test.re
+++ b/__tests__/Relude_Float_test.re
@@ -64,6 +64,38 @@ describe("Float", () => {
     |> toEqual(true)
   );
 
+  test("pow", () =>
+    expect(Float.pow(2.0, 4.0)) |> toEqual(16.0)
+  );
+
+  test("pow (nan)", () =>
+    expect(Float.pow(-2.0, 0.3333333) |> Float.isNaN) |> toEqual(true)
+  );
+
+  test("sqrt", () =>
+    expect(Float.sqrt(9.0)) |> toEqual(3.0)
+  );
+
+  test("sqrt (nan)", () =>
+    expect(Float.sqrt(-9.0) |> Float.isNaN) |> toEqual(true)
+  );
+
+  test("isNaN (false for normal number)", () =>
+    expect(Float.isNaN(3.0)) |> toEqual(false)
+  );
+
+  test("isNaN (false for infinity)", () =>
+    expect(Float.isNaN(Float.infinity)) |> toEqual(false)
+  );
+
+  test("isNaN (true for nan)", () =>
+    expect(Float.isNaN(Float.nan)) |> toEqual(true)
+  );
+
+  test("isNaN (true for computation that returns nan)", () =>
+    expect(Float.isNaN(Float.sqrt(-1.0))) |> toEqual(true)
+  );
+
   test("compareAsInt (-1)", () =>
     expect(Float.compareAsInt(3.0, 3.1)) |> toEqual(-1)
   );
@@ -137,11 +169,13 @@ describe("Float", () => {
   );
 
   test("named lessThanOrEq (smaller)", () =>
-    expect(Float.OrdNamed.lessThanOrEq(~compareTo=2.0, 1.0)) |> toEqual(true)
+    expect(Float.OrdNamed.lessThanOrEq(~compareTo=2.0, 1.0))
+    |> toEqual(true)
   );
 
   test("named lessThanOrEq (larger)", () =>
-    expect(Float.OrdNamed.lessThanOrEq(~compareTo=0.0, 3.0)) |> toEqual(false)
+    expect(Float.OrdNamed.lessThanOrEq(~compareTo=0.0, 3.0))
+    |> toEqual(false)
   );
 
   test("named greaterThan (larger)", () =>
@@ -149,7 +183,8 @@ describe("Float", () => {
   );
 
   test("named greaterThan (equal)", () =>
-    expect(Float.OrdNamed.greaterThan(~compareTo=1.0, 1.0)) |> toEqual(false)
+    expect(Float.OrdNamed.greaterThan(~compareTo=1.0, 1.0))
+    |> toEqual(false)
   );
 
   test("named greaterThanOrEq (eq)", () =>

--- a/__tests__/Relude_String_test.re
+++ b/__tests__/Relude_String_test.re
@@ -153,6 +153,22 @@ describe("String", () => {
     ) |> toThrow
   );
 
+  test("charAtOrEmpty (in range)", () =>
+    expect(Str.charAtOrEmpty(0, "abc")) |> toEqual("a")
+  );
+
+  test("charAtOrEmpty (empty string)", () =>
+    expect(Str.charAtOrEmpty(0, "")) |> toEqual("")
+  );
+
+  test("charAtOrEmpty (above range)", () =>
+    expect(Str.charAtOrEmpty(2, "a")) |> toEqual("")
+  );
+
+  test("charAtOrEmpty (below range)", () =>
+    expect(Str.charAtOrEmpty(-1, "abc")) |> toEqual("")
+  );
+
   test("toList", () =>
     expect(Str.toList("abcde")) |> toEqual(["a", "b", "c", "d", "e"])
   );

--- a/__tests__/Relude_String_test.re
+++ b/__tests__/Relude_String_test.re
@@ -125,6 +125,18 @@ describe("String", () => {
     expect(Str.fromCharCode(65)) |> toEqual("A")
   );
 
+  test("charCodeAt (success)", () =>
+    expect(Str.charCodeAt(0, "abc")) |> toEqual(Some(97))
+  );
+
+  test("charCodeAt (negative index)", () =>
+    expect(Str.charCodeAt(-1, "abc")) |> toEqual(None)
+  );
+
+  test("charCodeAt (empty string)", () =>
+    expect(Str.charCodeAt(0, "")) |> toEqual(None)
+  );
+
   test("charAt success", () =>
     expect(Str.charAt(2, "abcdefg")) |> toEqual(Some("c"))
   );

--- a/src/Relude_Float.re
+++ b/src/Relude_Float.re
@@ -19,6 +19,22 @@ let zero: float = 0.0;
 let one: float = 1.0;
 
 /**
+ * Value for "not a number", used for mathematical operations that do not result
+ * in a real number, such as `0.0 /. 0.0` and `sqrt(-2)`.
+ */
+let nan: float = nan;
+
+/**
+ * Positive infinity
+ */
+let infinity: float = infinity;
+
+/**
+ * Negative infinity
+ */
+let negativeInfinity: float = neg_infinity;
+
+/**
  * Finds the sum of two floats
  */
 let add: (float, float) => float = (+.);
@@ -39,14 +55,45 @@ let multiply: (float, float) => float = ( *. );
 let divide: (float, float) => float = (/.);
 
 /**
- * Finds the max float value
+ * Raise the first number to the power of the second number.
+ *
+ * ```re
+ * pow(2.0, 4.0) == 16.0;
+ * pow(3.0, 2.0) == 9.0;
+ * pow(-2.0, (0.333333)) |> isNaN;
+ * ```
  */
-let top: float = BsAbstract.Float.Bounded.top;
+let pow = (a, b) => a ** b;
 
 /**
- * Finds the max float value
+ * Find the square root of the given float. The square root of negative numbers
+ * is `nan`.
  */
-let bottom: float = BsAbstract.Float.Bounded.bottom;
+let sqrt = sqrt;
+
+/**
+ * The maximum float value.
+ */
+let top: float = max_float;
+
+/**
+ * The minimum float value. Note that when using Bucklescript, this value is
+ * hard-coded and is not necessarily equal to `Number.MIN_VALUE` in JS.
+ */
+let bottom: float = min_float;
+
+/**
+ * NaN values are never equal to other numeric values, including other NaN
+ * values. This means that the intuitive `myValue == nan` is not sufficient for
+ * determining whether a value is NaN.
+ *
+ * ```re
+ * isNaN(3.14) == false;
+ * isNaN(infinity) == false;
+ * isNaN(nan) == true;
+ * ```
+ */
+let isNaN: float => bool = x => x != x;
 
 /**
  * Compates two floats
@@ -211,7 +258,7 @@ module Show: BsAbstract.Interface.SHOW with type t = float = {
 */
 let fromString: string => option(float) =
   v =>
-    try (Some(float_of_string(v))) {
+    try(Some(float_of_string(v))) {
     | _ => None
     };
 

--- a/src/Relude_String.re
+++ b/src/Relude_String.re
@@ -274,6 +274,24 @@ let charAt: (int, string) => option(string) =
     Js.String.get(str, i) |> Js.Nullable.return |> Js.Nullable.toOption;
 
 /**
+  `charAtOrEmpty(n, str)` returns the string containing the character at the
+  given index or the empty string if the index is out of range.
+
+  ```re
+  charAtOrEmpty(0, "abc") == "a";
+  charAtOrEmpty(0, "") == "";
+  charAtOrEmpty(2, "a") == "";
+  charAtOrEmpty(-1, "abc") == "";
+  ```
+*/
+let charAtOrEmpty: (int, string) => string =
+  (i, str) =>
+    switch (charAt(i, str)) {
+    | None => ""
+    | Some(x) => x
+    };
+
+/**
   `charAtNullable(n, str)` returns `Js.Nullable.return(chStr)`,
   where `chStr` is a string consisting of the character at
   location `n` in the string. The first character in a string has position zero.

--- a/src/Relude_String.re
+++ b/src/Relude_String.re
@@ -254,6 +254,23 @@ let toLowerCase: string => string = Js.String.toLowerCase;
 let fromCharCode: int => string = Js.String.fromCharCode;
 
 /**
+  `charCodeAt(n, str)` returns (optionally) the numeric character code at the
+  given 0-based position in a string. If the provided position is out of the
+  range of the size of the string (too high or negative), `None` is returned.
+
+  ```re
+  charCodeAt(0, "abc") == Some(97);
+  charCodeAt(-1, "abc") == None;
+  charCodeAt(0, "") == None;
+  ```
+*/
+let charCodeAt: (int, string) => option(int) =
+  (i, str) => {
+    let code = Js.String.charCodeAt(i, str);
+    Relude_Float.isNaN(code) ? None : Some(int_of_float(code));
+  };
+
+/**
   `charAt(n, str)` returns `Some(chStr)`, where `chStr` is a string
   consisting of the character at location `n` in the string. The
   first character in a string has position zero.


### PR DESCRIPTION
- Add `String.charCodeAt` (with safe `option(int)` return instead of Bucklescript's NaN-able float)
- Add `String.charAtOrEmpty` (convenience for falling back to empty string)
- Add `Float.isNaN`
- Add `pow` and `sqrt` to Float (mostly for testing `nan`, but also because they're useful?)