### PR TITLE
Ior and ALIGN

### DIFF
--- a/__tests__/Relude_Ior_test.re
+++ b/__tests__/Relude_Ior_test.re
@@ -5,164 +5,161 @@ module NonEmptyList = Relude_NonEmpty.List;
 module Ior = Relude_Ior;
 open Ior;
 
-module Error = {
+module That = {
   type t =
     | Unknown;
-
-  module Type: BsAbstract.Interface.TYPE with type t = t = {
-    type nonrec t = t;
-  };
 };
-module IorE = Ior.WithErrors(NonEmptyList.SemigroupAny, Error.Type);
+
+module IorT = Ior.WithThats(NonEmptyList.SemigroupAny, That);
 
 describe("Ior", () => {
   test("pure", () =>
-    expect(Ior.pure(5)) |> toEqual(IOk(5))
+    expect(Ior.pure(5)) |> toEqual(This(5))
   );
 
   testAll(
     "bind",
     [
-      (Ior.ok(1), IOk(2)),
-      (Ior.error("Warning"), IError("Warning")),
-      (Ior.both(1, "Warning"), IOk(2)),
+      (Ior.this(1), This(2)),
+      (Ior.that("Warning"), That("Warning")),
+      (Ior.both(1, "Warning"), This(2)),
     ],
     ((ior, expected)) =>
-    expect(Ior.bind(ior, a => Ior.ok(a + 1))) |> toEqual(expected)
+    expect(Ior.bind(ior, a => Ior.this(a + 1))) |> toEqual(expected)
   );
 
   testAll(
     "flatMap",
     [
-      (Ior.ok(1), IOk(2)),
-      (Ior.error("Warning"), IError("Warning")),
-      (Ior.both(1, "Warning"), IOk(2)),
+      (Ior.this(1), This(2)),
+      (Ior.that("Warning"), That("Warning")),
+      (Ior.both(1, "Warning"), This(2)),
     ],
     ((ior, expected)) =>
-    expect(Ior.flatMap(a => Ior.ok(a + 1), ior)) |> toEqual(expected)
+    expect(Ior.flatMap(a => Ior.this(a + 1), ior)) |> toEqual(expected)
   );
 
-  test("ok", () =>
-    expect(Ior.ok(5)) |> toEqual(IOk(5))
+  test("this", () =>
+    expect(Ior.this(5)) |> toEqual(This(5))
   );
 
-  test("error", () =>
-    expect(Ior.error(5)) |> toEqual(IError(5))
+  test("that", () =>
+    expect(Ior.that(5)) |> toEqual(That(5))
   );
 
   test("both", () =>
-    expect(Ior.both(5, "Warning")) |> toEqual(IBoth(5, "Warning"))
+    expect(Ior.both(5, "Warning")) |> toEqual(Both(5, "Warning"))
   );
 
   testAll(
-    "isOk",
+    "isThis",
     [
       (Ior.pure(5), true),
-      (Ior.error("Warning"), false),
+      (Ior.that("Warning"), false),
       (Ior.both(5, "Warning"), false),
     ],
     ((actual, expected)) =>
-    expect(Ior.isOk(actual)) |> toEqual(expected)
+    expect(Ior.isThis(actual)) |> toEqual(expected)
   );
 
   testAll(
-    "isError",
+    "isThat",
     [
       (Ior.pure(5), false),
-      (Ior.error("Warning"), true),
+      (Ior.that("Warning"), true),
       (Ior.both(5, "Warning"), false),
     ],
     ((actual, expected)) =>
-    expect(Ior.isError(actual)) |> toEqual(expected)
+    expect(Ior.isThat(actual)) |> toEqual(expected)
   );
 
   testAll(
     "isBoth",
     [
       (Ior.pure(5), false),
-      (Ior.error("Warning"), false),
+      (Ior.that("Warning"), false),
       (Ior.both(5, "Warning"), true),
     ],
     ((actual, expected)) =>
     expect(Ior.isBoth(actual)) |> toEqual(expected)
   );
 
-  test("map IOk", () =>
-    expect(Ior.map(a => a + 2, IOk(1))) |> toEqual(IOk(3))
+  test("map This", () =>
+    expect(Ior.map(a => a + 2, This(1))) |> toEqual(This(3))
   );
 
-  test("map IError", () =>
-    expect(Ior.map(a => a + 2, IError("Warning")))
-    |> toEqual(IError("Warning"))
+  test("map That", () =>
+    expect(Ior.map(a => a + 2, That("Warning")))
+    |> toEqual(That("Warning"))
   );
 
-  test("map IBoth", () =>
-    expect(Ior.map(a => a + 2, IBoth(5, "Warning")))
-    |> toEqual(IBoth(7, "Warning"))
+  test("map Both", () =>
+    expect(Ior.map(a => a + 2, Both(5, "Warning")))
+    |> toEqual(Both(7, "Warning"))
   );
 
-  test("tap IOk", () => {
+  test("tap This", () => {
     let actual = ref(0);
     let _ =
       Ior.tap(
-        ok => actual := ok,
-        _error => actual := (-1),
-        (_ok, _error) => actual := (-2),
-        IOk(1),
+        this => actual := this,
+        _that => actual := (-1),
+        (_this, _that) => actual := (-2),
+        This(1),
       );
 
     expect(actual^) |> toEqual(1);
   });
 
-  test("tap IError", () => {
+  test("tap That", () => {
     let actual = ref(0);
     let _ =
       Ior.tap(
-        _ok => actual := (-1),
-        error => actual := error,
-        (_ok, _error) => actual := (-2),
-        IError(1),
+        _this => actual := (-1),
+        that => actual := that,
+        (_this, _that) => actual := (-2),
+        That(1),
       );
 
     expect(actual^) |> toEqual(1);
   });
 
-  test("tap IBoth", () => {
+  test("tap Both", () => {
     let actual = ref(0);
     let _ =
       Ior.tap(
-        _ok => actual := (-1),
-        _error => actual := (-2),
-        (ok, error) => actual := ok + error,
-        IBoth(1, 2),
+        _this => actual := (-1),
+        _that => actual := (-2),
+        (this, that) => actual := this + that,
+        Both(1, 2),
       );
 
     expect(actual^) |> toEqual(3);
   });
 
   testAll(
-    "tapOk",
-    [(IOk(1), 1), (IError("Warning"), 0), (IBoth(5, "Warning"), 0)],
+    "tapThis",
+    [(This(1), 1), (That("Warning"), 0), (Both(5, "Warning"), 0)],
     ((ior, expected)) => {
       let actual = ref(0);
-      let _ = Ior.tapOk(a => actual := a, ior);
+      let _ = Ior.tapThis(a => actual := a, ior);
       expect(actual^) |> toEqual(expected);
     },
   );
 
   testAll(
-    "tapError",
-    [(IOk(1), 0), (IError(1), 1), (IBoth(1, 2), 0)],
+    "tapThat",
+    [(This(1), 0), (That(1), 1), (Both(1, 2), 0)],
     ((ior, expected)) => {
       let actual = ref(0);
-      let _ = Ior.tapError(a => actual := a, ior);
+      let _ = Ior.tapThat(a => actual := a, ior);
       expect(actual^) |> toEqual(expected);
     },
   );
 
   testAll(
     "tapBoth",
-    [(IOk(1), 0), (IError(2), 0), (IBoth(1, 2), 3)],
+    [(This(1), 0), (That(2), 0), (Both(1, 2), 3)],
     ((ior, expected)) => {
       let actual = ref(0);
       let _ = Ior.tapBoth((a, e) => actual := a + e, ior);
@@ -171,121 +168,119 @@ describe("Ior", () => {
   );
 
   testAll(
-    "tapOkOrBothOk",
-    [(IOk(1), 1), (IError(2), 0), (IBoth(1, 2), 1)],
+    "tapThisOrBoth",
+    [(This(1), 1), (That(2), 0), (Both(1, 2), 1)],
     ((ior, expected)) => {
       let actual = ref(0);
-      let _ = Ior.tapOkOrBothOk(a => actual := a, ior);
+      let _ = Ior.tapThisOrBoth(a => actual := a, ior);
       expect(actual^) |> toEqual(expected);
     },
   );
 
   testAll(
-    "tapErrorOrBothError",
-    [(IOk(1), 0), (IError(2), 2), (IBoth(1, 2), 2)],
+    "tapThatOrBoth",
+    [(This(1), 0), (That(2), 2), (Both(1, 2), 2)],
     ((ior, expected)) => {
       let actual = ref(0);
-      let _ = Ior.tapErrorOrBothError(a => actual := a, ior);
+      let _ = Ior.tapThatOrBoth(a => actual := a, ior);
       expect(actual^) |> toEqual(expected);
     },
   );
 
-  test("map2 IOk IOk", () =>
-    expect(Ior.map2((++), (a, b) => a + b, IOk(1), IOk(2)))
-    |> toEqual(IOk(3))
+  test("map2 This This", () =>
+    expect(Ior.map2((++), (a, b) => a + b, This(1), This(2)))
+    |> toEqual(This(3))
   );
 
-  test("map2 IOk IError", () =>
-    expect(Ior.map2((++), (a, b) => a + b, IOk(1), IError("W2")))
-    |> toEqual(IError("W2"))
+  test("map2 This That", () =>
+    expect(Ior.map2((++), (a, b) => a + b, This(1), That("W2")))
+    |> toEqual(That("W2"))
   );
 
-  test("map2 IOk IBoth", () =>
-    expect(Ior.map2((++), (a, b) => a + b, IOk(1), IBoth(2, "W2")))
-    |> toEqual(IBoth(3, "W2"))
+  test("map2 This Both", () =>
+    expect(Ior.map2((++), (a, b) => a + b, This(1), Both(2, "W2")))
+    |> toEqual(Both(3, "W2"))
   );
 
-  test("map2 IError IOk", () =>
-    expect(Ior.map2((++), (a, b) => a + b, IError("W1"), IOk(1)))
-    |> toEqual(IError("W1"))
+  test("map2 That This", () =>
+    expect(Ior.map2((++), (a, b) => a + b, That("W1"), This(1)))
+    |> toEqual(That("W1"))
   );
 
-  test("map2 IError IError", () =>
-    expect(Ior.map2((++), (a, b) => a + b, IError("W1"), IError("W2")))
-    |> toEqual(IError("W1W2"))
+  test("map2 That That", () =>
+    expect(Ior.map2((++), (a, b) => a + b, That("W1"), That("W2")))
+    |> toEqual(That("W1W2"))
   );
 
-  test("map2 IError IBoth", () =>
-    expect(Ior.map2((++), (a, b) => a + b, IError("W1"), IBoth(1, "W2")))
-    |> toEqual(IError("W1W2"))
+  test("map2 That Both", () =>
+    expect(Ior.map2((++), (a, b) => a + b, That("W1"), Both(1, "W2")))
+    |> toEqual(That("W1W2"))
   );
 
-  test("map2 IBoth IOk", () =>
-    expect(Ior.map2((++), (a, b) => a + b, IBoth(1, "W1"), IOk(2)))
-    |> toEqual(IBoth(3, "W1"))
+  test("map2 Both This", () =>
+    expect(Ior.map2((++), (a, b) => a + b, Both(1, "W1"), This(2)))
+    |> toEqual(Both(3, "W1"))
   );
 
-  test("map2 IBoth IError", () =>
-    expect(Ior.map2((++), (a, b) => a + b, IBoth(1, "W1"), IError("W2")))
-    |> toEqual(IError("W1W2"))
+  test("map2 Both That", () =>
+    expect(Ior.map2((++), (a, b) => a + b, Both(1, "W1"), That("W2")))
+    |> toEqual(That("W1W2"))
   );
 
-  test("map2 IBoth IBoth", () =>
+  test("map2 Both Both", () =>
+    expect(Ior.map2((++), (a, b) => a + b, Both(1, "W1"), Both(2, "W2")))
+    |> toEqual(Both(3, "W1W2"))
+  );
+
+  test("map3 This This This", () =>
     expect(
-      Ior.map2((++), (a, b) => a + b, IBoth(1, "W1"), IBoth(2, "W2")),
+      Ior.map3((++), (a, b, c) => a + b + c, This(1), This(2), This(3)),
     )
-    |> toEqual(IBoth(3, "W1W2"))
+    |> toEqual(This(6))
   );
 
-  test("map3 IOk IOk IOk", () =>
-    expect(
-      Ior.map3((++), (a, b, c) => a + b + c, IOk(1), IOk(2), IOk(3)),
-    )
-    |> toEqual(IOk(6))
-  );
-
-  test("map4 IOk IOk IOk IOk", () =>
+  test("map4 This This This This", () =>
     expect(
       Ior.map4(
         (++),
         (a, b, c, d) => a + b + c + d,
-        IOk(1),
-        IOk(2),
-        IOk(3),
-        IOk(4),
+        This(1),
+        This(2),
+        This(3),
+        This(4),
       ),
     )
-    |> toEqual(IOk(10))
+    |> toEqual(This(10))
   );
 
-  test("map5 IOk IOk IOk IOk IOk", () =>
+  test("map5 This This This This This", () =>
     expect(
       Ior.map5(
         (++),
         (a, b, c, d, f) => a + b + c + d + f,
-        IOk(1),
-        IOk(2),
-        IOk(3),
-        IOk(4),
-        IOk(5),
+        This(1),
+        This(2),
+        This(3),
+        This(4),
+        This(5),
       ),
     )
-    |> toEqual(IOk(15))
+    |> toEqual(This(15))
   );
 
-  describe("WithErrors", () => {
+  describe("WithThats", () => {
     test("map", () =>
-      Ior.error(NonEmptyList.pure(Error.Unknown))
-      |> IorE.map(a => a + 1)
+      Ior.that(NonEmptyList.pure(That.Unknown))
+      |> IorT.map(a => a + 1)
       |> expect
-      |> toEqual(IError(NonEmptyList.pure(Error.Unknown)))
+      |> toEqual(That(NonEmptyList.pure(That.Unknown)))
     );
 
     test("apply", () =>
-      Ior.error(NonEmptyList.pure(Error.Unknown))
-      |> IorE.apply(Ior.ok(a => a + 1))
+      Ior.that(NonEmptyList.pure(That.Unknown))
+      |> IorT.apply(Ior.this(a => a + 1))
       |> expect
-      |> toEqual(IError(NonEmptyList.pure(Error.Unknown)))
+      |> toEqual(That(NonEmptyList.pure(That.Unknown)))
     );
   });
 });

--- a/__tests__/Relude_Option_test.re
+++ b/__tests__/Relude_Option_test.re
@@ -139,6 +139,36 @@ describe("Option", () => {
     expect(Option.apply(Some(a => a + 2), Some(1))) |> toEqual(Some(3))
   );
 
+  testAll(
+    "align",
+    [
+      (Some(42), Some("a"), Some(Relude_Ior_Type.Both(42, "a"))),
+      (Some(42), None, Some(Relude_Ior_Type.This(42))),
+      (None, Some("a"), Some(Relude_Ior_Type.That("a"))),
+      (None, None, None),
+    ],
+    ((fa, fb, expected)) => {
+    expect(Option.align(fa, fb)) |> toEqual(expected)
+  });
+
+  testAll(
+    "alignWith",
+    [
+      (Some(42), Some("99"), Some(141)),
+      (Some(42), None, Some(42)),
+      (None, Some("99"), Some(99)),
+      (None, None, None),
+    ],
+    ((fa, fb, expected)) => {
+      let f =
+        fun
+        | Relude_Ior_Type.This(a) => a
+        | Relude_Ior_Type.That(b) => int_of_string(b)
+        | Relude_Ior_Type.Both(a, b) => a + int_of_string(b);
+      expect(Option.alignWith(f, fa, fb)) |> toEqual(expected);
+    },
+  );
+
   test("pure", () =>
     expect(Option.pure(5)) |> toEqual(Some(5))
   );

--- a/__tests__/Relude_Validation_test.re
+++ b/__tests__/Relude_Validation_test.re
@@ -326,6 +326,66 @@ describe("Validation", () => {
        )
   });
 
+  testAll(
+    "alignWithAppendErrors",
+    [
+      (
+        Validation.ok(42),
+        Validation.ok("a"),
+        Validation.ok(Relude_Ior_Type.Both(42, "a")),
+      ),
+      (
+        Validation.ok(42),
+        Validation.error("fail2"),
+        Validation.ok(Relude_Ior_Type.This(42)),
+      ),
+      (
+        Validation.error("fail1"),
+        Validation.ok("a"),
+        Validation.ok(Relude_Ior_Type.That("a")),
+      ),
+      (
+        Validation.error("fail1"),
+        Validation.error("fail2"),
+        Validation.error("fail1fail2"),
+      ),
+    ],
+    ((inputA, inputB, expected)) => {
+      let actual =
+        Validation.alignWithAppendErrors((a, b) => a ++ b, inputA, inputB);
+      expect(actual) |> toEqual(expected);
+    },
+  );
+
+  testAll(
+    "alignWithWithAppendErrors",
+    [
+      (Validation.ok(42), Validation.ok("99"), Validation.ok(141)),
+      (Validation.ok(42), Validation.error("fail2"), Validation.ok(42)),
+      (Validation.error("fail1"), Validation.ok("99"), Validation.ok(99)),
+      (
+        Validation.error("fail1"),
+        Validation.error("fail2"),
+        Validation.error("fail1fail2"),
+      ),
+    ],
+    ((inputA, inputB, expected)) => {
+      let f =
+        fun
+        | Relude_Ior_Type.This(a) => a
+        | Relude_Ior_Type.That(b) => int_of_string(b)
+        | Relude_Ior_Type.Both(a, b) => a + int_of_string(b);
+      let actual =
+        Validation.alignWithWithAppendErrors(
+          (a, b) => a ++ b,
+          f,
+          inputA,
+          inputB,
+        );
+      expect(actual) |> toEqual(expected);
+    },
+  );
+
   test("makeWithValidation success", () => {
     let validation = Person.makeWithValidation("Andy", 55, "English");
     let expected: Person.t = {name: "Andy", age: 55, language: "English"};

--- a/src/Relude_Interface.re
+++ b/src/Relude_Interface.re
@@ -29,7 +29,6 @@ module type NATURAL_TRANSFORMATION = {
   type f('a);
   type g('a);
   let f: f('a) => g('a);
-
   // Another encoding would be using FUNCTOR modules here, but the f('a)/g('a) version seems easier to work with inline,
   // and we've already gone off the deep end, so let's not make it any more clunky.
   //module F: BsAbstract.Interface.FUNCTOR;
@@ -110,6 +109,29 @@ module type ISO_LIST = {
   type t('a);
   let fromList: list('a) => t('a);
   let toList: t('a) => list('a);
+};
+
+/**
+ * Module type signature for Ior-based zipping and unzipping
+ */
+module type SEMIALIGN = {
+  include BsAbstract.Interface.FUNCTOR;
+  let align: (t('a), t('b)) => t(Relude_Ior_Type.t('a, 'b));
+  let alignWith: (Relude_Ior_Type.t('a, 'b) => 'c, t('a), t('b)) => t('c);
+};
+
+/**
+ * Module type signature for an extension of ALIGN that adds an empty `nil` value.
+ *
+ * Note that this has a parallel to the applicative typeclasses:
+ * 
+ * APPLY/APPLICATIVE/TRAVERSABLE
+ * 
+ * SEMIALIGN/ALIGN/CROSSWALK (or maybe ALIGNABLE?)
+ */
+module type ALIGN = {
+  include SEMIALIGN;
+  let nil: t('a);
 };
 
 /**

--- a/src/Relude_Ior.re
+++ b/src/Relude_Ior.re
@@ -5,191 +5,207 @@ during applicative validation.
 E.g. if you are doing applicative validation to construct a User model, you could parse a phone number and
 allow it, but collect a warning that certain phone number formats are deprecated.
 */
-type t('a, 'e) =
-  | IOk('a)
-  | IError('e)
-  | IBoth('a, 'e);
+type t('a, 'b) =
+  | This('a)
+  | That('b)
+  | Both('a, 'b);
 
 /**
- * Constructs an IOk value with the given success value
+ * Constructs a This value with the given success value
  */
-let ok: 'a => t('a, 'e) = a => IOk(a);
+let this: 'a => t('a, 'b) = a => This(a);
 
 /**
- * Constructs an IError value with the given error value
+ * Constructs an That value with the given that value
  */
-let error: 'e => t('a, 'e) = e => IError(e);
+let that: 'b => t('a, 'b) = b => That(b);
 
 /**
- * Constructs an IBoth value with the given success and error values
+ * Constructs an Both value with the given this and that values
  */
-let both: ('a, 'e) => t('a, 'e) = (a, e) => IBoth(a, e);
+let both: ('a, 'b) => t('a, 'b) = (a, b) => Both(a, b);
 
 /**
- * Indicates if the Ior is IOk with any value
+ * Indicates if the Ior is This with any value
  */
-let isOk: 'a 'e. t('a, 'e) => bool =
+let isThis: 'a 'b. t('a, 'b) => bool =
   fun
-  | IOk(_) => true
-  | IError(_) => false
-  | IBoth(_, _) => false;
+  | This(_) => true
+  | That(_) => false
+  | Both(_, _) => false;
 
 /**
- * Indicates if the Ior is IError with any value
+ * Indicates if the Ior is That with any value
  */
-let isError: 'a 'e. t('a, 'e) => bool =
+let isThat: 'a 'b. t('a, 'b) => bool =
   fun
-  | IOk(_) => false
-  | IError(_) => true
-  | IBoth(_, _) => false;
+  | This(_) => false
+  | That(_) => true
+  | Both(_, _) => false;
 
 /**
- * Indicates if the Ior is IBoth with any values
+ * Indicates if the Ior is Both with any values
  */
-let isBoth: 'a 'e. t('a, 'e) => bool =
+let isBoth: 'a 'b. t('a, 'b) => bool =
   fun
-  | IOk(_) => false
-  | IError(_) => false
-  | IBoth(_, _) => true;
+  | This(_) => false
+  | That(_) => false
+  | Both(_, _) => true;
 
 /**
- * Maps a pure function over the success channel of the Ior
+ * Maps a pure function over the `this` channel of the Ior
  */
-let map: 'a 'b 'e. ('a => 'b, t('a, 'e)) => t('b, 'e) =
+let mapThis: 'a 'b 'c. ('a => 'c, t('a, 'b)) => t('c, 'b) =
   (f, fa) =>
     switch (fa) {
-    | IError(_) as e => e
-    | IOk(a) => IOk(f(a))
-    | IBoth(a, e) => IBoth(f(a), e)
+    | That(_) as e => e
+    | This(a) => This(f(a))
+    | Both(a, b) => Both(f(a), b)
     };
 
 /**
- * Applies a side effect function if the value is IOk, IError, or IBoth
+ * Alias for `mapThis`
+ */
+let map = mapThis;
+
+/**
+ * Maps a pure function over the `that` channel of the Ior
+ */
+let mapThat: 'a 'b 'c. ('b => 'c, t('a, 'b)) => t('a, 'c) =
+  (f, fa) =>
+    switch (fa) {
+    | This(_) as a => a
+    | That(b) => That(f(b))
+    | Both(a, b) => Both(a, f(b))
+    };
+
+/**
+ * Applies a side effect function if the value is This, That, or Both
  */
 let tap:
-  'a 'e.
-  ('a => unit, 'e => unit, ('a, 'e) => unit, t('a, 'e)) => t('a, 'e)
+  'a 'b.
+  ('a => unit, 'b => unit, ('a, 'b) => unit, t('a, 'b)) => t('a, 'b)
  =
-  (ifOk, ifError, ifBoth, fa) =>
+  (ifThis, ifThat, ifBoth, fa) =>
     switch (fa) {
-    | IOk(a) =>
-      ifOk(a);
+    | This(a) =>
+      ifThis(a);
       fa;
-    | IError(e) =>
-      ifError(e);
+    | That(e) =>
+      ifThat(e);
       fa;
-    | IBoth(a, e) =>
+    | Both(a, e) =>
       ifBoth(a, e);
       fa;
     };
 
 /**
- * Applies a side-effect function if the value is IOk
+ * Applies a side-effect function if the value is This
  */
-let tapOk: 'a 'e. ('a => unit, t('a, 'e)) => t('a, 'e) =
-  (ifOk, fa) =>
+let tapThis: 'a 'b. ('a => unit, t('a, 'b)) => t('a, 'b) =
+  (ifThis, fa) =>
     switch (fa) {
-    | IOk(a) =>
-      ifOk(a);
+    | This(a) =>
+      ifThis(a);
       fa;
-    | IError(_) => fa
-    | IBoth(_, _) => fa
+    | That(_) => fa
+    | Both(_, _) => fa
     };
 
 /**
- * Applies a side-effect function if the value is IError
+ * Applies a side-effect function if the value is That
  */
-let tapError: 'a 'e. ('e => unit, t('a, 'e)) => t('a, 'e) =
-  (ifError, fa) =>
+let tapThat: 'a 'b. ('b => unit, t('a, 'b)) => t('a, 'b) =
+  (ifThat, fa) =>
     switch (fa) {
-    | IOk(_) => fa
-    | IError(e) =>
-      ifError(e);
+    | This(_) => fa
+    | That(e) =>
+      ifThat(e);
       fa;
-    | IBoth(_, _) => fa
+    | Both(_, _) => fa
     };
 
 /**
- * Applies a side-effect function if the value is IBoth
+ * Applies a side-effect function if the value is Both
  */
-let tapBoth: 'a 'e. (('a, 'e) => unit, t('a, 'e)) => t('a, 'e) =
+let tapBoth: 'a 'b. (('a, 'b) => unit, t('a, 'b)) => t('a, 'b) =
   (ifBoth, fa) =>
     switch (fa) {
-    | IOk(_) => fa
-    | IError(_) => fa
-    | IBoth(a, e) =>
+    | This(_) => fa
+    | That(_) => fa
+    | Both(a, e) =>
       ifBoth(a, e);
       fa;
     };
 
 /**
- * Applies a side effect function to the 'a value in an IOk or an IBoth
+ * Applies a side effect function to the 'a value in an This or an Both
  */
-let tapOkOrBothOk: 'a 'e. ('a => unit, t('a, 'e)) => t('a, 'e) =
-  (ifValue, fa) =>
+let tapThisOrBoth: 'a 'b. ('a => unit, t('a, 'b)) => t('a, 'b) =
+  (ifThis, fa) =>
     switch (fa) {
-    | IOk(a) =>
-      ifValue(a);
+    | This(a) =>
+      ifThis(a);
       fa;
-    | IError(_) => fa
-    | IBoth(a, _) =>
-      ifValue(a);
+    | That(_) => fa
+    | Both(a, _) =>
+      ifThis(a);
       fa;
     };
 
 /**
- * Applies a side effect function to the 'e value in an IError or an IBoth
+ * Applies a side effect function to the 'b value in an That or an Both
  */
-let tapErrorOrBothError: 'a 'e. ('e => unit, t('a, 'e)) => t('a, 'e) =
-  (ifError, fa) =>
+let tapThatOrBoth: 'a 'b. ('b => unit, t('a, 'b)) => t('a, 'b) =
+  (ifThat, fa) =>
     switch (fa) {
-    | IOk(_) => fa
-    | IError(e) =>
-      ifError(e);
+    | This(_) => fa
+    | That(e) =>
+      ifThat(e);
       fa;
-    | IBoth(_, e) =>
-      ifError(e);
+    | Both(_, e) =>
+      ifThat(e);
       fa;
     };
 
 /**
- * Applies a wrapped function to the success channel, with error collecting semantics.
+ * Applies a wrapped function to the success channel, with `that` collecting semantics.
  */
-let applyWithAppendErrors:
-  (('e, 'e) => 'e, t('a => 'b, 'e), t('a, 'e)) => t('b, 'e) =
-  (appendErrors, ff, fa) =>
+let applyWithAppendThats:
+  (('b, 'b) => 'b, t('a => 'c, 'b), t('a, 'b)) => t('c, 'b) =
+  (appendThats, ff, fa) =>
     switch (ff, fa) {
-    | (IOk(f), IOk(a)) => IOk(f(a))
-    | (IOk(_), IError(e)) => IError(e)
-    | (IOk(f), IBoth(a, e)) => IBoth(f(a), e)
-    | (IError(e), IOk(_)) => IError(e)
-    | (IError(e1), IError(e2)) => IError(appendErrors(e1, e2))
-    | (IError(e1), IBoth(_, e2)) => IError(appendErrors(e1, e2))
-    | (IBoth(f, e1), IOk(a)) => IBoth(f(a), e1)
-    | (IBoth(_, e1), IError(e2)) => IError(appendErrors(e1, e2))
-    | (IBoth(f, e1), IBoth(a, e2)) => IBoth(f(a), appendErrors(e1, e2))
+    | (This(f), This(a)) => This(f(a))
+    | (This(_), That(b)) => That(b)
+    | (This(f), Both(a, b)) => Both(f(a), b)
+    | (That(b), This(_)) => That(b)
+    | (That(b1), That(b2)) => That(appendThats(b1, b2))
+    | (That(b1), Both(_, b2)) => That(appendThats(b1, b2))
+    | (Both(f, b1), This(a)) => Both(f(a), b1)
+    | (Both(_, b1), That(b2)) => That(appendThats(b1, b2))
+    | (Both(f, b1), Both(a, b2)) => Both(f(a), appendThats(b1, b2))
     };
 
 /**
- * Lifts a pure value into an IOk
+ * Lifts a pure value into an This
  */
-let pure: 'a => t('a, 'e) = a => IOk(a);
+let pure: 'a 'b. 'a => t('a, 'b) = a => This(a);
 
 /**
  * Applies a monadic function to the success channel of the Ior
  */
-let bind: (t('a, 'e), 'a => t('b, 'e)) => t('b, 'e) =
+let bind: (t('a, 'b), 'a => t('c, 'b)) => t('c, 'b) =
   (fa, f) =>
     switch (fa) {
-    | IOk(a) => f(a)
-    | IError(_) as err => err
-    | IBoth(a, _) => f(a)
+    | This(a) => f(a)
+    | That(_) as that => that
+    | Both(a, _) => f(a)
     };
 
 /**
  * Applies a monadic function to the success channel of the Ior
  */
-let flatMap: ('a => t('b, 'e), t('a, 'e)) => t('b, 'e) =
+let flatMap: ('a => t('c, 'b), t('a, 'b)) => t('c, 'b) =
   (f, fa) => bind(fa, f);
 
 /**
@@ -197,8 +213,8 @@ let flatMap: ('a => t('b, 'e), t('a, 'e)) => t('b, 'e) =
  */
 let map2:
   (('x, 'x) => 'x, ('a, 'b) => 'c, t('a, 'x), t('b, 'x)) => t('c, 'x) =
-  (appendErrors, f, fa, fb) =>
-    applyWithAppendErrors(appendErrors, map(f, fa), fb);
+  (appendThats, f, fa, fb) =>
+    applyWithAppendThats(appendThats, map(f, fa), fb);
 
 /**
  * Maps the results of 3 Ior values using the given function
@@ -206,8 +222,8 @@ let map2:
 let map3:
   (('x, 'x) => 'x, ('a, 'b, 'c) => 'd, t('a, 'x), t('b, 'x), t('c, 'x)) =>
   t('d, 'x) =
-  (appendErrors, f, fa, fb, fc) =>
-    applyWithAppendErrors(appendErrors, map2(appendErrors, f, fa, fb), fc);
+  (appendThats, f, fa, fb, fc) =>
+    applyWithAppendThats(appendThats, map2(appendThats, f, fa, fb), fc);
 
 /**
  * Maps the results of 4 Ior values using the given function
@@ -222,12 +238,8 @@ let map4:
     t('d, 'x)
   ) =>
   t('e, 'x) =
-  (appendErrors, f, fa, fb, fc, fd) =>
-    applyWithAppendErrors(
-      appendErrors,
-      map3(appendErrors, f, fa, fb, fc),
-      fd,
-    );
+  (appendThats, f, fa, fb, fc, fd) =>
+    applyWithAppendThats(appendThats, map3(appendThats, f, fa, fb, fc), fd);
 
 /**
  * Maps the results of 5 Ior values using the given function
@@ -243,41 +255,41 @@ let map5:
     t('e, 'x)
   ) =>
   t('f, 'x) =
-  (appendErrors, f, fa, fb, fc, fd, fe) =>
-    applyWithAppendErrors(
-      appendErrors,
-      map4(appendErrors, f, fa, fb, fc, fd),
+  (appendThats, f, fa, fb, fc, fd, fe) =>
+    applyWithAppendThats(
+      appendThats,
+      map4(appendThats, f, fa, fb, fc, fd),
       fe,
     );
 
 /**
- * Creates a module that locks in the Error TYPE and SEMIGROUP_ANY modules, so
+ * Creates a module that locks in the That TYPE and SEMIGROUP_ANY modules, so
  * that we can implement the typeclass instances for the single-type-parameter typeclasses.
  */
-module WithErrors =
+module WithThats =
        (
-         Errors: BsAbstract.Interface.SEMIGROUP_ANY,
-         Error: BsAbstract.Interface.TYPE,
+         Thats: BsAbstract.Interface.SEMIGROUP_ANY,
+         That: BsAbstract.Interface.TYPE,
        ) => {
   module Functor:
-    BsAbstract.Interface.FUNCTOR with type t('a) = t('a, Errors.t(Error.t)) = {
-    type nonrec t('a) = t('a, Errors.t(Error.t));
+    BsAbstract.Interface.FUNCTOR with type t('a) = t('a, Thats.t(That.t)) = {
+    type nonrec t('a) = t('a, Thats.t(That.t));
     let map = map;
   };
   let map = Functor.map;
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
   module Apply:
-    BsAbstract.Interface.APPLY with type t('a) = t('a, Errors.t(Error.t)) = {
+    BsAbstract.Interface.APPLY with type t('a) = t('a, Thats.t(That.t)) = {
     include Functor;
-    let apply = (ff, fa) => applyWithAppendErrors(Errors.append, ff, fa);
+    let apply = (ff, fa) => applyWithAppendThats(Thats.append, ff, fa);
   };
   let apply = Apply.apply;
   include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
   module Applicative:
     BsAbstract.Interface.APPLICATIVE with
-      type t('a) = t('a, Errors.t(Error.t)) = {
+      type t('a) = t('a, Thats.t(That.t)) = {
     include Apply;
     let pure = pure;
   };
@@ -285,7 +297,7 @@ module WithErrors =
   include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
   module Monad:
-    BsAbstract.Interface.MONAD with type t('a) = t('a, Errors.t(Error.t)) = {
+    BsAbstract.Interface.MONAD with type t('a) = t('a, Thats.t(That.t)) = {
     include Applicative;
     let flat_map = bind;
   };

--- a/src/extensions/Relude_Extensions_Align.re
+++ b/src/extensions/Relude_Extensions_Align.re
@@ -1,0 +1,4 @@
+module AlignExtensions = (A: Relude_Interface.ALIGN) => {
+  // TODO: https://hackage.haskell.org/package/these-0.7.3/docs/Data-Align.html
+  // add some of the specialized align/zip/pad functions here
+};

--- a/src/extensions/Relude_Extensions_Semialign.re
+++ b/src/extensions/Relude_Extensions_Semialign.re
@@ -1,0 +1,4 @@
+module SemialignExtensions = (S: Relude_Interface.SEMIALIGN) => {
+  // TODO: all sorts of stuff
+  // https://hackage.haskell.org/package/semialign-1/docs/Data-Semialign.html#g:1
+};

--- a/src/ior/Relude_Ior_Type.re
+++ b/src/ior/Relude_Ior_Type.re
@@ -1,0 +1,4 @@
+type t('a, 'b) =
+  | This('a)
+  | That('b)
+  | Both('a, 'b);


### PR DESCRIPTION
Closes #188 

### :sparkles: New

#### Reworked `Ior` to remove success/fail semantics, and make it more general purpose

Before this PR, `Ior` had constructors `IOk('a)`, `IError('e)`, and `IBoth('a, 'e)`, but this makes the type more semantic, and less useful for the purposes below. I changed the constructors to `This('a)`, `That('b)`, and `Both('a, 'b)`. This still allows for success/fail semantics (`This` being success, and `That` being failure), but it also allows the type to be used for less-semantic things, like `ALIGN`.

This was a breaking change in `Ior`, but should be easy to fix - just rename `IOk` to `This`, `IError` to `That`, and `IBoth` to `Both` (and other similar name changes).

#### Added some additional functions for `Ior`

- `catThis`, `catThat`, `merge`, `fold`, etc. - see files changed

#### Added `SEMIALIGN` and `ALIGN` typeclasses

```reason
module type SEMIALIGN = {
  include BsAbstract.Interface.FUNCTOR;
  let align: (t('a), t('b)) => t(Relude_Ior_Type.t('a, 'b));
  let alignWith: (Relude_Ior_Type.t('a, 'b) => 'c, t('a), t('b)) => t('c);
};

module type ALIGN = {
  include SEMIALIGN;
  let nil: t('a);
};
```

These are quite similar to the `APPLY` and `APPLICATIVE` typeclasses (and also similar to `SEMIGROUP`/`MONOID`), but they have some interesting uses that you can't get with `APPLY`.

One use of these is that they allow you to compose two effectful values, and will capture a successful result if either or both sides succeed. This is similar to `apply`, but `apply` fails if either side fails, whereas `align` will only fail if both sides fail. The result of `align` is captured in an `Ior`, which has constructors for `This('a)`, `That('b)`, or `Both('a 'b)`.

Another use of these is for zipping values together with the ability to fill in default values. Some of these helper functions have not yet been implemented, but you can see some here: https://hackage.haskell.org/package/semialign-1.1/docs/Data-Align.html#g:1

See Haskell, Scala cats/scalaz, and purescript resources for other info on `Align`.

#### Added `align` and `alignWith` functions to various types

- `Option`
- `Result`
- `Validation`
- `IO`

#### Added `SEMIALIGN` and `ALIGN` instances

- `Option` - `Semialign` and `Align`
- `Result.WithError` - `Semialign` (with fail-fast error semantics)
- `Validation.WithErrors` - `Semialign` (with error collecting semantics)
- `IO.WithError` - `Semialign`

#### Added extension modules for `SEMIALIGN` and `ALIGN`

These are empty placeholders for now, but would likely be the place to add some of the zip helpers

### :rotating_light: Breaking changes

- `Ior` had some renames described above
- `Bifunctor` isntance was moved to the top-level of `IO` rather than being inside the `WithError` module functor
- Possibly a few other minor breaking changes with functions/modules being moved - let me know if anyone runs into problems, and I can help to track them down.
