### PR TITLE
Add `fromIOWithResult` for getting a promise from an IO

### DIFF
--- a/__tests__/js/Relude_Js_Promise_test.re
+++ b/__tests__/js/Relude_Js_Promise_test.re
@@ -53,6 +53,22 @@ describe("Js.Promise", () => {
        )
   );
 
+  testPromise("fromIOWithResult success", () =>
+    Relude_IO.pure(42)
+    |> Relude_Js_Promise.fromIOWithResult
+    |> Js.Promise.then_(actual =>
+         actual |> expect |> toEqual(Ok(42)) |> Js.Promise.resolve
+       )
+  );
+
+  testPromise("fromIOWithResult error", () =>
+    Relude_IO.throw(42)
+    |> Relude_Js_Promise.fromIOWithResult
+    |> Js.Promise.then_(actual =>
+         actual |> expect |> toEqual(Error(42)) |> Js.Promise.resolve
+       )
+  );
+
   testPromise("fromIO success", () =>
     Relude_IO.pure(42)
     |> Relude_Js_Promise.fromIO

--- a/src/js/Relude_Js_Promise.re
+++ b/src/js/Relude_Js_Promise.re
@@ -42,6 +42,21 @@ Converts a `Relude.IO` into a Js.Promise.t.
 
 This function will cause the IO effects to be run.
 
+The promise that is returned will not reject, it will instead have a `Result` as its resolution
+ */
+let fromIOWithResult:
+  'a 'e.
+  Relude_IO.t('a, 'e) => Js.Promise.t(result('a, 'e))
+ =
+  io =>
+    Js.Promise.make((~resolve, ~reject as _) =>
+      io |> Relude_IO.unsafeRunAsync(result => resolve(. result))
+    );
+/**
+Converts a `Relude.IO` into a Js.Promise.t.
+
+This function will cause the IO effects to be run.
+
 The error channel is unsafely coerced into the promise error type, which is
 probably fine, because the Js.Promise error type is opaque.
  */


### PR DESCRIPTION
All of the functions available for converting an IO forced the error into the opaque error channel  which is a little hard to deal with. It would be nice if there was an option to keep the result in the success channel and deal with the error later in a more predictable way.