### PR TITLE
Reverse order of leftSiblings when moving up a TreeZipper

### DIFF
--- a/__tests__/Relude_TreeZipper_test.re
+++ b/__tests__/Relude_TreeZipper_test.re
@@ -662,6 +662,16 @@ describe("TreeZipper", () => {
     expect(actual) |> toEqual(expected);
   });
 
+  test("moveUpToTop maintains structure", () => {
+    let actual =
+      testTree1
+      |> TreeZipper.fromTree
+      |> TreeZipper.moveBy([`Down(2), `Right(2)])
+      |> Option.map(TreeZipper.moveUpToTop);
+    let expected = Some(testTree1 |> TreeZipper.fromTree);
+    expect(actual) |> toEqual(expected);
+  });
+
   test("moveDown", () => {
     let actual = testTree1 |> TreeZipper.fromTree |> TreeZipper.moveDown;
     let expected =

--- a/src/Relude_TreeZipper.re
+++ b/src/Relude_TreeZipper.re
@@ -387,7 +387,7 @@ let moveUp: 'a. t('a) => option(t('a)) =
            rightSiblings: ancestorsHeadRight,
            children:
              Relude_List.flatten([
-               leftSiblings,
+               leftSiblings |> Relude_List.reverse,
                [Relude_Tree.make(focus, children)],
                rightSiblings,
              ]),


### PR DESCRIPTION
Fixes #248 