### PR TITLE
Improve NonEmpty coverage

### DIFF
--- a/__tests__/Relude_NonEmpty_test.re
+++ b/__tests__/Relude_NonEmpty_test.re
@@ -50,6 +50,18 @@ describe("NonEmpty.List", () => {
     expect(NonEmpty.List.toArray(input)) |> toEqual(expected)
   );
 
+  test("pure", () =>
+    expect(NonEmpty.List.pure(1)) |> toEqual(NonEmpty.List.make(1, []))
+  );
+
+  test("flatMap", () =>
+    expect(
+      NonEmpty.List.one(1)
+      |> NonEmpty.List.flatMap(a => NonEmpty.List.one(a + 1)),
+    )
+    |> toEqual(NonEmpty.List.make(2, []))
+  );
+
   test("cons", () =>
     expect(NonEmpty.List.cons(1, NonEmpty.List.one(2)))
     |> toEqual(NonEmpty.List.make(1, [2]))
@@ -58,6 +70,14 @@ describe("NonEmpty.List", () => {
   test("uncons", () =>
     expect(NonEmpty.List.uncons(NonEmpty.List.make(1, [2, 3])))
     |> toEqual((1, [2, 3]))
+  );
+
+  test("fromSequence", () =>
+    NonEmpty.List.one(1)
+    |> NonEmpty.List.toSequence
+    |> NonEmpty.List.fromSequence
+    |> expect
+    |> toEqual(Some(NonEmpty.List.make(1, [])))
   );
 
   test("concat with two full NonEmpty.Lists", () => {
@@ -120,10 +140,27 @@ describe("NonEmpty.List", () => {
     expect(NonEmpty.List.reverse(input)) |> toEqual(expected)
   );
 
-  test("eq", () => {
+  test("apply", () => {
+    let result =
+      NonEmpty.List.apply(
+        NonEmpty.List.make(v => v + 10, [v => v * 3]),
+        NonEmpty.List.make(1, [2]),
+      );
+    let expected = NonEmpty.List.make(11, [12, 3, 6]);
+    expect(result) |> toEqual(expected);
+  });
+
+  test("eq tail", () => {
     let ne = NonEmpty.List.make(1, [2, 3]);
     expect(NonEmpty.List.eq((module Relude_Int.Eq), ne, ne))
     |> toEqual(true);
+  });
+
+  test("eq head", () => {
+    let ne1 = NonEmpty.List.make(0, [2, 3]);
+    let ne2 = NonEmpty.List.make(1, [2, 3]);
+    expect(NonEmpty.List.eq((module Relude_Int.Eq), ne1, ne2))
+    |> toEqual(false);
   });
 
   test("show", () => {
@@ -221,6 +258,26 @@ describe("NonEmpty.Array", () => {
     ((input, expected)) =>
     expect(NonEmpty.Array.reverse(input)) |> toEqual(expected)
   );
+
+  test("toNonEmptyList", () =>
+    NonEmpty.Array.cons(1, NonEmpty.Array.one(2))
+    |> NonEmpty.Array.toNonEmptyList
+    |> expect
+    |> toEqual(NonEmpty.List.make(1, [2]))
+  );
+
+  test("fromNonEmptyList", () =>
+    NonEmpty.List.make(1, [2])
+    |> NonEmpty.Array.fromNonEmptyList
+    |> expect
+    |> toEqual(NonEmpty.Array.make(1, [|2|]))
+  );
+
+  test("show", () => {
+    let ne = NonEmpty.Array.make(1, [|2, 3|]);
+    expect(NonEmpty.Array.show((module Relude_Int.Show), ne))
+    |> toEqual("[!1, 2, 3!]");
+  });
 
   module NonEmptyArrayWithOption =
     NonEmpty.Array.WithApplicative(Relude_Option.Applicative);


### PR DESCRIPTION
* Before: `58.81%` Statements
* After: `61.29%` Statements

Sorry, I'm unable to make coverage higher, I don't know how to deal with `module` function, for example: `function WithSequence(TailSequence) {}`:
![screenshot_2020-01-31 21-43-19](https://user-images.githubusercontent.com/87983/73543809-bdd47780-4472-11ea-8f4b-8867d920f614.jpg)
