### PR TITLE
Make it build with latest Bucklescript

### DIFF
--- a/__tests__/Relude_Array_test.re
+++ b/__tests__/Relude_Array_test.re
@@ -29,10 +29,6 @@ describe("Array", () => {
     expect(Array.isNotEmpty([|1|])) |> toBe(true)
   );
 
-  test("empty is []", () =>
-    expect(Array.empty) |> toEqual([||])
-  );
-
   test("pure creates a one-item array", () =>
     expect(Array.pure(123)) |> toEqual([|123|])
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -906,15 +906,14 @@
       }
     },
     "bs-abstract": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/bs-abstract/-/bs-abstract-0.18.0.tgz",
-      "integrity": "sha512-kohLdSzk6fIw4u+O214/0paiPmhkJ+ChBOrXLWufQGT/aLu6hOWNlLIpWX7BFi7oGEsUMlIBxTs5jPWBT9gnjg==",
+      "version": "github:gaku-sei/bs-abstract#0dd5a7cbddcf13f8b7073934b61fecfe9cdb48b8",
+      "from": "github:gaku-sei/bs-abstract#support-bs-7.0.2",
       "dev": true
     },
     "bs-platform": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.0.1.tgz",
-      "integrity": "sha512-UjStdtHhbtC/l6vKJ1XRDqrPk7rFf5PLYHtRX3akDXEYVnTbN36z0g4DEr5mU8S0N945e33HYts9x+i7hKKpZQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.1.0.tgz",
+      "integrity": "sha512-XUeZf1nGzmsVymG89j5L8G9YNDHl0J/5iDGExXA7a4RKxnbvP2TselBZAzFeEH4rs3gG01b7yKt+h2pm7yh7Ww==",
       "dev": true
     },
     "bser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -906,14 +906,15 @@
       }
     },
     "bs-abstract": {
-      "version": "github:gaku-sei/bs-abstract#0dd5a7cbddcf13f8b7073934b61fecfe9cdb48b8",
-      "from": "github:gaku-sei/bs-abstract#support-bs-7.0.2",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bs-abstract/-/bs-abstract-1.0.0.tgz",
+      "integrity": "sha512-RldrJAr9N0n/Sr20PCSORztmKpRBw6Jbi7EJFsERZlmQ805/flCj9FMfMza4uUxLISAFSSEhIYs97mwt2X6I+w==",
       "dev": true
     },
     "bs-platform": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.1.0.tgz",
-      "integrity": "sha512-XUeZf1nGzmsVymG89j5L8G9YNDHl0J/5iDGExXA7a4RKxnbvP2TselBZAzFeEH4rs3gG01b7yKt+h2pm7yh7Ww==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.1.1.tgz",
+      "integrity": "sha512-ckZHR3J+yxyEKXOBHX8+hfzWG2XX5BxhQ4Iw9lulHFGYdAm9Ep9LgKkIah7G6RYADLmVfTxFE48igvY3kkkl+g==",
       "dev": true
     },
     "bser": {

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "license": "MIT",
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.9",
-    "bs-abstract": "^0.18.0",
-    "bs-platform": "^7.0.1",
+    "bs-abstract": "github:gaku-sei/bs-abstract#support-bs-7.0.2",
+    "bs-platform": "^7.1.0",
     "docsify-cli": "~4.4.0"
   },
   "peerDependencies": {
     "bs-abstract": "^0.18.0",
-    "bs-platform": "^7.0.1"
+    "bs-platform": "^7.1.0"
   },
   "jest": {
     "verbose": false,

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "license": "MIT",
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.9",
-    "bs-abstract": "github:gaku-sei/bs-abstract#support-bs-7.0.2",
-    "bs-platform": "^7.1.0",
+    "bs-abstract": "^1.0.0",
+    "bs-platform": "^7.1.1",
     "docsify-cli": "~4.4.0"
   },
   "peerDependencies": {
-    "bs-abstract": "^0.18.0",
-    "bs-platform": "^7.1.0"
+    "bs-abstract": "^1.0.0",
+    "bs-platform": "^7.1.1"
   },
   "jest": {
     "verbose": false,

--- a/src/Relude_Interface.re
+++ b/src/Relude_Interface.re
@@ -29,7 +29,6 @@ module type NATURAL_TRANSFORMATION = {
   type f('a);
   type g('a);
   let f: f('a) => g('a);
-
   // Another encoding would be using FUNCTOR modules here, but the f('a)/g('a) version seems easier to work with inline,
   // and we've already gone off the deep end, so let's not make it any more clunky.
   //module F: BsAbstract.Interface.FUNCTOR;
@@ -43,7 +42,6 @@ module type NATURAL_TRANSFORMATION = {
 module type SEQUENCE = {
   type t('a);
 
-  let empty: t('a);
   let emptyLazy: unit => t('a);
   let length: t('a) => int;
   let isEmpty: t('a) => bool;
@@ -66,18 +64,16 @@ module type SEQUENCE = {
   let eqBy: (('a, 'a) => bool, t('a), t('a)) => bool;
   let showBy: ('a => string, t('a)) => string;
 
-  module MonoidAny: BsAbstract.Interface.MONOID_ANY with type t('a) = t('a);
+  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) := t('a);
 
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a);
-
-  module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a);
+  module Apply: BsAbstract.Interface.APPLY with type t('a) := t('a);
 
   module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) = t('a);
+    BsAbstract.Interface.APPLICATIVE with type t('a) := t('a);
 
-  module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a);
+  module Monad: BsAbstract.Interface.MONAD with type t('a) := t('a);
 
-  module Foldable: BsAbstract.Interface.FOLDABLE with type t('a) = t('a);
+  module Foldable: BsAbstract.Interface.FOLDABLE with type t('a) := t('a);
 
   module Traversable:
     (A: BsAbstract.Interface.APPLICATIVE) =>

--- a/src/Relude_NonEmpty.re
+++ b/src/Relude_NonEmpty.re
@@ -12,7 +12,7 @@ module WithSequence = (TailSequence: Relude_Interface.SEQUENCE) => {
    * Creates a NonEmpty with a single value
    */
   let one: 'a. 'a => t('a) =
-    head => NonEmpty(head, TailSequence.MonoidAny.empty);
+    head => NonEmpty(head, TailSequence.emptyLazy());
 
   /**
    * Constructs a NonEmpty with the given head and tail values
@@ -37,7 +37,7 @@ module WithSequence = (TailSequence: Relude_Interface.SEQUENCE) => {
   let toSequence: 'a. t('a) => TailSequence.t('a) =
     fun
     | NonEmpty(head, tail) =>
-      TailSequence.MonoidAny.append(TailSequence.Monad.pure(head), tail);
+      TailSequence.concat(TailSequence.Monad.pure(head), tail);
 
   /**
    * Converts a list to a NonEmpty, failing if the list is empty
@@ -95,10 +95,7 @@ module WithSequence = (TailSequence: Relude_Interface.SEQUENCE) => {
     (nonEmpty1, nonEmpty2) =>
       NonEmpty(
         head(nonEmpty1),
-        TailSequence.MonoidAny.append(
-          tail(nonEmpty1),
-          toSequence(nonEmpty2),
-        ),
+        TailSequence.concat(tail(nonEmpty1), toSequence(nonEmpty2)),
       );
 
   module SemigroupAny:

--- a/src/Relude_NonEmpty.re
+++ b/src/Relude_NonEmpty.re
@@ -149,8 +149,8 @@ module WithSequence = (TailSequence: Relude_Interface.SEQUENCE) => {
       module TailFoldMapPlus =
         TailSequence.Foldable.Fold_Map_Plus(FoldMapPlus);
       let fold_map:
-        'a.
-        ('a => FoldMapPlus.t('a), t('a)) => FoldMapPlus.t('a)
+        'a 'b.
+        ('a => FoldMapPlus.t('b), t('a)) => FoldMapPlus.t('b)
        =
         (f, NonEmpty(x, xs)) =>
           FoldMapPlus.alt(f(x), TailFoldMapPlus.fold_map(f, xs));
@@ -159,7 +159,10 @@ module WithSequence = (TailSequence: Relude_Interface.SEQUENCE) => {
     module Fold_Map_Any = (FoldMapAny: BsAbstract.Interface.MONOID_ANY) => {
       module SequenceFoldMapAny =
         TailSequence.Foldable.Fold_Map_Any(FoldMapAny);
-      let fold_map: 'a. ('a => FoldMapAny.t('a), t('a)) => FoldMapAny.t('a) =
+      let fold_map:
+        'a 'b.
+        ('a => FoldMapAny.t('b), t('a)) => FoldMapAny.t('b)
+       =
         (f, NonEmpty(x, xs)) =>
           FoldMapAny.append(f(x), SequenceFoldMapAny.fold_map(f, xs));
     };

--- a/src/Relude_Sequence.re
+++ b/src/Relude_Sequence.re
@@ -1,6 +1,5 @@
 module List: Relude_Interface.SEQUENCE with type t('a) = list('a) = {
   type t('a) = list('a);
-  let empty = [];
   let emptyLazy = () => [];
   let length = Relude_List_Instances.length;
   let isEmpty = Relude_List_Base.isEmpty;
@@ -23,7 +22,6 @@ module List: Relude_Interface.SEQUENCE with type t('a) = list('a) = {
   let showBy = Relude_List_Instances.showBy;
   let mkString =
     Relude_List_Instances.intercalate((module BsAbstract.String.Monoid));
-  module MonoidAny = Relude_List_Instances.MonoidAny;
   module Functor = Relude_List_Instances.Functor;
   module Apply = Relude_List_Instances.Apply;
   module Applicative = Relude_List_Instances.Applicative;
@@ -36,7 +34,6 @@ module List: Relude_Interface.SEQUENCE with type t('a) = list('a) = {
 
 module Array: Relude_Interface.SEQUENCE with type t('a) = array('a) = {
   type t('a) = array('a);
-  let empty = [||];
   let emptyLazy = () => [||];
   let length = Relude_Array_Base.length;
   let isEmpty = Relude_Array_Base.isEmpty;
@@ -59,7 +56,6 @@ module Array: Relude_Interface.SEQUENCE with type t('a) = array('a) = {
   let showBy = Relude_Array_Instances.showBy;
   let mkString =
     Relude_Array_Instances.intercalate((module BsAbstract.String.Monoid));
-  module MonoidAny = Relude_Array_Instances.MonoidAny;
   module Functor = Relude_Array_Instances.Functor;
   module Apply = Relude_Array_Instances.Apply;
   module Applicative = Relude_Array_Instances.Applicative;

--- a/src/Relude_SequenceZipper.re
+++ b/src/Relude_SequenceZipper.re
@@ -4,14 +4,11 @@
  * Heavily inspired by Queensland Function Programming Lab Haskell implementation,
  * although without many of the advanced capabilities, like the ListZipperOp stuff.
  * https://github.com/qfpl/list-zipper/blob/master/src/Data/ListZipper.hs
- * 
+ *
  * See also this very enlightening presentation about zippers for more background:
  * http://data.tmorris.net/talks/zippers/0a1062fd0526d7ac1f41ade1e4db1465d311b4fd/zippers.pdf
  */
 module WithSequence = (S: Relude_Interface.SEQUENCE) => {
-  module SFoldableExtensions =
-    Relude_Extensions_Foldable.FoldableExtensions(S.Foldable);
-
   /**
    * A Zipper type contains a sequence on the left (in reverse order, so that the head
    * of the left sequence is treated as if it's the item immediately to the left of the focus),
@@ -291,7 +288,7 @@ module WithSequence = (S: Relude_Interface.SEQUENCE) => {
    * TODO: not needed with Foldable extensions
    */
   let toArray: 'a. t('a) => array('a) =
-    zipper => zipper |> toSequence |> SFoldableExtensions.toArray;
+    zipper => zipper |> toSequence |> S.toArray;
 
   /**
    * Converts the Zipper into a list
@@ -299,7 +296,7 @@ module WithSequence = (S: Relude_Interface.SEQUENCE) => {
    * TODO: not needed with Foldable extensions
    */
   let toList: 'a. t('a) => list('a) =
-    zipper => zipper |> toSequence |> SFoldableExtensions.toList;
+    zipper => zipper |> toSequence |> S.toList;
 
   /**
    * Converts the Zipper into a NonEmptyArray
@@ -707,7 +704,9 @@ module WithSequence = (S: Relude_Interface.SEQUENCE) => {
     if (checkFocus && f(focus)) {
       Some(z);
     } else {
-      z |> moveRight |> Relude_Option.flatMap(findRightBy(~checkFocus=true, f));
+      z
+      |> moveRight
+      |> Relude_Option.flatMap(findRightBy(~checkFocus=true, f));
     };
 
   /**

--- a/src/Relude_Tree.re
+++ b/src/Relude_Tree.re
@@ -285,13 +285,13 @@ module Foldable: BsAbstract.Interface.FOLDABLE with type t('a) = t('a) = {
   };
 
   module Fold_Map_Any = (M: BsAbstract.Interface.MONOID_ANY) => {
-    let fold_map: ('a => M.t('a), t('a)) => M.t('a) =
+    let fold_map: 'a 'b. ('a => M.t('b), t('a)) => M.t('b) =
       (f, tree) =>
         tree |> foldLeft((acc, value) => M.append(acc, f(value)), M.empty);
   };
 
   module Fold_Map_Plus = (P: BsAbstract.Interface.PLUS) => {
-    let fold_map: ('a => P.t('a), t('a)) => P.t('a) =
+    let fold_map: 'a 'b. ('a => P.t('b), t('a)) => P.t('b) =
       (f, tree) =>
         tree |> foldLeft((acc, value) => P.alt(acc, f(value)), P.empty);
   };

--- a/src/array/Relude_Array_Instances.re
+++ b/src/array/Relude_Array_Instances.re
@@ -11,17 +11,6 @@ module SemigroupAny:
 include Relude_Extensions_SemigroupAny.SemigroupAnyExtensions(SemigroupAny);
 
 /**
- * Returns an empty array.  Warning: arrays are mutable so this value cannot be shared.
- */
-let empty: 'a. array('a) = [||];
-
-module MonoidAny: BsAbstract.Interface.MONOID_ANY with type t('a) = array('a) = {
-  include SemigroupAny;
-  let empty = empty;
-};
-include Relude_Extensions_MonoidAny.MonoidAnyExtensions(MonoidAny);
-
-/**
  * Applies a pure function to each value in the array
  */
 let map: 'a 'b. ('a => 'b, array('a)) => array('b) = BsAbstract.Array.Functor.map;
@@ -77,23 +66,6 @@ module Alt: BsAbstract.Interface.ALT with type t('a) = array('a) = {
 };
 include Relude_Extensions_Alt.AltExtensions(Alt);
 
-module Plus: BsAbstract.Interface.PLUS with type t('a) = array('a) = {
-  include MonoidAny;
-  let map = map;
-  let alt = alt;
-};
-include Relude_Extensions_Plus.PlusExtensions(Plus);
-
-module Alternative:
-  BsAbstract.Interface.ALTERNATIVE with type t('a) = array('a) = {
-  include MonoidAny;
-  let map = map;
-  let alt = alt;
-  let apply = apply;
-  let pure = pure;
-};
-include Relude_Extensions_Alternative.AlternativeExtensions(Alternative);
-
 /**
  * Imap is the invariant map function for arrays.
  */
@@ -102,18 +74,6 @@ let imap: 'a 'b. ('a => 'b, 'b => 'a, array('a)) => array('b) = BsAbstract.Array
 module Invariant: BsAbstract.Interface.INVARIANT with type t('a) = array('a) = {
   type t('a) = array('a);
   let imap = imap;
-};
-
-module MonadZero: BsAbstract.Interface.MONAD_ZERO with type t('a) = array('a) = {
-  include Monad;
-  let empty = empty;
-  let alt = alt;
-};
-
-module MonadPlus: BsAbstract.Interface.MONAD_PLUS with type t('a) = array('a) = {
-  include Monad;
-  let empty = empty;
-  let alt = alt;
 };
 
 /**


### PR DESCRIPTION
There's more that can be done for `bs-platform@7` (e.g. we could start preferring `result` over `Belt.Result` and take advantage of the always-in-scope result constructors; maybe there's some unboxing to be done), but for now the most important thing is to make sure it builds.

In order to do that, I'm depending on a `bs-abstract` pull request. Hopefully that gets merged soon, but a friendly fork would be an option if we want to get a release out quickly. Additionally, I've had to remove some of the array typeclass implementations (Monoid Any, Plus, Alternative, Monad Plus). I was able to keep `NonEmptyArray` around (I think without any breaking changes to NEA, but I did have to change the module type of `Sequence` slightly).

I'll try to put together a list of what changed, and we probably don't want to merge this until we have a more stable release of `bs-abstract` to depend on, but at least if people want to try out the latest Bucklescript, they can point Relude at this branch for now.