### PR TITLE
Update to Bastet

### DIFF
--- a/__tests__/Relude_ContT_test.re
+++ b/__tests__/Relude_ContT_test.re
@@ -10,7 +10,7 @@ module Error = {
   type t =
     | Error(string);
 
-  module Type: BsAbstract.Interface.TYPE with type t = t = {
+  module Type: BsBastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };
@@ -18,7 +18,7 @@ module Error = {
 module Unit = {
   type t = unit;
 
-  module Type: BsAbstract.Interface.TYPE with type t = t = {
+  module Type: BsBastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };

--- a/__tests__/Relude_Free_Monad_test.re
+++ b/__tests__/Relude_Free_Monad_test.re
@@ -19,11 +19,11 @@ module StorageF = {
     };
 
   module WithKeyAndValue =
-         (K: BsAbstract.Interface.TYPE, V: BsAbstract.Interface.TYPE) => {
+         (K: BsBastet.Interface.TYPE, V: BsBastet.Interface.TYPE) => {
     type nonrec t('a) = t(K.t, V.t, 'a);
 
     // With the key/value types locked-in, we can define our functor
-    module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+    module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
       type nonrec t('a) = t('a);
       let map = map;
     };

--- a/__tests__/Relude_Function_test.re
+++ b/__tests__/Relude_Function_test.re
@@ -4,7 +4,7 @@ open Expect;
 module Function = Relude_Function;
 module StringArgument = {
   type t = string;
-  module Type: BsAbstract.Interface.TYPE with type t = t = {
+  module Type: BsBastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };

--- a/__tests__/Relude_IO_test.re
+++ b/__tests__/Relude_IO_test.re
@@ -3416,7 +3416,7 @@ let eGet = e => EGet(e);
 let eParse = e => EParse(e);
 let ePrint = e => EPrint(e);
 
-module AppErrorType: BsAbstract.Interface.TYPE with type t = appError = {
+module AppErrorType: BsBastet.Interface.TYPE with type t = appError = {
   type t = appError;
 };
 module IOAppError = IO.WithError(AppErrorType);
@@ -3482,7 +3482,7 @@ describe("IO realish examples", () => {
 
 let testFilePath = FS.testFilePath("Eff_test.txt");
 
-module JsExnType: BsAbstract.Interface.TYPE with type t = Js.Exn.t = {
+module JsExnType: BsBastet.Interface.TYPE with type t = Js.Exn.t = {
   type t = Js.Exn.t;
 };
 module IOJsExn = IO.WithError(JsExnType);

--- a/__tests__/Relude_ResultT_test.re
+++ b/__tests__/Relude_ResultT_test.re
@@ -9,7 +9,7 @@ type error = {message: string};
 
 module Error = {
   type t = error;
-  module Type: BsAbstract.Interface.TYPE with type t = t = {
+  module Type: BsBastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };

--- a/__tests__/Relude_Validation_test.re
+++ b/__tests__/Relude_Validation_test.re
@@ -14,7 +14,7 @@ module Error = {
     | InvalidLanguage(string);
 
   // This is used below to create the Apply instance for the Validation
-  module Type: BsAbstract.Interface.TYPE with type t = t = {
+  module Type: BsBastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };

--- a/__tests__/extensions/Relude_Extensions_Enum_test.re
+++ b/__tests__/extensions/Relude_Extensions_Enum_test.re
@@ -2,7 +2,7 @@ open Jest;
 open Expect;
 open Relude.Globals;
 
-module MonthBase = {
+module Month = {
   type t =
     | Jan
     | Feb
@@ -62,41 +62,51 @@ module MonthBase = {
       let f = toInt1Based;
     });
 
-  let eq = Eq.eq;
-  let compare = Ord.compare;
+  module Bounded: BsBastet.Interface.BOUNDED with type t = t = {
+    include Ord;
+    let bottom = Jan;
+    let top = Dec;
+  };
 
-  let bottom = Jan;
-  let top = Dec;
-  let pred: t => option(t) = month => fromInt1Based(toInt1Based(month) - 1);
-  let succ: t => option(t) = month => fromInt1Based(toInt1Based(month) + 1);
-  let cardinality = 12;
-  let toEnum = fromInt1Based;
+  module Enum: Relude.Interface.ENUM with type t = t = {
+    include Ord;
+    let pred: t => option(t) =
+      month => fromInt1Based(toInt1Based(month) - 1);
 
-  let fromEnum = toInt1Based;
+    let succ: t => option(t) =
+      month => fromInt1Based(toInt1Based(month) + 1);
+  };
 
-  let show: t => string =
-    fun
-    | Jan => "Jan"
-    | Feb => "Feb"
-    | Mar => "Mar"
-    | Apr => "Apr"
-    | May => "May"
-    | Jun => "Jun"
-    | Jul => "Jul"
-    | Aug => "Aug"
-    | Sep => "Sep"
-    | Oct => "Oct"
-    | Nov => "Nov"
-    | Dec => "Dec";
-};
+  module BoundedEnum: Relude.Interface.BOUNDED_ENUM with type t = t = {
+    include Bounded;
+    include (Enum: Relude.Interface.ENUM with type t := t);
+    let cardinality = 12;
+    let toEnum = fromInt1Based;
+    let fromEnum = toInt1Based;
+  };
 
-module Month = {
-  include MonthBase;
-  include Relude.Extensions.Eq.EqExtensions(MonthBase);
-  include Relude.Extensions.Bounded.BoundedExtensions(MonthBase);
-  include Relude.Extensions.Enum.EnumExtensions(MonthBase);
-  include Relude.Extensions.BoundedEnum.BoundedEnumExtensions(MonthBase);
-  include Relude.Extensions.Show.ShowExtensions(MonthBase);
+  module Show: BsBastet.Interface.SHOW with type t = t = {
+    type nonrec t = t;
+    let show: t => string =
+      fun
+      | Jan => "Jan"
+      | Feb => "Feb"
+      | Mar => "Mar"
+      | Apr => "Apr"
+      | May => "May"
+      | Jun => "Jun"
+      | Jul => "Jul"
+      | Aug => "Aug"
+      | Sep => "Sep"
+      | Oct => "Oct"
+      | Nov => "Nov"
+      | Dec => "Dec";
+  };
+  include Relude.Extensions.Eq.EqExtensions(Eq);
+  include Relude.Extensions.Bounded.BoundedExtensions(Bounded);
+  include Relude.Extensions.Enum.EnumExtensions(Enum);
+  include Relude.Extensions.BoundedEnum.BoundedEnumExtensions(BoundedEnum);
+  include Relude.Extensions.Show.ShowExtensions(Show);
 };
 
 open Month;

--- a/__tests__/extensions/Relude_Extensions_Enum_test.re
+++ b/__tests__/extensions/Relude_Extensions_Enum_test.re
@@ -2,7 +2,7 @@ open Jest;
 open Expect;
 open Relude.Globals;
 
-module Month = {
+module MonthBase = {
   type t =
     | Jan
     | Feb
@@ -18,109 +18,85 @@ module Month = {
     | Dec;
 
   let toInt1Based: t => int =
-    month =>
-      switch (month) {
-      | Jan => 1
-      | Feb => 2
-      | Mar => 3
-      | Apr => 4
-      | May => 5
-      | Jun => 6
-      | Jul => 7
-      | Aug => 8
-      | Sep => 9
-      | Oct => 10
-      | Nov => 11
-      | Dec => 12
-      };
+    fun
+    | Jan => 1
+    | Feb => 2
+    | Mar => 3
+    | Apr => 4
+    | May => 5
+    | Jun => 6
+    | Jul => 7
+    | Aug => 8
+    | Sep => 9
+    | Oct => 10
+    | Nov => 11
+    | Dec => 12;
 
   let fromInt1Based: int => option(t) =
-    i =>
-      switch (i) {
-      | 1 => Some(Jan)
-      | 2 => Some(Feb)
-      | 3 => Some(Mar)
-      | 4 => Some(Apr)
-      | 5 => Some(May)
-      | 6 => Some(Jun)
-      | 7 => Some(Jul)
-      | 8 => Some(Aug)
-      | 9 => Some(Sep)
-      | 10 => Some(Oct)
-      | 11 => Some(Nov)
-      | 12 => Some(Dec)
-      | _ => None
-      };
+    fun
+    | 1 => Some(Jan)
+    | 2 => Some(Feb)
+    | 3 => Some(Mar)
+    | 4 => Some(Apr)
+    | 5 => Some(May)
+    | 6 => Some(Jun)
+    | 7 => Some(Jul)
+    | 8 => Some(Aug)
+    | 9 => Some(Sep)
+    | 10 => Some(Oct)
+    | 11 => Some(Nov)
+    | 12 => Some(Dec)
+    | _ => None;
 
-  module Eq: BsAbstract.Interface.EQ with type t = t =
+  module Eq: BsBastet.Interface.EQ with type t = t =
     Int.EqBy({
       type a = t;
       type b = int;
       let f = toInt1Based;
     });
-  include Relude.Extensions.Eq.EqExtensions(Eq);
 
-  module Ord: BsAbstract.Interface.ORD with type t = t =
+  module Ord: BsBastet.Interface.ORD with type t = t =
     Int.OrdBy({
       type a = t;
       type b = int;
       let f = toInt1Based;
     });
-  include Relude.Extensions.Ord.OrdExtensions(Ord);
+
+  let eq = Eq.eq;
+  let compare = Ord.compare;
 
   let bottom = Jan;
-
   let top = Dec;
-
-  module Bounded: BsAbstract.Interface.BOUNDED with type t = t = {
-    include Ord;
-    let bottom = bottom;
-    let top = top;
-  };
-  include Relude.Extensions.Bounded.BoundedExtensions(Bounded);
-
   let pred: t => option(t) = month => fromInt1Based(toInt1Based(month) - 1);
-
   let succ: t => option(t) = month => fromInt1Based(toInt1Based(month) + 1);
+  let cardinality = 12;
+  let toEnum = fromInt1Based;
 
-  module Enum: Relude.Interface.ENUM with type t = t = {
-    include Ord;
-    let pred = pred;
-    let succ = succ;
-  };
-  include Relude.Extensions.Enum.EnumExtensions(Enum);
-
-  module BoundedEnum: Relude.Interface.BOUNDED_ENUM with type t = t = {
-    include Bounded;
-    include (Enum: Relude.Interface.ENUM with type t := t);
-    let cardinality = 12;
-    let toEnum = fromInt1Based;
-    let fromEnum = toInt1Based;
-  };
-  include Relude.Extensions.BoundedEnum.BoundedEnumExtensions(BoundedEnum);
+  let fromEnum = toInt1Based;
 
   let show: t => string =
-    month =>
-      switch (month) {
-      | Jan => "Jan"
-      | Feb => "Feb"
-      | Mar => "Mar"
-      | Apr => "Apr"
-      | May => "May"
-      | Jun => "Jun"
-      | Jul => "Jul"
-      | Aug => "Aug"
-      | Sep => "Sep"
-      | Oct => "Oct"
-      | Nov => "Nov"
-      | Dec => "Dec"
-      };
+    fun
+    | Jan => "Jan"
+    | Feb => "Feb"
+    | Mar => "Mar"
+    | Apr => "Apr"
+    | May => "May"
+    | Jun => "Jun"
+    | Jul => "Jul"
+    | Aug => "Aug"
+    | Sep => "Sep"
+    | Oct => "Oct"
+    | Nov => "Nov"
+    | Dec => "Dec";
+};
 
-  module Show: BsAbstract.Interface.SHOW with type t = t = {
-    type nonrec t = t;
-    let show = show;
-  };
-  include Relude.Extensions.Show.ShowExtensions(Show);
+module Month = {
+  include MonthBase;
+  include Relude.Extensions.Eq.EqExtensions(MonthBase);
+  include Relude.Extensions.Bounded.BoundedExtensions(MonthBase);
+  include Relude.Extensions.Enum.EnumExtensions(MonthBase);
+  include Relude.Extensions.BoundedEnum.BoundedEnumExtensions(MonthBase);
+  include Relude.Extensions.Show.ShowExtensions(MonthBase);
 };
 
 open Month;

--- a/__tests__/extensions/Relude_Extensions_Ord_test.re
+++ b/__tests__/extensions/Relude_Extensions_Ord_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 open Relude.Globals;
-open BsAbstract.Interface;
+open BsBastet.Interface;
 
 module User = {
   type t = {

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -22,7 +22,7 @@
   },
   "suffix": ".bs.js",
   "bs-dependencies": [
-    "bs-abstract"
+    "bs-bastet"
   ],
   "bs-dev-dependencies": [
     "@glennsl/bs-jest"

--- a/docs/Conventions.md
+++ b/docs/Conventions.md
@@ -22,7 +22,7 @@ The main benefits of `|>` is that there is no compiler magic involved (it's an o
 
 See the [typeclasses](typeclasses/Introduction.md) section of the documentation for more information about typeclasses.
 
-[bs-abstract](https://github.com/Risto-Stevcev/bs-abstract) provides many of the typeclass interfaces/signatures (module types) and typeclass instances (implementations).  `Relude` adds the concept of typeclass extensions, which are module functors that you can use to gain access to functions and modules for free by providing an instance of a typeclass signature.
+[bs-bastet](https://github.com/Risto-Stevcev/bs-bastet) provides many of the typeclass interfaces/signatures (module types) and typeclass instances (implementations).  `Relude` adds the concept of typeclass extensions, which are module functors that you can use to gain access to functions and modules for free by providing an instance of a typeclass signature.
 
 ## Extensions
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,15 +24,15 @@ We use peer dependencies in all `Relude` libraries, so that the top-level host l
 
 `Relude` also has many of its own types, which have their own modules, like `Relude.AsyncResult`, `Relude.ReaderT`, etc.
 
-## I'm getting strange errors about types like `array(string)` not being the same as `BsAbstract.Array.Foldable.t`
+## I'm getting strange errors about types like `array(string)` not being the same as `BsBastet.Array.Foldable.t`
 
 If you are trying to compile and get an error like:
 
 ```reasonml
-This has type array(t) but somewhere wanted BsAbstract.Array.Foldable.t(string)`
+This has type array(t) but somewhere wanted BsBastet.Array.Foldable.t(string)`
 ```
 
-you likely need to add `bs-abstract` to your `bs-dependencies` in your `bsconfig.json` file.  This error occurs because BuckleScript is not able to find the types defined in the `BsAbstract` module, so it can't determine that `array(t)` is the same type as `BsAbstract.Array.Foldable.t(string)`.
+you likely need to add `bs-abstract` to your `bs-dependencies` in your `bsconfig.json` file.  This error occurs because BuckleScript is not able to find the types defined in the `BsBastet` module, so it can't determine that `array(t)` is the same type as `BsBastet.Array.Foldable.t(string)`.
 
 Because we are not using .rei interface files, we are not able to abstract these types away for functions that get included into our implementation modules.  (See .rei topic below).
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,12 +2,7 @@
 
 ## Does `Relude` work with native ReasonML/OCaml?
 
-`Relude` does **not** currently support compiling with native ReasonML/OCaml (i.e. via esy nor dune).
-There are some issues open for exploring the possibility of compiling on the native OCaml
-environment.
-
-- [bs-abstract native compilation issue](https://github.com/Risto-Stevcev/bs-abstract/issues/13)
-- [Relude native compilation issue](https://github.com/reazen/relude/issues/133)
+`Relude` does **not** currently support compiling with native ReasonML/OCaml (i.e. via esy nor dune). There is [an issue open](https://github.com/reazen/relude/issues/133) to track progress.
 
 ## Why does `Relude` use peer dependencies for everything, rather than hard production dependencies?
 
@@ -16,7 +11,7 @@ where it made sense for each library to install its own set of dependencies.  Th
 
 However, in a statically-typed language, this doesn't work so well, because the compiler seeks to align the shared types across modules and libraries.  E.g. if two libraries `A` and `B` depend on some module `C`, the compiler will expect to find a single version of the library `C`, so that it can compile `A` and `B` with the same types exposed by `C`.  If this were not the case, it would be difficult for libraries to work together with the same shared types.
 
-We use peer dependencies in all `Relude` libraries, so that the top-level host library or application can ultimately control what single version of each dependency is installed.  E.g. `Relude` depends on `bs-abstract` as a peer dependency, so any library using `Relude` must also explicitly install `bs-abstract`, as it won't be installed automatically with `Relude`.
+We use peer dependencies in all `Relude` libraries, so that the top-level host library or application can ultimately control what single version of each dependency is installed.  E.g. `Relude` depends on `bs-bastet` as a peer dependency, so any library using `Relude` must also explicitly install `bs-bastet`, as it won't be installed automatically with `Relude`.
 
 ## What's the difference between `Relude.Result` and `Belt.Result`, `Relude.Option` and OCaml stdlib `option`, `Relude.Js.Json` and `Js.Json`, etc.?
 
@@ -32,7 +27,7 @@ If you are trying to compile and get an error like:
 This has type array(t) but somewhere wanted BsBastet.Array.Foldable.t(string)`
 ```
 
-you likely need to add `bs-abstract` to your `bs-dependencies` in your `bsconfig.json` file.  This error occurs because BuckleScript is not able to find the types defined in the `BsBastet` module, so it can't determine that `array(t)` is the same type as `BsBastet.Array.Foldable.t(string)`.
+you likely need to add `bs-bastet` to your `bs-dependencies` in your `bsconfig.json` file.  This error occurs because BuckleScript is not able to find the types defined in the `BsBastet` module, so it can't determine that `array(t)` is the same type as `BsBastet.Array.Foldable.t(string)`.
 
 Because we are not using .rei interface files, we are not able to abstract these types away for functions that get included into our implementation modules.  (See .rei topic below).
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -2,25 +2,25 @@
 
 The library is published on [npm](https://www.npmjs.com/package/relude). We try to respect semantic versioning, but while Relude is at version `0.x`, there will likely be breaking changes without corresponding major version bumps.  We will try to document migration paths in release notes when possible.
 
-Note: we currently depend on [bs-abstract](https://github.com/Risto-Stevcev/bs-abstract) as a `peerDependency` (and a `devDependency`).  We use peer dependencies rather than hard dependencies to avoid
+Note: we currently depend on [bs-bastet](https://github.com/Risto-Stevcev/bs-bastet) as a `peerDependency` (and a `devDependency`).  We use peer dependencies rather than hard dependencies to avoid
 the duplicate package issues that surface when using a statically typed language in the npm duplicated package installation methodology.
 
 
-1. Install `bs-abstract` and `relude` via `npm` or `yarn`
+1. Install `bs-bastet` and `relude` via `npm` or `yarn`
 
 ```sh
-> npm install --save bs-abstract relude
+> npm install --save bs-bastet relude
 ```
 
-2. **IMPORTANT**: add `relude` **and** `bs-abstract` to your `bsconfig.json`:
+2. **IMPORTANT**: add `relude` **and** `bs-bastet` to your `bsconfig.json`:
 
 ```json
 {
   "bs-dependencies": [
-    "bs-abstract",
+    "bs-bastet",
     "relude"
   ]
 }
 ```
 
-Without `bs-abstract` in your `bs-dependencies`, some things may fail to compile - see the [FAQ](FAQ.md) for more information.
+Without `bs-bastet` in your `bs-dependencies`, some things may fail to compile - see the [FAQ](FAQ.md) for more information.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -22,7 +22,7 @@ Also, building our own standard library allows us to build out a set of addition
 
 ## Typeclass module types (interfaces)
 
-`Relude` uses many of the typeclass interface definitions and implementations provided by `bs-abstract`, while also adding some of it's own typeclasses.  Using the typeclass module types from [BsAbstract.Interface](https://github.com/Risto-Stevcev/bs-abstract/blob/master/src/interfaces/Interface.re) allows us to gain compatibility with any other libraries which happen to use the same typeclass signatures "for free."  E.g. if something implements a `MONAD` in another library, it should be compatible with any of the utiltiies provided by `Relude`, which use the `MONAD` module type.
+`Relude` uses many of the typeclass interface definitions and implementations provided by `bs-bastet`, while also adding some of it's own typeclasses.  Using the typeclass module types from [BsBastet.Interface](https://github.com/Risto-Stevcev/bastet/blob/master/bastet/src/Interface.re) allows us to gain compatibility with any other libraries which happen to use the same typeclass signatures "for free."  E.g. if something implements a `MONAD` in another library, it should be compatible with any of the utiltiies provided by `Relude`, which use the `MONAD` module type.
 
 ## Typeclass modules (instances or implementations)
 
@@ -30,7 +30,7 @@ Also, building our own standard library allows us to build out a set of addition
 
 ## Extensions and infix operators
 
-Using typeclass-style abstractions allows us to provide a ton of extra functionality "for free" for many modules.  For example, for any module that has an implementation of the module type `BsAbstract.Interface.MONAD`, we can `include` a wide variety of extension functions and infix operators for free for that module, all implemented consistently and predictably.  If you've ever found yourself implementing `map2`, `flatten`, `length`, `toArray`, etc. for your types, it's likely that you could instead get these functions for free by implementing the corresponding typeclass.
+Using typeclass-style abstractions allows us to provide a ton of extra functionality "for free" for many modules.  For example, for any module that has an implementation of the module type `BsBastet.Interface.MONAD`, we can `include` a wide variety of extension functions and infix operators for free for that module, all implemented consistently and predictably.  If you've ever found yourself implementing `map2`, `flatten`, `length`, `toArray`, etc. for your types, it's likely that you could instead get these functions for free by implementing the corresponding typeclass.
 
 ## IO
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -4,7 +4,7 @@
 
 `Relude` currently works with BuckleScript/ReasonML, so the main focus has been on JavaScript-based platforms, like the browser or Node.js.  We would like to one day support native OCaml/ReasonML native, but we are not there yet.
 
-The core typeclass interfaces used in `Relude` come from the library [bs-abstract](https://github.com/Risto-Stevcev/bs-abstract).
+The core typeclass interfaces used in `Relude` come from the library [bs-bastet](https://github.com/Risto-Stevcev/bs-bastet).
 
 ## Opinions
 
@@ -26,7 +26,7 @@ Also, building our own standard library allows us to build out a set of addition
 
 ## Typeclass modules (instances or implementations)
 
-`Relude` also uses many of the actual typeclass instances (or implementations) provided by `bs-abstract`, while also providing some of our own.
+`Relude` also uses many of the actual typeclass instances (or implementations) provided by `bs-bastet`, while also providing some of our own.
 
 ## Extensions and infix operators
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ found in most modern pure functional languages, but our goal is to make the
 library as easy-to-use as a library like [Lodash](https://lodash.com/docs)
 for those who don't know or care about the underlying abstractions. This is
 made possible by OCaml's module system and the foundational work that has
-gone into [bs-abstract](https://github.com/Risto-Stevcev/bs-abstract), on
+gone into [bs-bastet](https://github.com/Risto-Stevcev/bs-bastet), on
 which much of Relude is based.
 
 The API of Relude is inspired by [PureScript's Prelude](https://pursuit.purescript.org/packages/purescript-prelude), as well as other FP ecosystems including Scala, Haskell, and Elm.

--- a/docs/typeclasses/Introduction.md
+++ b/docs/typeclasses/Introduction.md
@@ -2,12 +2,7 @@
 
 ## Overview
 
-This guide will not attempt to fully explain what typeclasses and typeclass instances are, and how they fit into functional programming, but it will try to explain how typeclasses are implemented in [bs-abstract](https://github.com/Risto-Stevcev) and `Relude`.  Also, the descriptions here are meant to help readers gain intuition, and are not intended to be 100% rigorously correct.  There are plenty of other resources on these topics which can be sought out for further reading.
-
-## Typeclasss in Relude
-
-- [Alt](Alt.md)
-- [Alternative](Alt.md)
+This guide will not attempt to fully explain what typeclasses and typeclass instances are, and how they fit into functional programming, but it will try to explain how typeclasses are implemented in [bs-bastet](https://github.com/Risto-Stevcev/bs-bastet) and `Relude`.  Also, the descriptions here are meant to help readers gain intuition, and are not intended to be 100% rigorously correct.  There are plenty of other resources on these topics which can be sought out for further reading.
 
 ## What is a typeclass?
 
@@ -23,7 +18,7 @@ One big downsides of OCaml compared to Haskell/PureScript/Scala is the lack of i
 
 Also, the lack of modular implicits and the related lack of [ad-hoc polymorphism](https://en.wikipedia.org/wiki/Ad_hoc_polymorphism) are a few of the reasons why Reason/OCaml have to have different operators for operating on `int` and `float` values.  (They don't have to have different operators, but they do by default so they can both exist "in scope" at the same time.)  These same reasons are also why you can't use the conventional map `<$>`, bind/flatMap `>>=`, and other infix operators freely on different types in OCaml code without locally scoping the operators.
 
-One of Relude's design goals is to provide as many of the most commonly used typeclass instances for the types and combinations of types you might encounter in most applications.  However, we do not attempt to hide the underlying machinery of bs-abstract, so you are free to define your own typeclasses and typeclass instances, and use them interchangably with the rest of the Relude modules.
+One of Relude's design goals is to provide as many of the most commonly used typeclass instances for the types and combinations of types you might encounter in most applications.  However, we do not attempt to hide the underlying machinery of bs-bastet, so you are free to define your own typeclasses and typeclass instances, and use them interchangably with the rest of the Relude modules.
 
 ## Verifying typeclass laws
 

--- a/docs/typeclasses/Show.md
+++ b/docs/typeclasses/Show.md
@@ -6,7 +6,7 @@ It might seem clunky at first to have to define or derive `Show` for all your ty
 
 ## Show typeclass (module type)
 
-Note: bs-abstract uses a convention of all-caps for the core typeclass module types.
+Note: bs-bastet uses a convention of all-caps for the core typeclass module types.
 
 ```reason
 module type SHOW = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -827,6 +827,11 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bisect_ppx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bisect_ppx/-/bisect_ppx-2.1.0.tgz",
+      "integrity": "sha512-wFw+BwOExrX2MbtlNlHY5gNDw8Wsd+aL5ykRdN904aGLrVfuV6YUf1S0+X/4khA8GhibgqC7pLazW4/IvxgPIw=="
+    },
     "boxen": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
@@ -905,16 +910,25 @@
         }
       }
     },
-    "bs-abstract": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bs-abstract/-/bs-abstract-1.0.0.tgz",
-      "integrity": "sha512-RldrJAr9N0n/Sr20PCSORztmKpRBw6Jbi7EJFsERZlmQ805/flCj9FMfMza4uUxLISAFSSEhIYs97mwt2X6I+w==",
-      "dev": true
+    "bs-bastet": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bs-bastet/-/bs-bastet-1.2.3.tgz",
+      "integrity": "sha512-CszRJi1EvDwOfPThn1ePvLJDVttMB4C6c8X3uYUOWiBhyPtJlDjTNhArDxIyVKTKQOeCZcOfzBbqRf185xCdSQ==",
+      "dev": true,
+      "requires": {
+        "bs-stdlib-shims": "^0.1.0"
+      }
     },
     "bs-platform": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.1.1.tgz",
-      "integrity": "sha512-ckZHR3J+yxyEKXOBHX8+hfzWG2XX5BxhQ4Iw9lulHFGYdAm9Ep9LgKkIah7G6RYADLmVfTxFE48igvY3kkkl+g==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.2.2.tgz",
+      "integrity": "sha512-PWcFfN+jCTtT/rMaHDhKh+W9RUTpaRunmSF9vbLYcrJbpgCNW6aFKAY33u0P3mLxwuhshN3b4FxqGUBPj6exZQ==",
+      "dev": true
+    },
+    "bs-stdlib-shims": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bs-stdlib-shims/-/bs-stdlib-shims-0.1.0.tgz",
+      "integrity": "sha512-CszWow8iXOKgmzNCc5dR3kERaqzIp3f4nbV7lJF5vS9BHm70GqLlu7OBE/VCPKZ5noG1VtJAIVqIdLFqUdIRUQ==",
       "dev": true
     },
     "bser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,30 +5,32 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/core": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.5.tgz",
-      "integrity": "sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.4",
-        "@babel/helpers": "^7.7.4",
-        "@babel/parser": "^7.7.5",
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
-        "@babel/types": "^7.7.4",
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.0",
+        "@babel/parser": "^7.9.0",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "json5": "^2.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
         "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
@@ -59,12 +61,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-      "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+      "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4",
+        "@babel/types": "^7.9.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -79,100 +81,179 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-      "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.7.4",
-        "@babel/template": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-      "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+      "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+      "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/template": "^7.8.6",
+        "@babel/types": "^7.9.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
       "dev": true
     },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-      "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+    "@babel/helper-replace-supers": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.6"
       }
     },
-    "@babel/helpers": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
-      "integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+    "@babel/helper-simple-access": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+      "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-      "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
       "dev": true
     },
-    "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
-      "integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/template": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-      "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6"
       }
     },
     "@babel/traverse": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-      "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+      "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.4",
-        "@babel/helper-function-name": "^7.7.4",
-        "@babel/helper-split-export-declaration": "^7.7.4",
-        "@babel/parser": "^7.7.4",
-        "@babel/types": "^7.7.4",
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.9.0",
+        "@babel/types": "^7.9.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -196,20 +277,26 @@
       }
     },
     "@babel/types": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+      "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
+        "@babel/helper-validator-identifier": "^7.9.0",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
     "@cnakazawa/watch": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
-      "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+      "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
       "dev": true,
       "requires": {
         "exec-sh": "^0.3.2",
@@ -217,180 +304,615 @@
       }
     },
     "@glennsl/bs-jest": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@glennsl/bs-jest/-/bs-jest-0.4.9.tgz",
-      "integrity": "sha512-WAqXMcI6WL7JVvGdakBr1tcw8BYWXHrOZfuA1myMkFggzAv24H/OEwyqaU7x+yXd4cJaBUY8v3SjQ3Pnk/zqsg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@glennsl/bs-jest/-/bs-jest-0.5.1.tgz",
+      "integrity": "sha512-+yhWn6uxFt+k61xcWz/xnLC3ticZR5m2d2++a7vXIq2qxiktegBc3ZD/5nvKU8ciFnsHEOoyIzBzoZH2oRGdkw==",
       "dev": true,
       "requires": {
-        "jest": "^24.3.1"
+        "jest": "^25.1.0"
       }
     },
-    "@jest/console": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
-      "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
       "dev": true,
       "requires": {
-        "@jest/source-map": "^24.9.0",
-        "chalk": "^2.0.1",
-        "slash": "^2.0.0"
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
+    },
+    "@jest/console": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.2.3.tgz",
+      "integrity": "sha512-k+37B1aSvOt9tKHWbZZSOy1jdgzesB0bj96igCVUG1nAH1W5EoUfgc5EXbBVU08KSLvkVdWopLXaO3xfVGlxtQ==",
+      "dev": true,
+      "requires": {
+        "@jest/source-map": "^25.2.1",
+        "chalk": "^3.0.0",
+        "jest-util": "^25.2.3",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/core": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
-      "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-25.2.4.tgz",
+      "integrity": "sha512-WcWYShl0Bqfcb32oXtjwbiR78D/djhMdJW+ulp4/bmHgeODcsieqUJfUH+kEv8M7VNV77E6jds5aA+WuGh1nmg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.7.1",
-        "@jest/reporters": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/transform": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
+        "@jest/console": "^25.2.3",
+        "@jest/reporters": "^25.2.4",
+        "@jest/test-result": "^25.2.4",
+        "@jest/transform": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
         "exit": "^0.1.2",
-        "graceful-fs": "^4.1.15",
-        "jest-changed-files": "^24.9.0",
-        "jest-config": "^24.9.0",
-        "jest-haste-map": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.9.0",
-        "jest-resolve-dependencies": "^24.9.0",
-        "jest-runner": "^24.9.0",
-        "jest-runtime": "^24.9.0",
-        "jest-snapshot": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-validate": "^24.9.0",
-        "jest-watcher": "^24.9.0",
-        "micromatch": "^3.1.10",
-        "p-each-series": "^1.0.0",
-        "realpath-native": "^1.1.0",
-        "rimraf": "^2.5.4",
-        "slash": "^2.0.0",
-        "strip-ansi": "^5.0.0"
+        "graceful-fs": "^4.2.3",
+        "jest-changed-files": "^25.2.3",
+        "jest-config": "^25.2.4",
+        "jest-haste-map": "^25.2.3",
+        "jest-message-util": "^25.2.4",
+        "jest-regex-util": "^25.2.1",
+        "jest-resolve": "^25.2.3",
+        "jest-resolve-dependencies": "^25.2.4",
+        "jest-runner": "^25.2.4",
+        "jest-runtime": "^25.2.4",
+        "jest-snapshot": "^25.2.4",
+        "jest-util": "^25.2.3",
+        "jest-validate": "^25.2.3",
+        "jest-watcher": "^25.2.4",
+        "micromatch": "^4.0.2",
+        "p-each-series": "^2.1.0",
+        "realpath-native": "^2.0.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "@jest/environment": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
-      "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.2.4.tgz",
+      "integrity": "sha512-wA4xlhD19/gukkDpJ5HQsTle0pgnzI5qMFEjw267lpTDC8d9N7Ihqr5pI+l0p8Qn1SQhai+glSqxrGdzKy4jxw==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^24.9.0",
-        "@jest/transform": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "jest-mock": "^24.9.0"
+        "@jest/fake-timers": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "jest-mock": "^25.2.3"
       }
     },
     "@jest/fake-timers": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
-      "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.2.4.tgz",
+      "integrity": "sha512-oC1TJiwfMcBttVN7Wz+VZnqEAgYTiEMu0QLOXpypR89nab0uCB31zm/QeBZddhSstn20qe3yqOXygp6OwvKT/Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-mock": "^24.9.0"
+        "@jest/types": "^25.2.3",
+        "jest-message-util": "^25.2.4",
+        "jest-mock": "^25.2.3",
+        "jest-util": "^25.2.3",
+        "lolex": "^5.0.0"
       }
     },
     "@jest/reporters": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
-      "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.2.4.tgz",
+      "integrity": "sha512-VHbLxM03jCc+bTLOluW/IqHR2G0Cl0iATwIQbuZtIUast8IXO4fD0oy4jpVGpG5b20S6REA8U3BaQoCW/CeVNQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/transform": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^25.2.3",
+        "@jest/test-result": "^25.2.4",
+        "@jest/transform": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "chalk": "^3.0.0",
+        "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.2",
-        "istanbul-lib-coverage": "^2.0.2",
-        "istanbul-lib-instrument": "^3.0.1",
-        "istanbul-lib-report": "^2.0.4",
-        "istanbul-lib-source-maps": "^3.0.1",
-        "istanbul-reports": "^2.2.6",
-        "jest-haste-map": "^24.9.0",
-        "jest-resolve": "^24.9.0",
-        "jest-runtime": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-worker": "^24.6.0",
-        "node-notifier": "^5.4.2",
-        "slash": "^2.0.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.0",
+        "jest-haste-map": "^25.2.3",
+        "jest-resolve": "^25.2.3",
+        "jest-util": "^25.2.3",
+        "jest-worker": "^25.2.1",
+        "node-notifier": "^6.0.0",
+        "slash": "^3.0.0",
         "source-map": "^0.6.0",
-        "string-length": "^2.0.0"
+        "string-length": "^3.1.0",
+        "terminal-link": "^2.0.0",
+        "v8-to-istanbul": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/source-map": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
-      "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.2.1.tgz",
+      "integrity": "sha512-PgScGJm1U27+9Te/cxP4oUFqJ2PX6NhBL2a6unQ7yafCgs8k02c0LSyjSIx/ao0AwcAdCczfAPDf5lJ7zoB/7A==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
-        "graceful-fs": "^4.1.15",
+        "graceful-fs": "^4.2.3",
         "source-map": "^0.6.0"
       }
     },
     "@jest/test-result": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
-      "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.2.4.tgz",
+      "integrity": "sha512-AI7eUy+q2lVhFnaibDFg68NGkrxVWZdD6KBr9Hm6EvN0oAe7GxpEwEavgPfNHQjU2mi6g+NsFn/6QPgTUwM1qg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "@types/istanbul-lib-coverage": "^2.0.0"
+        "@jest/console": "^25.2.3",
+        "@jest/transform": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
-      "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.2.4.tgz",
+      "integrity": "sha512-TEZm/Rkd6YgskdpTJdYLBtu6Gc11tfWPuSpatq0duH77ekjU8dpqX2zkPdY/ayuHxztV5LTJoV5BLtI9mZfXew==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^24.9.0",
-        "jest-haste-map": "^24.9.0",
-        "jest-runner": "^24.9.0",
-        "jest-runtime": "^24.9.0"
+        "@jest/test-result": "^25.2.4",
+        "jest-haste-map": "^25.2.3",
+        "jest-runner": "^25.2.4",
+        "jest-runtime": "^25.2.4"
       }
     },
     "@jest/transform": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
-      "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.2.4.tgz",
+      "integrity": "sha512-6eRigvb+G6bs4kW5j1/y8wu4nCrmVuIe0epPBbiWaYlwawJ8yi1EIyK3d/btDqmBpN5GpN4YhR6iPPnDmkYdTA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^24.9.0",
-        "babel-plugin-istanbul": "^5.1.0",
-        "chalk": "^2.0.1",
+        "@jest/types": "^25.2.3",
+        "babel-plugin-istanbul": "^6.0.0",
+        "chalk": "^3.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.1.15",
-        "jest-haste-map": "^24.9.0",
-        "jest-regex-util": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "micromatch": "^3.1.10",
+        "graceful-fs": "^4.2.3",
+        "jest-haste-map": "^25.2.3",
+        "jest-regex-util": "^25.2.1",
+        "jest-util": "^25.2.3",
+        "micromatch": "^4.0.2",
         "pirates": "^4.0.1",
-        "realpath-native": "^1.1.0",
-        "slash": "^2.0.0",
+        "realpath-native": "^2.0.0",
+        "slash": "^3.0.0",
         "source-map": "^0.6.1",
-        "write-file-atomic": "2.4.1"
+        "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        }
       }
     },
     "@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.3.tgz",
+      "integrity": "sha512-6oLQwO9mKif3Uph3RX5J1i3S7X7xtDHWBaaaoeKw8hOzV6YUd0qDcYcHZ6QXMHDIzSr7zzrEa51o2Ovlj6AtKQ==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@sindresorhus/is": {
@@ -398,6 +920,15 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -409,9 +940,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
-      "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
+      "integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -441,13 +972,19 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
-      "integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.9.tgz",
+      "integrity": "sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -456,9 +993,9 @@
       "dev": true
     },
     "@types/istanbul-lib-report": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
@@ -474,6 +1011,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -481,18 +1024,18 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
-      "integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
+      "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
-      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
     "abab": {
@@ -502,9 +1045,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-globals": {
@@ -532,12 +1075,12 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -553,10 +1096,21 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
       "version": "4.1.0",
@@ -581,6 +1135,15 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -671,42 +1234,95 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
     "babel-jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
-      "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.2.4.tgz",
+      "integrity": "sha512-+yDzlyJVWrqih9i2Cvjpt7COaN8vUwCsKGtxJLzg6I0xhxD54K8mvDUCliPKLufyzHh/c5C4MRj4Vk7VMjOjIg==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^24.9.0",
-        "@jest/types": "^24.9.0",
+        "@jest/transform": "^25.2.4",
+        "@jest/types": "^25.2.3",
         "@types/babel__core": "^7.1.0",
-        "babel-plugin-istanbul": "^5.1.0",
-        "babel-preset-jest": "^24.9.0",
-        "chalk": "^2.4.2",
-        "slash": "^2.0.0"
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-preset-jest": "^25.2.1",
+        "chalk": "^3.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "babel-plugin-istanbul": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
-      "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+      "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "find-up": "^3.0.0",
-        "istanbul-lib-instrument": "^3.3.0",
-        "test-exclude": "^5.2.3"
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^4.0.0",
+        "test-exclude": "^6.0.0"
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
-      "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.2.1.tgz",
+      "integrity": "sha512-HysbCQfJhxLlyxDbKcB2ucGYV0LjqK4h6dBoI3RtFuOxTiTWK6XGZMsHb0tGh8iJdV4hC6Z2GCHzVvDeh9i0lQ==",
       "dev": true,
       "requires": {
         "@types/babel__traverse": "^7.0.6"
@@ -724,13 +1340,14 @@
       }
     },
     "babel-preset-jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
-      "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.2.1.tgz",
+      "integrity": "sha512-zXHJBM5iR8oEO4cvdF83AQqqJf3tJrXy3x8nfu2Nlqvn4cneg4Ca8M7cQvC5S9BzDDy1O0tZ9iXru9J6E3ym+A==",
       "dev": true,
       "requires": {
+        "@babel/plugin-syntax-bigint": "^7.0.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-        "babel-plugin-jest-hoist": "^24.9.0"
+        "babel-plugin-jest-hoist": "^25.2.1"
       }
     },
     "babel-runtime": {
@@ -830,7 +1447,8 @@
     "bisect_ppx": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bisect_ppx/-/bisect_ppx-2.1.0.tgz",
-      "integrity": "sha512-wFw+BwOExrX2MbtlNlHY5gNDw8Wsd+aL5ykRdN904aGLrVfuV6YUf1S0+X/4khA8GhibgqC7pLazW4/IvxgPIw=="
+      "integrity": "sha512-wFw+BwOExrX2MbtlNlHY5gNDw8Wsd+aL5ykRdN904aGLrVfuV6YUf1S0+X/4khA8GhibgqC7pLazW4/IvxgPIw==",
+      "dev": true
     },
     "boxen": {
       "version": "3.2.0",
@@ -888,9 +1506,9 @@
       }
     },
     "browser-process-hrtime": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
     "browser-resolve": {
@@ -911,11 +1529,12 @@
       }
     },
     "bs-bastet": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bs-bastet/-/bs-bastet-1.2.3.tgz",
-      "integrity": "sha512-CszRJi1EvDwOfPThn1ePvLJDVttMB4C6c8X3uYUOWiBhyPtJlDjTNhArDxIyVKTKQOeCZcOfzBbqRf185xCdSQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/bs-bastet/-/bs-bastet-1.2.5.tgz",
+      "integrity": "sha512-XIMv0CpovzTXmrEnzwnY2M3MuuesbGSzs+yaFvb3NAVyIP/aLlXCRv/roH6qybDBIGwW9JjbB7lxo73yqMi1qg==",
       "dev": true,
       "requires": {
+        "bisect_ppx": "^2.1.0",
         "bs-stdlib-shims": "^0.1.0"
       }
     },
@@ -1059,6 +1678,555 @@
         "upath": "^1.1.1"
       },
       "dependencies": {
+        "fsevents": {
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+          "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "node-pre-gyp": "*"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "3.2.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.7",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.6.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.3.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.9.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.14.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4.4.2"
+              }
+            },
+            "nopt": {
+              "version": "4.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npm-normalize-package-bin": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1",
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.13",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.8.6",
+                "minizlib": "^1.2.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.3"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1155,6 +2323,12 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "collect-v8-coverage": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz",
+      "integrity": "sha512-VKIhJgvk8E1W28m5avZ2Gv2Ruv5YiF56ug2oclvaG9md69BuZImMG2sk9g7QNKLUbtYAKQjXjYxbYZVUlMMKmQ==",
+      "dev": true
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1188,13 +2362,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1327,18 +2494,26 @@
       "dev": true
     },
     "cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
       "dev": true
     },
     "cssstyle": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
-      "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.2.0.tgz",
+      "integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
       "dev": true,
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+          "dev": true
+        }
       }
     },
     "dashdash": {
@@ -1359,19 +2534,6 @@
         "abab": "^2.0.0",
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
-      },
-      "dependencies": {
-        "whatwg-url": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-          "dev": true,
-          "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
-          }
-        }
       }
     },
     "debug": {
@@ -1416,20 +2578,17 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
     "defer-to-connect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
       "integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==",
       "dev": true
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -1498,15 +2657,15 @@
       "dev": true
     },
     "detect-newline": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
     "diff-sequences": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.1.tgz",
+      "integrity": "sha512-foe7dXnGlSh3jR1ovJmdv+77VQj98eKCHHwJPbZ2eEf0fHwKbkZicpPxEch9smZ+n2dnF6QFwkOQdLq9hpeJUg==",
       "dev": true
     },
     "docsify": {
@@ -1671,44 +2830,6 @@
         "once": "^1.4.0"
       }
     },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
-      "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-inspect": "^1.7.0",
-        "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1722,12 +2843,12 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
@@ -1735,9 +2856,9 @@
       }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "estraverse": {
@@ -1821,17 +2942,44 @@
       }
     },
     "expect": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
-      "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-25.2.4.tgz",
+      "integrity": "sha512-hfuPhPds4yOsZtIw4kwAg70r0hqGmpqekgA+VX7pf/3wZ6FY+xIOXZhNsPMMMsspYG/YIsbAiwqsdnD4Ht+bCA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.9.0",
-        "ansi-styles": "^3.2.0",
-        "jest-get-type": "^24.9.0",
-        "jest-matcher-utils": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-regex-util": "^24.9.0"
+        "@jest/types": "^25.2.3",
+        "ansi-styles": "^4.0.0",
+        "jest-get-type": "^25.2.1",
+        "jest-matcher-utils": "^25.2.3",
+        "jest-message-util": "^25.2.4",
+        "jest-regex-util": "^25.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
       }
     },
     "extend": {
@@ -1944,15 +3092,15 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fast-levenshtein": {
@@ -2088,557 +3236,16 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
-      }
+      "optional": true
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
       "dev": true
     },
     "get-caller-file": {
@@ -2769,19 +3376,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
-    },
-    "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      }
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -2797,15 +3393,6 @@
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -2829,12 +3416,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "has-value": {
@@ -2875,12 +3456,6 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
-    "hosted-git-info": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
-      "dev": true
-    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -2889,6 +3464,12 @@
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
     },
     "http-cache-semantics": {
       "version": "4.0.3",
@@ -2920,6 +3501,12 @@
         "sshpk": "^1.7.0"
       }
     },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2936,13 +3523,13 @@
       "dev": true
     },
     "import-local": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^3.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
       }
     },
     "imurmurhash": {
@@ -3069,14 +3656,11 @@
         }
       }
     },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3098,12 +3682,6 @@
         }
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -3117,12 +3695,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-ci": {
@@ -3153,12 +3725,6 @@
           }
         }
       }
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3278,29 +3844,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
-    },
-    "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.1"
-      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -3351,24 +3899,24 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
+      "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "istanbul-lib-coverage": "^2.0.5",
-        "semver": "^6.0.0"
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -3380,37 +3928,41 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
+        "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
       },
       "dependencies": {
@@ -3432,360 +3984,501 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-Vm9xwCiQ8t2cNNnckyeAV0UdxKpcQUz4nMxsBvIu8n2kmPSiyb5uaF/8LpmKr+yqL/MdOXaX2Nmdo4Qyxium9Q==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
       }
     },
     "jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
-      "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-25.2.4.tgz",
+      "integrity": "sha512-Lu4LXxf4+durzN/IFilcAoQSisOwgHIXgl9vffopePpSSwFqfj1Pj4y+k3nL8oTbnvjxgDIsEcepy6he4bWqnQ==",
       "dev": true,
       "requires": {
-        "import-local": "^2.0.0",
-        "jest-cli": "^24.9.0"
+        "@jest/core": "^25.2.4",
+        "import-local": "^3.0.2",
+        "jest-cli": "^25.2.4"
       },
       "dependencies": {
-        "jest-cli": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-          "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@jest/core": "^24.9.0",
-            "@jest/test-result": "^24.9.0",
-            "@jest/types": "^24.9.0",
-            "chalk": "^2.0.1",
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-cli": {
+          "version": "25.2.4",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.2.4.tgz",
+          "integrity": "sha512-zeY2pRDWKj2LZudIncvvguwLMEdcnJqc2jJbwza1beqi80qqLvkPF/BjbFkK2sIV3r+mfTJS+7ITrvK6pCdRjg==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^25.2.4",
+            "@jest/test-result": "^25.2.4",
+            "@jest/types": "^25.2.3",
+            "chalk": "^3.0.0",
             "exit": "^0.1.2",
-            "import-local": "^2.0.0",
+            "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^24.9.0",
-            "jest-util": "^24.9.0",
-            "jest-validate": "^24.9.0",
+            "jest-config": "^25.2.4",
+            "jest-util": "^25.2.3",
+            "jest-validate": "^25.2.3",
             "prompts": "^2.0.1",
-            "realpath-native": "^1.1.0",
-            "yargs": "^13.3.0"
+            "realpath-native": "^2.0.0",
+            "yargs": "^15.3.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
     },
     "jest-changed-files": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
-      "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.2.3.tgz",
+      "integrity": "sha512-EFxy94dvvbqRB36ezIPLKJ4fDIC+jAdNs8i8uTwFpaXd6H3LVc3ova1lNS4ZPWk09OCR2vq5kSdSQgar7zMORg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.9.0",
-        "execa": "^1.0.0",
-        "throat": "^4.0.0"
+        "@jest/types": "^25.2.3",
+        "execa": "^3.2.0",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "jest-config": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
-      "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.2.4.tgz",
+      "integrity": "sha512-fxy3nIpwJqOUQJRVF/q+pNQb6dv5b9YufOeCbpPZJ/md1zXpiupbhfehpfODhnKOfqbzSiigtSLzlWWmbRxnqQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "babel-jest": "^24.9.0",
-        "chalk": "^2.0.1",
+        "@jest/test-sequencer": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "babel-jest": "^25.2.4",
+        "chalk": "^3.0.0",
+        "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
-        "jest-environment-jsdom": "^24.9.0",
-        "jest-environment-node": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "jest-jasmine2": "^24.9.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-validate": "^24.9.0",
-        "micromatch": "^3.1.10",
-        "pretty-format": "^24.9.0",
-        "realpath-native": "^1.1.0"
+        "jest-environment-jsdom": "^25.2.4",
+        "jest-environment-node": "^25.2.4",
+        "jest-get-type": "^25.2.1",
+        "jest-jasmine2": "^25.2.4",
+        "jest-regex-util": "^25.2.1",
+        "jest-resolve": "^25.2.3",
+        "jest-util": "^25.2.3",
+        "jest-validate": "^25.2.3",
+        "micromatch": "^4.0.2",
+        "pretty-format": "^25.2.3",
+        "realpath-native": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "jest-diff": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
-      "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.2.3.tgz",
+      "integrity": "sha512-VtZ6LAQtaQpFsmEzps15dQc5ELbJxy4L2DOSo2Ev411TUEtnJPkAMD7JneVypeMJQ1y3hgxN9Ao13n15FAnavg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "diff-sequences": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
+        "chalk": "^3.0.0",
+        "diff-sequences": "^25.2.1",
+        "jest-get-type": "^25.2.1",
+        "pretty-format": "^25.2.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-docblock": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
-      "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.2.3.tgz",
+      "integrity": "sha512-d3/tmjLLrH5fpRGmIm3oFa3vOaD/IjPxtXVOrfujpfJ9y1tCDB1x/tvunmdOVAyF03/xeMwburl6ITbiQT1mVA==",
       "dev": true,
       "requires": {
-        "detect-newline": "^2.1.0"
+        "detect-newline": "^3.0.0"
       }
     },
     "jest-each": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
-      "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.2.3.tgz",
+      "integrity": "sha512-RTlmCjsBDK2c9T5oO4MqccA3/5Y8BUtiEy7OOQik1iyCgdnNdHbI0pNEpyapZPBG0nlvZ4mIu7aY6zNUvLraAQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
-        "jest-get-type": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "pretty-format": "^24.9.0"
+        "@jest/types": "^25.2.3",
+        "chalk": "^3.0.0",
+        "jest-get-type": "^25.2.1",
+        "jest-util": "^25.2.3",
+        "pretty-format": "^25.2.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-environment-jsdom": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
-      "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.2.4.tgz",
+      "integrity": "sha512-5dm+tNwrLmhELdjAwiQnVGf/U9iFMWdTL4/wyrMg2HU6RQnCiuxpWbIigLHUhuP1P2Ak0F4k3xhjrikboKyShA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.9.0",
-        "@jest/fake-timers": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "jest-mock": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jsdom": "^11.5.1"
+        "@jest/environment": "^25.2.4",
+        "@jest/fake-timers": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "jest-mock": "^25.2.3",
+        "jest-util": "^25.2.3",
+        "jsdom": "^15.2.1"
       }
     },
     "jest-environment-node": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
-      "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.2.4.tgz",
+      "integrity": "sha512-Jkc5Y8goyXPrLRHnrUlqC7P4o5zn2m4zw6qWoRJ59kxV1f2a5wK+TTGhrhCwnhW/Ckpdl/pm+LufdvhJkvJbiw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.9.0",
-        "@jest/fake-timers": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "jest-mock": "^24.9.0",
-        "jest-util": "^24.9.0"
-      }
-    },
-    "jest-get-type": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
-      "dev": true
-    },
-    "jest-haste-map": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
-      "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "anymatch": "^2.0.0",
-        "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
-        "graceful-fs": "^4.1.15",
-        "invariant": "^2.2.4",
-        "jest-serializer": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-worker": "^24.9.0",
-        "micromatch": "^3.1.10",
-        "sane": "^4.0.3",
-        "walker": "^1.0.7"
-      }
-    },
-    "jest-jasmine2": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
-      "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
-      "dev": true,
-      "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
-        "co": "^4.6.0",
-        "expect": "^24.9.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^24.9.0",
-        "jest-matcher-utils": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-runtime": "^24.9.0",
-        "jest-snapshot": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "pretty-format": "^24.9.0",
-        "throat": "^4.0.0"
-      }
-    },
-    "jest-leak-detector": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
-      "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
-      "dev": true,
-      "requires": {
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
-      }
-    },
-    "jest-matcher-utils": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
-      "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.1",
-        "jest-diff": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
-      }
-    },
-    "jest-message-util": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
-      "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "@types/stack-utils": "^1.0.1",
-        "chalk": "^2.0.1",
-        "micromatch": "^3.1.10",
-        "slash": "^2.0.0",
-        "stack-utils": "^1.0.1"
-      }
-    },
-    "jest-mock": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
-      "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^24.9.0"
-      }
-    },
-    "jest-pnp-resolver": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
-      "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
-      "dev": true
-    },
-    "jest-regex-util": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
-      "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
-      "dev": true
-    },
-    "jest-resolve": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
-      "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "browser-resolve": "^1.11.3",
-        "chalk": "^2.0.1",
-        "jest-pnp-resolver": "^1.2.1",
-        "realpath-native": "^1.1.0"
-      }
-    },
-    "jest-resolve-dependencies": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
-      "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-snapshot": "^24.9.0"
-      }
-    },
-    "jest-runner": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
-      "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
-      "dev": true,
-      "requires": {
-        "@jest/console": "^24.7.1",
-        "@jest/environment": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.4.2",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.15",
-        "jest-config": "^24.9.0",
-        "jest-docblock": "^24.3.0",
-        "jest-haste-map": "^24.9.0",
-        "jest-jasmine2": "^24.9.0",
-        "jest-leak-detector": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-resolve": "^24.9.0",
-        "jest-runtime": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-worker": "^24.6.0",
-        "source-map-support": "^0.5.6",
-        "throat": "^4.0.0"
-      }
-    },
-    "jest-runtime": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
-      "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
-      "dev": true,
-      "requires": {
-        "@jest/console": "^24.7.1",
-        "@jest/environment": "^24.9.0",
-        "@jest/source-map": "^24.3.0",
-        "@jest/transform": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "@types/yargs": "^13.0.0",
-        "chalk": "^2.0.1",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.15",
-        "jest-config": "^24.9.0",
-        "jest-haste-map": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-mock": "^24.9.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.9.0",
-        "jest-snapshot": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-validate": "^24.9.0",
-        "realpath-native": "^1.1.0",
-        "slash": "^2.0.0",
-        "strip-bom": "^3.0.0",
-        "yargs": "^13.3.0"
-      }
-    },
-    "jest-serializer": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
-      "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
-      "dev": true
-    },
-    "jest-snapshot": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
-      "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.0.0",
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
-        "expect": "^24.9.0",
-        "jest-diff": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "jest-matcher-utils": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-resolve": "^24.9.0",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^24.9.0",
-        "semver": "^6.2.0"
+        "@jest/environment": "^25.2.4",
+        "@jest/fake-timers": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "jest-mock": "^25.2.3",
+        "jest-util": "^25.2.3",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -3796,72 +4489,931 @@
         }
       }
     },
-    "jest-util": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
-      "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+    "jest-get-type": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.1.tgz",
+      "integrity": "sha512-EYjTiqcDTCRJDcSNKbLTwn/LcDPEE7ITk8yRMNAOjEsN6yp+Uu+V1gx4djwnuj/DvWg0YGmqaBqPVGsPxlvE7w==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.3.tgz",
+      "integrity": "sha512-pAP22OHtPr4qgZlJJFks2LLgoQUr4XtM1a+F5UaPIZNiCRnePA0hM3L7aiJ0gzwiNIYwMTfKRwG/S1L28J3A3A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.9.0",
-        "@jest/fake-timers": "^24.9.0",
-        "@jest/source-map": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "callsites": "^3.0.0",
-        "chalk": "^2.0.1",
-        "graceful-fs": "^4.1.15",
+        "@jest/types": "^25.2.3",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
+        "graceful-fs": "^4.2.3",
+        "jest-serializer": "^25.2.1",
+        "jest-util": "^25.2.3",
+        "jest-worker": "^25.2.1",
+        "micromatch": "^4.0.2",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "jest-jasmine2": {
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.2.4.tgz",
+      "integrity": "sha512-juoKrmNmLwaheNbAg71SuUF9ovwUZCFNTpKVhvCXWk+SSeORcIUMptKdPCoLXV3D16htzhTSKmNxnxSk4SrTjA==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^25.2.4",
+        "@jest/source-map": "^25.2.1",
+        "@jest/test-result": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "chalk": "^3.0.0",
+        "co": "^4.6.0",
+        "expect": "^25.2.4",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^25.2.3",
+        "jest-matcher-utils": "^25.2.3",
+        "jest-message-util": "^25.2.4",
+        "jest-runtime": "^25.2.4",
+        "jest-snapshot": "^25.2.4",
+        "jest-util": "^25.2.3",
+        "pretty-format": "^25.2.3",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-leak-detector": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.2.3.tgz",
+      "integrity": "sha512-yblCMPE7NJKl7778Cf/73yyFWAas5St0iiEBwq7RDyaz6Xd4WPFnPz2j7yDb/Qce71A1IbDoLADlcwD8zT74Aw==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^25.2.1",
+        "pretty-format": "^25.2.3"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.2.3.tgz",
+      "integrity": "sha512-ZmiXiwQRVM9MoKjGMP5YsGGk2Th5ncyRxfXKz5AKsmU8m43kgNZirckVzaP61MlSa9LKmXbevdYqVp1ZKAw2Rw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "jest-diff": "^25.2.3",
+        "jest-get-type": "^25.2.1",
+        "pretty-format": "^25.2.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.2.4.tgz",
+      "integrity": "sha512-9wWMH3Bf+GVTv0GcQLmH/FRr0x0toptKw9TA8U5YFLVXx7Tq9pvcNzTyJrcTJ+wLqNbMPPJlJNft4MnlcrtF5Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/test-result": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "@types/stack-utils": "^1.0.1",
+        "chalk": "^3.0.0",
+        "micromatch": "^4.0.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.2.3.tgz",
+      "integrity": "sha512-xlf+pyY0j47zoCs8zGGOGfWyxxLximE8YFOfEK8s4FruR8DtM/UjNj61um+iDuMAFEBDe1bhCXkqiKoCmWjJzg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^25.2.3"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+      "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.1.tgz",
+      "integrity": "sha512-wroFVJw62LdqTdkL508ZLV82FrJJWVJMIuYG7q4Uunl1WAPTf4ftPKrqqfec4SvOIlvRZUdEX2TFpWR356YG/w==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.2.3.tgz",
+      "integrity": "sha512-1vZMsvM/DBH258PnpUNSXIgtzpYz+vCVCj9+fcy4akZl4oKbD+9hZSlfe9RIDpU0Fc28ozHQrmwX3EqFRRIHGg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^25.2.3",
+        "browser-resolve": "^1.11.3",
+        "chalk": "^3.0.0",
+        "jest-pnp-resolver": "^1.2.1",
+        "realpath-native": "^2.0.0",
+        "resolve": "^1.15.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.2.4.tgz",
+      "integrity": "sha512-qhUnK4PfNHzNdca7Ub1mbAqE0j5WNyMTwxBZZJjQlUrdqsiYho/QGK65FuBkZuSoYtKIIqriR9TpGrPEc3P5Gg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^25.2.3",
+        "jest-regex-util": "^25.2.1",
+        "jest-snapshot": "^25.2.4"
+      }
+    },
+    "jest-runner": {
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.2.4.tgz",
+      "integrity": "sha512-5xaIfqqxck9Wg2CV4b9KmJtf/sWO7zWQx7O+34GCLGPzoPcVmB3mZtdrQI1/jS3Reqjru9ycLjgLHSf6XoxRqA==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^25.2.3",
+        "@jest/environment": "^25.2.4",
+        "@jest/test-result": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "chalk": "^3.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.3",
+        "jest-config": "^25.2.4",
+        "jest-docblock": "^25.2.3",
+        "jest-haste-map": "^25.2.3",
+        "jest-jasmine2": "^25.2.4",
+        "jest-leak-detector": "^25.2.3",
+        "jest-message-util": "^25.2.4",
+        "jest-resolve": "^25.2.3",
+        "jest-runtime": "^25.2.4",
+        "jest-util": "^25.2.3",
+        "jest-worker": "^25.2.1",
+        "source-map-support": "^0.5.6",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.2.4.tgz",
+      "integrity": "sha512-6ehOUizgIghN+aV5YSrDzTZ+zJ9omgEjJbTHj3Jqes5D52XHfhzT7cSfdREwkNjRytrR7mNwZ7pRauoyNLyJ8Q==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^25.2.3",
+        "@jest/environment": "^25.2.4",
+        "@jest/source-map": "^25.2.1",
+        "@jest/test-result": "^25.2.4",
+        "@jest/transform": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.3",
+        "jest-config": "^25.2.4",
+        "jest-haste-map": "^25.2.3",
+        "jest-message-util": "^25.2.4",
+        "jest-mock": "^25.2.3",
+        "jest-regex-util": "^25.2.1",
+        "jest-resolve": "^25.2.3",
+        "jest-snapshot": "^25.2.4",
+        "jest-util": "^25.2.3",
+        "jest-validate": "^25.2.3",
+        "realpath-native": "^2.0.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-serializer": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.2.1.tgz",
+      "integrity": "sha512-fibDi7M5ffx6c/P66IkvR4FKkjG5ldePAK1WlbNoaU4GZmIAkS9Le/frAwRUFEX0KdnisSPWf+b1RC5jU7EYJQ==",
+      "dev": true
+    },
+    "jest-snapshot": {
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.2.4.tgz",
+      "integrity": "sha512-nIwpW7FZCq5p0AE3Oyqyb6jL0ENJixXzJ5/CD/XRuOqp3gS5OM3O/k+NnTrniCXxPFV4ry6s9HNfiPQBi0wcoA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^25.2.3",
+        "@types/prettier": "^1.19.0",
+        "chalk": "^3.0.0",
+        "expect": "^25.2.4",
+        "jest-diff": "^25.2.3",
+        "jest-get-type": "^25.2.1",
+        "jest-matcher-utils": "^25.2.3",
+        "jest-message-util": "^25.2.4",
+        "jest-resolve": "^25.2.3",
+        "make-dir": "^3.0.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^25.2.3",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-util": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.3.tgz",
+      "integrity": "sha512-7tWiMICVSo9lNoObFtqLt9Ezt5exdFlWs5fLe1G4XLY2lEbZc814cw9t4YHScqBkWMfzth8ASHKlYBxiX2rdCw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^25.2.3",
+        "chalk": "^3.0.0",
         "is-ci": "^2.0.0",
-        "mkdirp": "^0.5.1",
-        "slash": "^2.0.0",
-        "source-map": "^0.6.0"
+        "make-dir": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-validate": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
-      "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.2.3.tgz",
+      "integrity": "sha512-GObn91jzU0B0Bv4cusAwjP6vnWy78hJUM8MOSz7keRfnac/ZhQWIsUjvk01IfeXNTemCwgR57EtdjQMzFZGREg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.9.0",
+        "@jest/types": "^25.2.3",
         "camelcase": "^5.3.1",
-        "chalk": "^2.0.1",
-        "jest-get-type": "^24.9.0",
+        "chalk": "^3.0.0",
+        "jest-get-type": "^25.2.1",
         "leven": "^3.1.0",
-        "pretty-format": "^24.9.0"
+        "pretty-format": "^25.2.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-watcher": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
-      "integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.2.4.tgz",
+      "integrity": "sha512-p7g7s3zqcy69slVzQYcphyzkB2FBmJwMbv6k6KjI5mqd6KnUnQPfQVKuVj2l+34EeuxnbXqnrjtUFmxhcL87rg==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "@types/yargs": "^13.0.0",
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
-        "jest-util": "^24.9.0",
-        "string-length": "^2.0.0"
+        "@jest/test-result": "^25.2.4",
+        "@jest/types": "^25.2.3",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "jest-util": "^25.2.3",
+        "string-length": "^3.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-worker": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-      "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.1.tgz",
+      "integrity": "sha512-IHnpekk8H/hCUbBlfeaPZzU6v75bqwJp3n4dUrQuQOAgOneI4tx3jV2o8pvlXnDfcRsfkFIUD//HWXpCmR+evQ==",
       "dev": true,
       "requires": {
         "merge-stream": "^2.0.0",
-        "supports-color": "^6.1.0"
+        "supports-color": "^7.0.0"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -3872,6 +5424,16 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -3879,36 +5441,36 @@
       "dev": true
     },
     "jsdom": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-      "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+      "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
       "dev": true,
       "requires": {
         "abab": "^2.0.0",
-        "acorn": "^5.5.3",
-        "acorn-globals": "^4.1.0",
+        "acorn": "^7.1.0",
+        "acorn-globals": "^4.3.2",
         "array-equal": "^1.0.0",
-        "cssom": ">= 0.3.2 < 0.4.0",
-        "cssstyle": "^1.0.0",
-        "data-urls": "^1.0.0",
+        "cssom": "^0.4.1",
+        "cssstyle": "^2.0.0",
+        "data-urls": "^1.1.0",
         "domexception": "^1.0.1",
-        "escodegen": "^1.9.1",
+        "escodegen": "^1.11.1",
         "html-encoding-sniffer": "^1.0.2",
-        "left-pad": "^1.3.0",
-        "nwsapi": "^2.0.7",
-        "parse5": "4.0.0",
+        "nwsapi": "^2.2.0",
+        "parse5": "5.1.0",
         "pn": "^1.1.0",
-        "request": "^2.87.0",
-        "request-promise-native": "^1.0.5",
-        "sax": "^1.2.4",
+        "request": "^2.88.0",
+        "request-promise-native": "^1.0.7",
+        "saxes": "^3.1.9",
         "symbol-tree": "^3.2.2",
-        "tough-cookie": "^2.3.4",
+        "tough-cookie": "^3.0.1",
         "w3c-hr-time": "^1.0.1",
+        "w3c-xmlserializer": "^1.1.2",
         "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.3",
-        "whatwg-mimetype": "^2.1.0",
-        "whatwg-url": "^6.4.1",
-        "ws": "^5.2.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^7.0.0",
+        "ws": "^7.0.0",
         "xml-name-validator": "^3.0.0"
       }
     },
@@ -3922,12 +5484,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-      "dev": true
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "json-schema": {
@@ -3949,12 +5505,20 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+      "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "jsonfile": {
@@ -4008,12 +5572,6 @@
         "package-json": "^6.3.0"
       }
     },
-    "left-pad": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4052,18 +5610,6 @@
         }
       }
     },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      }
-    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -4086,13 +5632,13 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+    "lolex": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "@sinonjs/commons": "^1.7.0"
       }
     },
     "lowercase-keys": {
@@ -4111,19 +5657,18 @@
       }
     },
     "make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+      "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
       "dev": true,
       "requires": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
+        "semver": "^6.0.0"
       },
       "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -4198,18 +5743,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.42.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
@@ -4260,23 +5805,6 @@
         }
       }
     },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4288,13 +5816,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4319,12 +5840,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nested-error-stacks": {
@@ -4362,28 +5877,33 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+      "integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
-        "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
+        "is-wsl": "^2.1.1",
+        "semver": "^6.3.0",
         "shellwords": "^0.1.1",
-        "which": "^1.3.0"
-      }
-    },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "normalize-path": {
@@ -4459,18 +5979,6 @@
         }
       }
     },
-    "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -4478,16 +5986,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
       }
     },
     "object.pick": {
@@ -4601,24 +6099,6 @@
         "pinkie-promise": "^2.0.0"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -4652,13 +6132,10 @@
       "dev": true
     },
     "p-each-series": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-      "dev": true,
-      "requires": {
-        "p-reduce": "^1.0.0"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+      "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+      "dev": true
     },
     "p-event": {
       "version": "4.1.0",
@@ -4692,12 +6169,6 @@
       "requires": {
         "p-limit": "^2.0.0"
       }
-    },
-    "p-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
-      "dev": true
     },
     "p-timeout": {
       "version": "2.0.1",
@@ -4740,20 +6211,10 @@
       "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc=",
       "dev": true
     },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      }
-    },
     "parse5": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
       "dev": true
     },
     "parseurl": {
@@ -4804,19 +6265,16 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "pify": {
@@ -4850,12 +6308,48 @@
       }
     },
     "pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0"
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
       }
     },
     "pn": {
@@ -4883,15 +6377,48 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.3.tgz",
+      "integrity": "sha512-IP4+5UOAVGoyqC/DiomOeHBUKN6q00gfyT2qpAsRH64tgOKB2yF7FHJXC18OCiU0/YFierACup/zdCOWw0F/0w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
+        "@jest/types": "^25.2.3",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
       }
     },
     "prismjs": {
@@ -4910,13 +6437,13 @@
       "dev": true
     },
     "prompts": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
-      "integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
-        "sisteransi": "^1.0.3"
+        "sisteransi": "^1.0.4"
       }
     },
     "pseudomap": {
@@ -4926,9 +6453,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
-      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
     "pump": {
@@ -4972,31 +6499,10 @@
       }
     },
     "react-is": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-      "dev": true,
-      "requires": {
-        "find-up": "^3.0.0",
-        "read-pkg": "^3.0.0"
-      }
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -5025,13 +6531,10 @@
       }
     },
     "realpath-native": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
-      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
-      "dev": true,
-      "requires": {
-        "util.promisify": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+      "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+      "dev": true
     },
     "regenerator-runtime": {
       "version": "0.10.5",
@@ -5087,9 +6590,9 @@
       "dev": true
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -5099,7 +6602,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -5109,25 +6612,19 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
         "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
           "dev": true,
           "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
           }
         }
       }
@@ -5150,6 +6647,18 @@
         "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
       }
     },
     "require-directory": {
@@ -5165,27 +6674,27 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
-      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "^5.0.0"
       }
     },
     "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
     "resolve-pathname": {
@@ -5226,9 +6735,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -5293,11 +6802,14 @@
         "walker": "~1.0.5"
       }
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+    "saxes": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+      "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.1.1"
+      }
     },
     "select": {
       "version": "1.1.2",
@@ -5416,7 +6928,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -5425,15 +6938,15 @@
       "dev": true
     },
     "sisteransi": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
-      "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
     "slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
     "snapdragon": {
@@ -5584,38 +7097,6 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-      "dev": true
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -5624,6 +7105,12 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -5682,30 +7169,13 @@
       "dev": true
     },
     "string-length": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+      "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
       "dev": true,
       "requires": {
         "astral-regex": "^1.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "strip-ansi": "^5.2.0"
       }
     },
     "string-width": {
@@ -5717,26 +7187,6 @@
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^5.1.0"
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -5758,15 +7208,21 @@
       }
     },
     "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "strip-json-comments": {
@@ -5782,6 +7238,33 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+      "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "symbol-tree": {
@@ -5849,22 +7332,31 @@
         }
       }
     },
-    "test-exclude": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+    "terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^2.0.0"
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      }
+    },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
       }
     },
     "throat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+      "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "dev": true
     },
     "through": {
@@ -5962,11 +7454,12 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
       "dev": true,
       "requires": {
+        "ip-regex": "^2.1.0",
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
@@ -6010,21 +7503,25 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
       "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
-      "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
+        "is-typedarray": "^1.0.0"
       }
     },
     "union-value": {
@@ -6162,16 +7659,6 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
-      }
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -6179,19 +7666,28 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+    "v8-to-istanbul": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.3.tgz",
+      "integrity": "sha512-sAjOC+Kki6aJVbUOXJbcR0MnbfjvBzwKZazEJymA2IX49uoOdEdk+4fBq5cXgYgiyKtAyrrJNtBZdOeDIF+Fng==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
       }
     },
     "verror": {
@@ -6206,12 +7702,23 @@
       }
     },
     "w3c-hr-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
-      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "^0.1.2"
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+      "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+      "dev": true,
+      "requires": {
+        "domexception": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "xml-name-validator": "^3.0.0"
       }
     },
     "walker": {
@@ -6245,9 +7752,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -6312,12 +7819,6 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
-    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -6347,13 +7848,10 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "3.0.0",
@@ -6365,6 +7863,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
     "y18n": {
@@ -6433,27 +7937,149 @@
       }
     },
     "yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
+        "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^18.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+      "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docsify-cli": "~4.4.0"
   },
   "peerDependencies": {
-    "bs-bastet": "^1.2.3",
+    "bs-bastet": "^1.2.5",
     "bs-platform": "^7.2.2"
   },
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "license": "MIT",
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.9",
-    "bs-abstract": "^1.0.0",
-    "bs-platform": "^7.1.1",
+    "bs-bastet": "^1.2.3",
+    "bs-platform": "^7.2.2",
     "docsify-cli": "~4.4.0"
   },
   "peerDependencies": {
-    "bs-abstract": "^1.0.0",
-    "bs-platform": "^7.1.1"
+    "bs-bastet": "^1.2.3",
+    "bs-platform": "^7.2.2"
   },
   "jest": {
     "verbose": false,
@@ -50,5 +50,8 @@
       "/node_modules/",
       "/testUtils/"
     ]
+  },
+  "dependencies": {
+    "bisect_ppx": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@glennsl/bs-jest": "^0.4.9",
-    "bs-bastet": "^1.2.3",
+    "@glennsl/bs-jest": "^0.5.1",
+    "bs-bastet": "^1.2.5",
     "bs-platform": "^7.2.2",
     "docsify-cli": "~4.4.0"
   },
@@ -40,6 +40,7 @@
     "bs-bastet": "^1.2.3",
     "bs-platform": "^7.2.2"
   },
+  "dependencies": {},
   "jest": {
     "verbose": false,
     "testPathIgnorePatterns": [
@@ -50,8 +51,5 @@
       "/node_modules/",
       "/testUtils/"
     ]
-  },
-  "dependencies": {
-    "bisect_ppx": "^2.1.0"
   }
 }

--- a/src/Relude_AsyncData.re
+++ b/src/Relude_AsyncData.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
  * AsyncData represents the state of data that is being loaded asynchronously.
  * While Promise and IO represent the effect of loading that data, `AsyncData`
@@ -220,7 +222,7 @@ let map: 'a 'b. ('a => 'b, t('a)) => t('b) =
     | Complete(a) => Complete(f(a))
     };
 
-module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
+module Functor: FUNCTOR with type t('a) = t('a) = {
   type nonrec t('a) = t('a);
   let map = map;
 };
@@ -376,7 +378,7 @@ let apply: 'a 'b. (t('a => 'b), t('a)) => t('b) =
     | (Complete(f), Complete(a)) => Complete(f(a))
     };
 
-module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
+module Apply: APPLY with type t('a) = t('a) = {
   include Functor;
   let apply = apply;
 };
@@ -387,7 +389,7 @@ include Relude_Extensions_Apply.ApplyExtensions(Apply);
  */
 let pure: 'a. 'a => t('a) = a => Complete(a);
 
-module Applicative: BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
+module Applicative: APPLICATIVE with type t('a) = t('a) = {
   include Apply;
   let pure = pure;
 };
@@ -405,7 +407,7 @@ let bind: 'a 'b. (t('a), 'a => t('b)) => t('b) =
     | Complete(a) => f(a)
     };
 
-module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
+module Monad: MONAD with type t('a) = t('a) = {
   include Applicative;
   let flat_map = bind;
 };
@@ -439,7 +441,7 @@ let alt: 'a. (t('a), t('a)) => t('a) =
     | (Complete(_) as c, Complete(_)) => c
     };
 
-module Alt: BsBastet.Interface.ALT with type t('a) = t('a) = {
+module Alt: ALT with type t('a) = t('a) = {
   include Functor;
   let alt = alt;
 };
@@ -462,7 +464,7 @@ let eqBy: 'a. (('a, 'a) => bool, t('a), t('a)) => bool =
     | (Complete(_), _) => false
     };
 
-module Eq = (E: BsBastet.Interface.EQ) : BsBastet.Interface.EQ => {
+module Eq = (E: EQ) : EQ => {
   type nonrec t = t(E.t);
   let eq = eqBy(E.eq);
 };
@@ -480,7 +482,7 @@ let showBy: 'a. ('a => string, t('a)) => string =
     | Complete(a) => "Complete(" ++ showA(a) ++ ")"
     };
 
-module Show = (S: BsBastet.Interface.SHOW) : BsBastet.Interface.SHOW => {
+module Show = (S: SHOW) : SHOW => {
   type nonrec t = t(S.t);
   let show = showBy(S.show);
 };

--- a/src/Relude_AsyncData.re
+++ b/src/Relude_AsyncData.re
@@ -220,7 +220,7 @@ let map: 'a 'b. ('a => 'b, t('a)) => t('b) =
     | Complete(a) => Complete(f(a))
     };
 
-module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
   type nonrec t('a) = t('a);
   let map = map;
 };
@@ -376,7 +376,7 @@ let apply: 'a 'b. (t('a => 'b), t('a)) => t('b) =
     | (Complete(f), Complete(a)) => Complete(f(a))
     };
 
-module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
   include Functor;
   let apply = apply;
 };
@@ -387,7 +387,7 @@ include Relude_Extensions_Apply.ApplyExtensions(Apply);
  */
 let pure: 'a. 'a => t('a) = a => Complete(a);
 
-module Applicative: BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+module Applicative: BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
   include Apply;
   let pure = pure;
 };
@@ -405,7 +405,7 @@ let bind: 'a 'b. (t('a), 'a => t('b)) => t('b) =
     | Complete(a) => f(a)
     };
 
-module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
   include Applicative;
   let flat_map = bind;
 };
@@ -439,7 +439,7 @@ let alt: 'a. (t('a), t('a)) => t('a) =
     | (Complete(_) as c, Complete(_)) => c
     };
 
-module Alt: BsAbstract.Interface.ALT with type t('a) = t('a) = {
+module Alt: BsBastet.Interface.ALT with type t('a) = t('a) = {
   include Functor;
   let alt = alt;
 };
@@ -462,7 +462,7 @@ let eqBy: 'a. (('a, 'a) => bool, t('a), t('a)) => bool =
     | (Complete(_), _) => false
     };
 
-module Eq = (E: BsAbstract.Interface.EQ) : BsAbstract.Interface.EQ => {
+module Eq = (E: BsBastet.Interface.EQ) : BsBastet.Interface.EQ => {
   type nonrec t = t(E.t);
   let eq = eqBy(E.eq);
 };
@@ -480,7 +480,7 @@ let showBy: 'a. ('a => string, t('a)) => string =
     | Complete(a) => "Complete(" ++ showA(a) ++ ")"
     };
 
-module Show = (S: BsAbstract.Interface.SHOW) : BsAbstract.Interface.SHOW => {
+module Show = (S: BsBastet.Interface.SHOW) : BsBastet.Interface.SHOW => {
   type nonrec t = t(S.t);
   let show = showBy(S.show);
 };

--- a/src/Relude_AsyncResult.re
+++ b/src/Relude_AsyncResult.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
  * AsyncResult is a specialization of AsyncData that uses a `result` as the
  * value type. This is useful for async data that may fail (for example, network
@@ -565,30 +567,29 @@ let eqBy:
  * This is useful so that we can provide typeclass instances for typeclasses that
  * have a single type hole, like Functor, Apply, Monad, etc.
  */
-module WithError = (E: BsBastet.Interface.TYPE) => {
-  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a, E.t) = {
+module WithError = (E: TYPE) => {
+  module Functor: FUNCTOR with type t('a) = t('a, E.t) = {
     type nonrec t('a) = t('a, E.t);
     let map = map;
   };
   let map = Functor.map;
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-  module Apply: BsBastet.Interface.APPLY with type t('a) = t('a, E.t) = {
+  module Apply: APPLY with type t('a) = t('a, E.t) = {
     include Functor;
     let apply = apply;
   };
   let apply = Apply.apply;
   include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-  module Applicative:
-    BsBastet.Interface.APPLICATIVE with type t('a) = t('a, E.t) = {
+  module Applicative: APPLICATIVE with type t('a) = t('a, E.t) = {
     include Apply;
     let pure = pure;
   };
   let pure = Applicative.pure;
   include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-  module Monad: BsBastet.Interface.MONAD with type t('a) = t('a, E.t) = {
+  module Monad: MONAD with type t('a) = t('a, E.t) = {
     include Applicative;
     let flat_map = bind;
   };

--- a/src/Relude_AsyncResult.re
+++ b/src/Relude_AsyncResult.re
@@ -565,15 +565,15 @@ let eqBy:
  * This is useful so that we can provide typeclass instances for typeclasses that
  * have a single type hole, like Functor, Apply, Monad, etc.
  */
-module WithError = (E: BsAbstract.Interface.TYPE) => {
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a, E.t) = {
+module WithError = (E: BsBastet.Interface.TYPE) => {
+  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a, E.t) = {
     type nonrec t('a) = t('a, E.t);
     let map = map;
   };
   let map = Functor.map;
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-  module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a, E.t) = {
+  module Apply: BsBastet.Interface.APPLY with type t('a) = t('a, E.t) = {
     include Functor;
     let apply = apply;
   };
@@ -581,14 +581,14 @@ module WithError = (E: BsAbstract.Interface.TYPE) => {
   include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
   module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) = t('a, E.t) = {
+    BsBastet.Interface.APPLICATIVE with type t('a) = t('a, E.t) = {
     include Apply;
     let pure = pure;
   };
   let pure = Applicative.pure;
   include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-  module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a, E.t) = {
+  module Monad: BsBastet.Interface.MONAD with type t('a) = t('a, E.t) = {
     include Applicative;
     let flat_map = bind;
   };

--- a/src/Relude_Bool.re
+++ b/src/Relude_Bool.re
@@ -74,7 +74,7 @@ let eq: (bool, bool) => bool =
 /**
  * EQ instance for booleans
  */
-module Eq: BsAbstract.Interface.EQ with type t = bool = {
+module Eq: BsBastet.Interface.EQ with type t = bool = {
   type t = bool;
   let eq = eq;
 };
@@ -82,7 +82,7 @@ module Eq: BsAbstract.Interface.EQ with type t = bool = {
 /**
  * Compares two booleans for equality
  */
-let compare: (bool, bool) => BsAbstract.Interface.ordering =
+let compare: (bool, bool) => BsBastet.Interface.ordering =
   (a, b) =>
     switch (a, b) {
     | (true, true) => `equal_to
@@ -94,7 +94,7 @@ let compare: (bool, bool) => BsAbstract.Interface.ordering =
 /**
  * ORD instance for booleans
  */
-module Ord: BsAbstract.Interface.ORD with type t = bool = {
+module Ord: BsBastet.Interface.ORD with type t = bool = {
   include Eq;
   let compare = compare;
 };
@@ -107,23 +107,23 @@ let show: bool => string = b => b ? "true" : "false";
 /**
  * SHOW instance for booleans
  */
-module Show: BsAbstract.Interface.SHOW with type t = bool = {
+module Show: BsBastet.Interface.SHOW with type t = bool = {
   type t = bool;
   let show = show;
 };
 
 module Conjunctive = {
-  module Magma: BsAbstract.Interface.MAGMA with type t = bool = {
+  module Magma: BsBastet.Interface.MAGMA with type t = bool = {
     type t = bool;
     let append = (&&);
   };
 
-  module MedialMagma: BsAbstract.Interface.MEDIAL_MAGMA with type t = bool = Magma;
+  module MedialMagma: BsBastet.Interface.MEDIAL_MAGMA with type t = bool = Magma;
 
-  module Semigroup: BsAbstract.Interface.SEMIGROUP with type t = bool = Magma;
+  module Semigroup: BsBastet.Interface.SEMIGROUP with type t = bool = Magma;
   include Relude_Extensions_Semigroup.SemigroupExtensions(Semigroup);
 
-  module Monoid: BsAbstract.Interface.MONOID with type t = bool = {
+  module Monoid: BsBastet.Interface.MONOID with type t = bool = {
     include Semigroup;
     let empty = true;
   };
@@ -133,17 +133,17 @@ module Conjunctive = {
 module And = Conjunctive;
 
 module Disjunctive = {
-  module Magma: BsAbstract.Interface.MAGMA with type t = bool = {
+  module Magma: BsBastet.Interface.MAGMA with type t = bool = {
     type t = bool;
     let append = (||);
   };
 
-  module MedialMagma: BsAbstract.Interface.MEDIAL_MAGMA with type t = bool = Magma;
+  module MedialMagma: BsBastet.Interface.MEDIAL_MAGMA with type t = bool = Magma;
 
-  module Semigroup: BsAbstract.Interface.SEMIGROUP with type t = bool = Magma;
+  module Semigroup: BsBastet.Interface.SEMIGROUP with type t = bool = Magma;
   include Relude_Extensions_Semigroup.SemigroupExtensions(Semigroup);
 
-  module Monoid: BsAbstract.Interface.MONOID with type t = bool = {
+  module Monoid: BsBastet.Interface.MONOID with type t = bool = {
     include Semigroup;
     let empty = false;
   };
@@ -152,7 +152,7 @@ module Disjunctive = {
 
 module Or = Disjunctive;
 
-module Bounded: BsAbstract.Interface.BOUNDED with type t = bool = {
+module Bounded: BsBastet.Interface.BOUNDED with type t = bool = {
   include Ord;
   let top = true;
   let bottom = false;

--- a/src/Relude_Bool.re
+++ b/src/Relude_Bool.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
  * Folds a bool value into a value of a different type, using a function
  * for the true and false cases.
@@ -74,7 +76,7 @@ let eq: (bool, bool) => bool =
 /**
  * EQ instance for booleans
  */
-module Eq: BsBastet.Interface.EQ with type t = bool = {
+module Eq: EQ with type t = bool = {
   type t = bool;
   let eq = eq;
 };
@@ -82,7 +84,7 @@ module Eq: BsBastet.Interface.EQ with type t = bool = {
 /**
  * Compares two booleans for equality
  */
-let compare: (bool, bool) => BsBastet.Interface.ordering =
+let compare: (bool, bool) => ordering =
   (a, b) =>
     switch (a, b) {
     | (true, true) => `equal_to
@@ -94,7 +96,7 @@ let compare: (bool, bool) => BsBastet.Interface.ordering =
 /**
  * ORD instance for booleans
  */
-module Ord: BsBastet.Interface.ORD with type t = bool = {
+module Ord: ORD with type t = bool = {
   include Eq;
   let compare = compare;
 };
@@ -107,23 +109,23 @@ let show: bool => string = b => b ? "true" : "false";
 /**
  * SHOW instance for booleans
  */
-module Show: BsBastet.Interface.SHOW with type t = bool = {
+module Show: SHOW with type t = bool = {
   type t = bool;
   let show = show;
 };
 
 module Conjunctive = {
-  module Magma: BsBastet.Interface.MAGMA with type t = bool = {
+  module Magma: MAGMA with type t = bool = {
     type t = bool;
     let append = (&&);
   };
 
-  module MedialMagma: BsBastet.Interface.MEDIAL_MAGMA with type t = bool = Magma;
+  module MedialMagma: MEDIAL_MAGMA with type t = bool = Magma;
 
-  module Semigroup: BsBastet.Interface.SEMIGROUP with type t = bool = Magma;
+  module Semigroup: SEMIGROUP with type t = bool = Magma;
   include Relude_Extensions_Semigroup.SemigroupExtensions(Semigroup);
 
-  module Monoid: BsBastet.Interface.MONOID with type t = bool = {
+  module Monoid: MONOID with type t = bool = {
     include Semigroup;
     let empty = true;
   };
@@ -133,17 +135,17 @@ module Conjunctive = {
 module And = Conjunctive;
 
 module Disjunctive = {
-  module Magma: BsBastet.Interface.MAGMA with type t = bool = {
+  module Magma: MAGMA with type t = bool = {
     type t = bool;
     let append = (||);
   };
 
-  module MedialMagma: BsBastet.Interface.MEDIAL_MAGMA with type t = bool = Magma;
+  module MedialMagma: MEDIAL_MAGMA with type t = bool = Magma;
 
-  module Semigroup: BsBastet.Interface.SEMIGROUP with type t = bool = Magma;
+  module Semigroup: SEMIGROUP with type t = bool = Magma;
   include Relude_Extensions_Semigroup.SemigroupExtensions(Semigroup);
 
-  module Monoid: BsBastet.Interface.MONOID with type t = bool = {
+  module Monoid: MONOID with type t = bool = {
     include Semigroup;
     let empty = false;
   };
@@ -152,7 +154,7 @@ module Disjunctive = {
 
 module Or = Disjunctive;
 
-module Bounded: BsBastet.Interface.BOUNDED with type t = bool = {
+module Bounded: BOUNDED with type t = bool = {
   include Ord;
   let top = true;
   let bottom = false;

--- a/src/Relude_ContT.re
+++ b/src/Relude_ContT.re
@@ -1,7 +1,9 @@
+open BsBastet.Interface;
+
 /**
  * Creates a ContT (continuation) Monad module with the given Monad module.
  */
-module WithMonad = (M: BsBastet.Interface.MONAD) => {
+module WithMonad = (M: MONAD) => {
   /**
    * The type of a continuation.  `'a` is the intermediate result type, and `'r`' is the final result type.
    */
@@ -68,7 +70,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
           ),
       );
 
-  module WithResult = (R: BsBastet.Interface.TYPE) => {
+  module WithResult = (R: TYPE) => {
     type nonrec t('a) = t(R.t, 'a); // = | ContT(('a => M.t(R.t)) => M.t(R.t));
 
     let make = make;
@@ -80,26 +82,25 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
     let pure = pure;
     let bind = bind;
 
-    module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
+    module Functor: FUNCTOR with type t('a) = t('a) = {
       type nonrec t('a) = t('a);
       let map = map;
     };
     include Relude_Extensions.Functor.FunctorExtensions(Functor);
 
-    module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
+    module Apply: APPLY with type t('a) = t('a) = {
       include Functor;
       let apply = apply;
     };
     include Relude_Extensions.Apply.ApplyExtensions(Apply);
 
-    module Applicative:
-      BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
+    module Applicative: APPLICATIVE with type t('a) = t('a) = {
       include Apply;
       let pure = pure;
     };
     include Relude_Extensions.Applicative.ApplicativeExtensions(Applicative);
 
-    module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
+    module Monad: MONAD with type t('a) = t('a) = {
       include Applicative;
       let flat_map = bind;
     };
@@ -113,8 +114,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
   };
 };
 
-module WithMonadAndResult =
-       (M: BsBastet.Interface.MONAD, R: BsBastet.Interface.TYPE) => {
+module WithMonadAndResult = (M: MONAD, R: TYPE) => {
   module WithMonad = WithMonad(M);
   include WithMonad.WithResult(R);
 };

--- a/src/Relude_ContT.re
+++ b/src/Relude_ContT.re
@@ -1,7 +1,7 @@
 /**
  * Creates a ContT (continuation) Monad module with the given Monad module.
  */
-module WithMonad = (M: BsAbstract.Interface.MONAD) => {
+module WithMonad = (M: BsBastet.Interface.MONAD) => {
   /**
    * The type of a continuation.  `'a` is the intermediate result type, and `'r`' is the final result type.
    */
@@ -68,7 +68,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
           ),
       );
 
-  module WithResult = (R: BsAbstract.Interface.TYPE) => {
+  module WithResult = (R: BsBastet.Interface.TYPE) => {
     type nonrec t('a) = t(R.t, 'a); // = | ContT(('a => M.t(R.t)) => M.t(R.t));
 
     let make = make;
@@ -80,26 +80,26 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
     let pure = pure;
     let bind = bind;
 
-    module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+    module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
       type nonrec t('a) = t('a);
       let map = map;
     };
     include Relude_Extensions.Functor.FunctorExtensions(Functor);
 
-    module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+    module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
       include Functor;
       let apply = apply;
     };
     include Relude_Extensions.Apply.ApplyExtensions(Apply);
 
     module Applicative:
-      BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+      BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
       include Apply;
       let pure = pure;
     };
     include Relude_Extensions.Applicative.ApplicativeExtensions(Applicative);
 
-    module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+    module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
       include Applicative;
       let flat_map = bind;
     };
@@ -114,7 +114,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
 };
 
 module WithMonadAndResult =
-       (M: BsAbstract.Interface.MONAD, R: BsAbstract.Interface.TYPE) => {
+       (M: BsBastet.Interface.MONAD, R: BsBastet.Interface.TYPE) => {
   module WithMonad = WithMonad(M);
   include WithMonad.WithResult(R);
 };

--- a/src/Relude_Eq.re
+++ b/src/Relude_Eq.re
@@ -19,7 +19,7 @@ let by: 'a 'b. ('b => 'a, eq('a)) => eq('b) =
 let cmap = by;
 
 module Contravariant:
-  BsAbstract.Interface.CONTRAVARIANT with type t('a) = eq('a) = {
+  BsBastet.Interface.CONTRAVARIANT with type t('a) = eq('a) = {
   type t('a) = eq('a);
   let cmap = cmap;
 };

--- a/src/Relude_Float.re
+++ b/src/Relude_Float.re
@@ -1,9 +1,11 @@
+open BsBastet.Interface;
+
 /**
  * Indicates if two floats are exactly equal
  */
 let eq: (float, float) => bool = (a, b) => a == b;
 
-module Eq: BsBastet.Interface.EQ with type t = float = {
+module Eq: EQ with type t = float = {
   type t = float;
   let eq = eq;
 };
@@ -98,15 +100,15 @@ let isNaN: float => bool = x => x != x;
 /**
  * Compates two floats
  */
-let compare: (float, float) => BsBastet.Interface.ordering = BsBastet.Float.Ord.compare;
+let compare: (float, float) => ordering = BsBastet.Float.Ord.compare;
 
-module Ord: BsBastet.Interface.ORD with type t = float = {
+module Ord: ORD with type t = float = {
   include Eq;
   let compare = compare;
 };
 include Relude_Extensions_Ord.OrdExtensions(Ord);
 
-module Semiring: BsBastet.Interface.SEMIRING with type t = float = {
+module Semiring: SEMIRING with type t = float = {
   type t = float;
   let zero = zero;
   let one = one;
@@ -115,14 +117,14 @@ module Semiring: BsBastet.Interface.SEMIRING with type t = float = {
 };
 include Relude_Extensions_Semiring.SemiringExtensions(Semiring);
 
-module Ring: BsBastet.Interface.RING with type t = float = {
+module Ring: RING with type t = float = {
   include Semiring;
   let subtract = (a, b) => a -. b;
 };
 include Relude_Extensions_Ring.RingExtensions(Ring);
 include OrdRingExtensions(Ring);
 
-module EuclideanRing: BsBastet.Interface.EUCLIDEAN_RING with type t = float = {
+module EuclideanRing: EUCLIDEAN_RING with type t = float = {
   include Ring;
   let divide = divide;
   let modulo = (_, _) => 0.0;
@@ -240,7 +242,7 @@ let show: float => string = Js.Float.toString;
  */
 let toString = show;
 
-module Show: BsBastet.Interface.SHOW with type t = float = {
+module Show: SHOW with type t = float = {
   type t = float;
   let show = show;
 };

--- a/src/Relude_Float.re
+++ b/src/Relude_Float.re
@@ -3,7 +3,7 @@
  */
 let eq: (float, float) => bool = (a, b) => a == b;
 
-module Eq: BsAbstract.Interface.EQ with type t = float = {
+module Eq: BsBastet.Interface.EQ with type t = float = {
   type t = float;
   let eq = eq;
 };
@@ -98,15 +98,15 @@ let isNaN: float => bool = x => x != x;
 /**
  * Compates two floats
  */
-let compare: (float, float) => BsAbstract.Interface.ordering = BsAbstract.Float.Ord.compare;
+let compare: (float, float) => BsBastet.Interface.ordering = BsBastet.Float.Ord.compare;
 
-module Ord: BsAbstract.Interface.ORD with type t = float = {
+module Ord: BsBastet.Interface.ORD with type t = float = {
   include Eq;
   let compare = compare;
 };
 include Relude_Extensions_Ord.OrdExtensions(Ord);
 
-module Semiring: BsAbstract.Interface.SEMIRING with type t = float = {
+module Semiring: BsBastet.Interface.SEMIRING with type t = float = {
   type t = float;
   let zero = zero;
   let one = one;
@@ -115,14 +115,14 @@ module Semiring: BsAbstract.Interface.SEMIRING with type t = float = {
 };
 include Relude_Extensions_Semiring.SemiringExtensions(Semiring);
 
-module Ring: BsAbstract.Interface.RING with type t = float = {
+module Ring: BsBastet.Interface.RING with type t = float = {
   include Semiring;
   let subtract = (a, b) => a -. b;
 };
 include Relude_Extensions_Ring.RingExtensions(Ring);
 include OrdRingExtensions(Ring);
 
-module EuclideanRing: BsAbstract.Interface.EUCLIDEAN_RING with type t = float = {
+module EuclideanRing: BsBastet.Interface.EUCLIDEAN_RING with type t = float = {
   include Ring;
   let divide = divide;
   let modulo = (_, _) => 0.0;
@@ -240,7 +240,7 @@ let show: float => string = Js.Float.toString;
  */
 let toString = show;
 
-module Show: BsAbstract.Interface.SHOW with type t = float = {
+module Show: BsBastet.Interface.SHOW with type t = float = {
   type t = float;
   let show = show;
 };
@@ -263,21 +263,21 @@ let fromString: string => option(float) =
     };
 
 module Additive = {
-  include BsAbstract.Float.Additive;
+  include BsBastet.Float.Additive;
 };
 
 module Multiplicative = {
-  include BsAbstract.Float.Multiplicative;
+  include BsBastet.Float.Multiplicative;
 };
 
 module Subtractive = {
-  include BsAbstract.Float.Subtractive;
+  include BsBastet.Float.Subtractive;
 };
 
 module Divisive = {
-  include BsAbstract.Float.Divisive;
+  include BsBastet.Float.Divisive;
 };
 
 module Infix = {
-  include BsAbstract.Float.Infix;
+  include BsBastet.Float.Infix;
 };

--- a/src/Relude_Free_Applicative.re
+++ b/src/Relude_Free_Applicative.re
@@ -1,6 +1,6 @@
 open Relude_Function.Infix;
 
-module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
+module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
   type t('a) =
     | Pure('a): t('a)
     | Apply(F.t('x), t('x => 'a)): t('a);
@@ -13,7 +13,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
         Apply(fx, freeXToA |> map(xToA => xToA >> aToB))
       };
 
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
@@ -29,7 +29,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
         Apply(fx, freeXToB);
       };
 
-  module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+  module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
     include Functor;
     let apply = apply;
   };
@@ -37,8 +37,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
 
   let pure: 'a. 'a => t('a) = a => Pure(a);
 
-  module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+  module Applicative: BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
     include Apply;
     let pure = pure;
   };
@@ -58,7 +57,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
    * doesn't seem to work with the existential type captured by the FreeAp
    * (at least I couldn't figure it out).
    */
-  module WithApplicative = (A: BsAbstract.Interface.APPLICATIVE) => {
+  module WithApplicative = (A: BsBastet.Interface.APPLICATIVE) => {
     /**
      * We also need a natural transformation in order to create our interpreters
      * for the free applicative. Because of the existential type captured by the
@@ -91,7 +90,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
 
   module WithApplicativeAndNT =
          (
-           A: BsAbstract.Interface.APPLICATIVE,
+           A: BsBastet.Interface.APPLICATIVE,
            NT:
              Relude_Interface.NATURAL_TRANSFORMATION with
                type f('a) = F.t('a) and type g('a) = A.t('a),

--- a/src/Relude_Free_Applicative.re
+++ b/src/Relude_Free_Applicative.re
@@ -1,6 +1,7 @@
+open BsBastet.Interface;
 open Relude_Function.Infix;
 
-module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
+module WithFunctor = (F: FUNCTOR) => {
   type t('a) =
     | Pure('a): t('a)
     | Apply(F.t('x), t('x => 'a)): t('a);
@@ -13,7 +14,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
         Apply(fx, freeXToA |> map(xToA => xToA >> aToB))
       };
 
-  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
@@ -29,7 +30,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
         Apply(fx, freeXToB);
       };
 
-  module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
+  module Apply: APPLY with type t('a) = t('a) = {
     include Functor;
     let apply = apply;
   };
@@ -37,7 +38,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
 
   let pure: 'a. 'a => t('a) = a => Pure(a);
 
-  module Applicative: BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
+  module Applicative: APPLICATIVE with type t('a) = t('a) = {
     include Apply;
     let pure = pure;
   };
@@ -57,7 +58,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
    * doesn't seem to work with the existential type captured by the FreeAp
    * (at least I couldn't figure it out).
    */
-  module WithApplicative = (A: BsBastet.Interface.APPLICATIVE) => {
+  module WithApplicative = (A: APPLICATIVE) => {
     /**
      * We also need a natural transformation in order to create our interpreters
      * for the free applicative. Because of the existential type captured by the
@@ -90,7 +91,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
 
   module WithApplicativeAndNT =
          (
-           A: BsBastet.Interface.APPLICATIVE,
+           A: APPLICATIVE,
            NT:
              Relude_Interface.NATURAL_TRANSFORMATION with
                type f('a) = F.t('a) and type g('a) = A.t('a),

--- a/src/Relude_Free_Monad.re
+++ b/src/Relude_Free_Monad.re
@@ -1,4 +1,4 @@
-module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
+module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
   type t('a) =
     | Pure('a)
     | FlatMap(F.t(t('a)));
@@ -11,7 +11,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
         FlatMap(fFreeA |> F.map(freeA => freeA |> map(aToB)))
       };
 
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
@@ -26,7 +26,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
       };
     };
 
-  module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+  module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
     include Functor;
     let apply = apply;
   };
@@ -34,8 +34,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
 
   let pure: 'a. 'a => t('a) = a => Pure(a);
 
-  module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+  module Applicative: BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
     include Apply;
     let pure = pure;
   };
@@ -49,7 +48,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
         FlatMap(fFreeA |> F.map(freeA => bind(freeA, aToFreeB)))
       };
 
-  module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+  module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
     include Applicative;
     let flat_map = bind;
   };
@@ -66,7 +65,7 @@ module WithFunctor = (F: BsAbstract.Interface.FUNCTOR) => {
   /**
    * Specifies a monad into which we will interpret our free monadic program
    */
-  module WithMonad = (M: BsAbstract.Interface.MONAD) => {
+  module WithMonad = (M: BsBastet.Interface.MONAD) => {
     /**
      * Applies an interpreter function to interpret each value of our algebra into
      * a target monad.

--- a/src/Relude_Free_Monad.re
+++ b/src/Relude_Free_Monad.re
@@ -1,4 +1,6 @@
-module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
+open BsBastet.Interface;
+
+module WithFunctor = (F: FUNCTOR) => {
   type t('a) =
     | Pure('a)
     | FlatMap(F.t(t('a)));
@@ -11,7 +13,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
         FlatMap(fFreeA |> F.map(freeA => freeA |> map(aToB)))
       };
 
-  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
@@ -26,7 +28,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
       };
     };
 
-  module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
+  module Apply: APPLY with type t('a) = t('a) = {
     include Functor;
     let apply = apply;
   };
@@ -34,7 +36,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
 
   let pure: 'a. 'a => t('a) = a => Pure(a);
 
-  module Applicative: BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
+  module Applicative: APPLICATIVE with type t('a) = t('a) = {
     include Apply;
     let pure = pure;
   };
@@ -48,7 +50,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
         FlatMap(fFreeA |> F.map(freeA => bind(freeA, aToFreeB)))
       };
 
-  module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
+  module Monad: MONAD with type t('a) = t('a) = {
     include Applicative;
     let flat_map = bind;
   };
@@ -65,7 +67,7 @@ module WithFunctor = (F: BsBastet.Interface.FUNCTOR) => {
   /**
    * Specifies a monad into which we will interpret our free monadic program
    */
-  module WithMonad = (M: BsBastet.Interface.MONAD) => {
+  module WithMonad = (M: MONAD) => {
     /**
      * Applies an interpreter function to interpret each value of our algebra into
      * a target monad.

--- a/src/Relude_Function.re
+++ b/src/Relude_Function.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
   This module defines functions that let you manipulate
   other functions.
@@ -400,30 +402,29 @@ module Infix = {
   let (>>) = flipCompose;
 };
 
-module WithArgument = (R: BsBastet.Interface.TYPE) => {
-  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = R.t => 'a = {
+module WithArgument = (R: TYPE) => {
+  module Functor: FUNCTOR with type t('a) = R.t => 'a = {
     type t('a) = R.t => 'a;
     let map = map;
   };
   let map = Functor.map;
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-  module Apply: BsBastet.Interface.APPLY with type t('a) = R.t => 'a = {
+  module Apply: APPLY with type t('a) = R.t => 'a = {
     include Functor;
     let apply = apply;
   };
   let apply = Apply.apply;
   include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-  module Applicative:
-    BsBastet.Interface.APPLICATIVE with type t('a) = R.t => 'a = {
+  module Applicative: APPLICATIVE with type t('a) = R.t => 'a = {
     include Apply;
     let pure = pure;
   };
   let pure = Applicative.pure;
   include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-  module Monad: BsBastet.Interface.MONAD with type t('a) = R.t => 'a = {
+  module Monad: MONAD with type t('a) = R.t => 'a = {
     include Applicative;
     let flat_map = bind;
   };

--- a/src/Relude_Function.re
+++ b/src/Relude_Function.re
@@ -400,15 +400,15 @@ module Infix = {
   let (>>) = flipCompose;
 };
 
-module WithArgument = (R: BsAbstract.Interface.TYPE) => {
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = R.t => 'a = {
+module WithArgument = (R: BsBastet.Interface.TYPE) => {
+  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = R.t => 'a = {
     type t('a) = R.t => 'a;
     let map = map;
   };
   let map = Functor.map;
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-  module Apply: BsAbstract.Interface.APPLY with type t('a) = R.t => 'a = {
+  module Apply: BsBastet.Interface.APPLY with type t('a) = R.t => 'a = {
     include Functor;
     let apply = apply;
   };
@@ -416,14 +416,14 @@ module WithArgument = (R: BsAbstract.Interface.TYPE) => {
   include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
   module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) = R.t => 'a = {
+    BsBastet.Interface.APPLICATIVE with type t('a) = R.t => 'a = {
     include Apply;
     let pure = pure;
   };
   let pure = Applicative.pure;
   include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-  module Monad: BsAbstract.Interface.MONAD with type t('a) = R.t => 'a = {
+  module Monad: BsBastet.Interface.MONAD with type t('a) = R.t => 'a = {
     include Applicative;
     let flat_map = bind;
   };

--- a/src/Relude_IO.re
+++ b/src/Relude_IO.re
@@ -1,3 +1,4 @@
+open BsBastet.Interface;
 open Relude_Function.Infix;
 
 /**
@@ -1405,8 +1406,7 @@ let throttle:
       };
   };
 
-module Bifunctor:
-  BsAbstract.Interface.BIFUNCTOR with type t('a, 'e) = t('a, 'e) = {
+module Bifunctor: BIFUNCTOR with type t('a, 'e) = t('a, 'e) = {
   type nonrec t('a, 'e) = t('a, 'e);
   let bimap = bimap;
 };
@@ -1417,10 +1417,10 @@ include Relude_Extensions_Bifunctor.BifunctorExtensions(Bifunctor);
 Because this is a bifunctor, we need to use a module functor to lock in the error type,
 so we can implement many of the single-type parameter typeclasses.
 */
-module WithError = (E: BsAbstract.Interface.TYPE) => {
+module WithError = (E: TYPE) => {
   type nonrec t('a) = t('a, E.t);
 
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
@@ -1428,22 +1428,21 @@ module WithError = (E: BsAbstract.Interface.TYPE) => {
   let mapError = mapError;
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-  module Alt: BsAbstract.Interface.ALT with type t('a) = t('a) = {
+  module Alt: ALT with type t('a) = t('a) = {
     include Functor;
     let alt = alt;
   };
   let alt = alt;
   include Relude_Extensions_Alt.AltExtensions(Alt);
 
-  module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+  module Apply: APPLY with type t('a) = t('a) = {
     include Functor;
     let apply = apply;
   };
   let apply = Apply.apply;
   include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-  module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+  module Applicative: APPLICATIVE with type t('a) = t('a) = {
     include Apply;
     let pure = pure;
   };
@@ -1457,7 +1456,7 @@ module WithError = (E: BsAbstract.Interface.TYPE) => {
   };
   include Relude_Extensions_Semialign.SemialignExtensions(Semialign);
 
-  module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+  module Monad: MONAD with type t('a) = t('a) = {
     include Applicative;
     let flat_map = bind;
   };
@@ -1482,8 +1481,7 @@ module WithError = (E: BsAbstract.Interface.TYPE) => {
   include Relude_Extensions_MonadError.MonadErrorExtensions(MonadError);
 
   // Not sure if this is valid, but I'll leave it for now
-  module Semigroupoid:
-    BsAbstract.Interface.SEMIGROUPOID with type t('a, 'b) = t('a => 'b) = {
+  module Semigroupoid: SEMIGROUPOID with type t('a, 'b) = t('a => 'b) = {
     type nonrec t('a, 'b) = t('a => 'b);
     let compose = compose;
   };

--- a/src/Relude_Identity.re
+++ b/src/Relude_Identity.re
@@ -19,7 +19,7 @@ let unwrap: 'a. t('a) => 'a = a => a;
  */
 let map: 'a 'b. ('a => 'b, t('a)) => t('b) = (f, fa) => f(fa);
 
-module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
   type nonrec t('a) = t('a);
   let map = map;
 };
@@ -30,7 +30,7 @@ include Relude_Extensions_Functor.FunctorExtensions(Functor);
  */
 let apply: 'a 'b. (t('a => 'b), t('a)) => t('b) = (ff, fa) => ff(fa);
 
-module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
   include Functor;
   let apply = apply;
 };
@@ -38,12 +38,12 @@ include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
 /**
  * Lifts a pure value into the Identity.
- * 
+ *
  * Alias for `wrap`
  */
 let pure: 'a. 'a => t('a) = wrap;
 
-module Applicative: BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+module Applicative: BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
   include Apply;
   let pure = pure;
 };
@@ -54,7 +54,7 @@ include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
  */
 let bind: 'a 'b. (t('a), 'a => t('b)) => t('b) = (fa, f) => f(fa);
 
-module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
   include Applicative;
   let flat_map = bind;
 };
@@ -66,7 +66,7 @@ include Relude_Extensions_Monad.MonadExtensions(Monad);
 let eq =
     (
       type a,
-      eq: (module BsAbstract.Interface.EQ with type t = a),
+      eq: (module BsBastet.Interface.EQ with type t = a),
       fa: t(a),
       fb: t(a),
     )
@@ -82,11 +82,10 @@ let eqBy: (('a, 'a) => bool, t('a), t('a)) => bool =
   (f, fa, fb) => f(unwrap(fa), unwrap(fb));
 
 module type EQ_F =
-  (EQ: BsAbstract.Interface.EQ) =>
-   BsAbstract.Interface.EQ with type t = t(EQ.t);
+  (EQ: BsBastet.Interface.EQ) => BsBastet.Interface.EQ with type t = t(EQ.t);
 
 module Eq: EQ_F =
-  (EQ: BsAbstract.Interface.EQ) => {
+  (EQ: BsBastet.Interface.EQ) => {
     type nonrec t = t(EQ.t);
     let eq: (t, t) => bool = (fa, fb) => eqBy(EQ.eq, fa, fb);
   };
@@ -97,7 +96,7 @@ module Eq: EQ_F =
 let show =
     (
       type a,
-      show: (module BsAbstract.Interface.SHOW with type t = a),
+      show: (module BsBastet.Interface.SHOW with type t = a),
       fa: t(a),
     )
     : string => {
@@ -111,13 +110,11 @@ let show =
 let showBy: 'a. ('a => string, t('a)) => string = (f, fa) => f(unwrap(fa));
 
 module type SHOW_F =
-  (S: BsAbstract.Interface.SHOW) =>
-   BsAbstract.Interface.SHOW with type t = t(S.t);
+  (S: BsBastet.Interface.SHOW) =>
+   BsBastet.Interface.SHOW with type t = t(S.t);
 
 module Show: SHOW_F =
-  (S: BsAbstract.Interface.SHOW) => {
+  (S: BsBastet.Interface.SHOW) => {
     type nonrec t = t(S.t);
     let show: t => string = fa => showBy(S.show, fa);
-  };
-
-// TODO: semigroup/monoid/plus/alt/etc.
+  } /* TODO: semigroup/monoid/plus/alt/etc*/;

--- a/src/Relude_Int.re
+++ b/src/Relude_Int.re
@@ -116,9 +116,9 @@ let rec rangeAsArray: (int, int) => array(int) =
 /**
   `eq(a, b)` returns `true` if the arguments are equal, `false` otherwise.
 */
-let eq: (int, int) => bool = BsAbstract.Int.Eq.eq;
+let eq: (int, int) => bool = BsBastet.Int.Eq.eq;
 
-module Eq: BsAbstract.Interface.EQ with type t = int = {
+module Eq: BsBastet.Interface.EQ with type t = int = {
   type t = int;
   let eq = eq;
 };
@@ -127,7 +127,7 @@ include Relude_Extensions_Eq.EqExtensions(Eq);
 /**
   `compare(a, b)` returns ` `less_than ` if `a` is less than `b`,
   ` `equal_to ` if `a` equals `b`, and ` `greater_than ` if `a`
-  is greater than `b`. The result is of type `BsAbstract.Interface.ordering`.
+  is greater than `b`. The result is of type `BsBastet.Interface.ordering`.
 
   ### Example
   ```re
@@ -136,15 +136,15 @@ include Relude_Extensions_Eq.EqExtensions(Eq);
   compare(5, 3) == `greater_than;
   ```
 */
-let compare: (int, int) => BsAbstract.Interface.ordering = BsAbstract.Int.Ord.compare;
+let compare: (int, int) => BsBastet.Interface.ordering = BsBastet.Int.Ord.compare;
 
-module Ord: BsAbstract.Interface.ORD with type t = int = {
+module Ord: BsBastet.Interface.ORD with type t = int = {
   include Eq;
   let compare = compare;
 };
 include Relude_Extensions_Ord.OrdExtensions(Ord);
 
-module Bounded: BsAbstract.Interface.BOUNDED with type t = int = {
+module Bounded: BsBastet.Interface.BOUNDED with type t = int = {
   include Ord;
   let top = top;
   let bottom = bottom;
@@ -170,7 +170,7 @@ include Relude_Extensions_Enum.EnumExtensions(Enum);
 
 // Not a BoundedEnum b/c cardinality would be larger than an signed int can represent
 
-module Semiring: BsAbstract.Interface.SEMIRING with type t = int = {
+module Semiring: BsBastet.Interface.SEMIRING with type t = int = {
   type t = int;
   let zero = zero;
   let one = one;
@@ -179,14 +179,14 @@ module Semiring: BsAbstract.Interface.SEMIRING with type t = int = {
 };
 include Relude_Extensions_Semiring.SemiringExtensions(Semiring);
 
-module Ring: BsAbstract.Interface.RING with type t = int = {
+module Ring: BsBastet.Interface.RING with type t = int = {
   include Semiring;
   let subtract = subtract;
 };
 include Relude_Extensions_Ring.RingExtensions(Ring);
 include OrdRingExtensions(Ring);
 
-module EuclideanRing: BsAbstract.Interface.EUCLIDEAN_RING with type t = int = {
+module EuclideanRing: BsBastet.Interface.EUCLIDEAN_RING with type t = int = {
   include Ring;
   let divide = divide;
   let modulo = modulo;
@@ -221,7 +221,7 @@ let show: int => string = string_of_int;
  */
 let toString = show;
 
-module Show: BsAbstract.Interface.SHOW with type t = int = {
+module Show: BsBastet.Interface.SHOW with type t = int = {
   type t = int;
   let show = show;
 };
@@ -245,23 +245,23 @@ let fromString: string => option(int) =
     };
 
 module Additive = {
-  include BsAbstract.Int.Additive;
+  include BsBastet.Int.Additive;
 };
 
 module Multiplicative = {
-  include BsAbstract.Int.Multiplicative;
+  include BsBastet.Int.Multiplicative;
 };
 
 module Subtractive = {
-  include BsAbstract.Int.Subtractive;
+  include BsBastet.Int.Subtractive;
 };
 
 module Divisive = {
-  include BsAbstract.Int.Divisive;
+  include BsBastet.Int.Divisive;
 };
 
 module Infix = {
-  include BsAbstract.Int.Infix;
+  include BsBastet.Int.Infix;
   include Relude_Extensions_Eq.EqInfix(Eq);
   include Relude_Extensions_Ord.OrdInfix(Ord);
 };

--- a/src/Relude_Int.re
+++ b/src/Relude_Int.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
  * `toFloat` returns the floating-point representation of the int
  */
@@ -118,7 +120,7 @@ let rec rangeAsArray: (int, int) => array(int) =
 */
 let eq: (int, int) => bool = BsBastet.Int.Eq.eq;
 
-module Eq: BsBastet.Interface.EQ with type t = int = {
+module Eq: EQ with type t = int = {
   type t = int;
   let eq = eq;
 };
@@ -127,7 +129,7 @@ include Relude_Extensions_Eq.EqExtensions(Eq);
 /**
   `compare(a, b)` returns ` `less_than ` if `a` is less than `b`,
   ` `equal_to ` if `a` equals `b`, and ` `greater_than ` if `a`
-  is greater than `b`. The result is of type `BsBastet.Interface.ordering`.
+  is greater than `b`. The result is of type `ordering`.
 
   ### Example
   ```re
@@ -136,15 +138,15 @@ include Relude_Extensions_Eq.EqExtensions(Eq);
   compare(5, 3) == `greater_than;
   ```
 */
-let compare: (int, int) => BsBastet.Interface.ordering = BsBastet.Int.Ord.compare;
+let compare: (int, int) => ordering = BsBastet.Int.Ord.compare;
 
-module Ord: BsBastet.Interface.ORD with type t = int = {
+module Ord: ORD with type t = int = {
   include Eq;
   let compare = compare;
 };
 include Relude_Extensions_Ord.OrdExtensions(Ord);
 
-module Bounded: BsBastet.Interface.BOUNDED with type t = int = {
+module Bounded: BOUNDED with type t = int = {
   include Ord;
   let top = top;
   let bottom = bottom;
@@ -170,7 +172,7 @@ include Relude_Extensions_Enum.EnumExtensions(Enum);
 
 // Not a BoundedEnum b/c cardinality would be larger than an signed int can represent
 
-module Semiring: BsBastet.Interface.SEMIRING with type t = int = {
+module Semiring: SEMIRING with type t = int = {
   type t = int;
   let zero = zero;
   let one = one;
@@ -179,14 +181,14 @@ module Semiring: BsBastet.Interface.SEMIRING with type t = int = {
 };
 include Relude_Extensions_Semiring.SemiringExtensions(Semiring);
 
-module Ring: BsBastet.Interface.RING with type t = int = {
+module Ring: RING with type t = int = {
   include Semiring;
   let subtract = subtract;
 };
 include Relude_Extensions_Ring.RingExtensions(Ring);
 include OrdRingExtensions(Ring);
 
-module EuclideanRing: BsBastet.Interface.EUCLIDEAN_RING with type t = int = {
+module EuclideanRing: EUCLIDEAN_RING with type t = int = {
   include Ring;
   let divide = divide;
   let modulo = modulo;
@@ -221,7 +223,7 @@ let show: int => string = string_of_int;
  */
 let toString = show;
 
-module Show: BsBastet.Interface.SHOW with type t = int = {
+module Show: SHOW with type t = int = {
   type t = int;
   let show = show;
 };

--- a/src/Relude_Interface.re
+++ b/src/Relude_Interface.re
@@ -16,7 +16,7 @@ module type FUNCTION_1 = {
  * Module type functor which captures a simple a => b function
  */
 module type FUNCTION_1_F =
-  (A: BsAbstract.Interface.TYPE, B: BsAbstract.Interface.TYPE) =>
+  (A: BsBastet.Interface.TYPE, B: BsBastet.Interface.TYPE) =>
    FUNCTION_1 with type a = A.t and type b = B.t;
 
 /**
@@ -31,8 +31,8 @@ module type NATURAL_TRANSFORMATION = {
   let f: f('a) => g('a);
   // Another encoding would be using FUNCTOR modules here, but the f('a)/g('a) version seems easier to work with inline,
   // and we've already gone off the deep end, so let's not make it any more clunky.
-  //module F: BsAbstract.Interface.FUNCTOR;
-  //module G: BsAbstract.Interface.FUNCTOR;
+  //module F: BsBastet.Interface.FUNCTOR;
+  //module G: BsBastet.Interface.FUNCTOR;
   //let f: F.t('a) => G.t('a);
 };
 
@@ -64,30 +64,30 @@ module type SEQUENCE = {
   let eqBy: (('a, 'a) => bool, t('a), t('a)) => bool;
   let showBy: ('a => string, t('a)) => string;
 
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) := t('a);
+  module Functor: BsBastet.Interface.FUNCTOR with type t('a) := t('a);
 
-  module Apply: BsAbstract.Interface.APPLY with type t('a) := t('a);
+  module Apply: BsBastet.Interface.APPLY with type t('a) := t('a);
 
   module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) := t('a);
+    BsBastet.Interface.APPLICATIVE with type t('a) := t('a);
 
-  module Monad: BsAbstract.Interface.MONAD with type t('a) := t('a);
+  module Monad: BsBastet.Interface.MONAD with type t('a) := t('a);
 
-  module Foldable: BsAbstract.Interface.FOLDABLE with type t('a) := t('a);
+  module Foldable: BsBastet.Interface.FOLDABLE with type t('a) := t('a);
 
   module Traversable:
-    (A: BsAbstract.Interface.APPLICATIVE) =>
+    (A: BsBastet.Interface.APPLICATIVE) =>
 
-      BsAbstract.Interface.TRAVERSABLE with
+      BsBastet.Interface.TRAVERSABLE with
         type t('a) = t('a) and type applicative_t('a) = A.t('a);
 
   module Eq:
-    (EqA: BsAbstract.Interface.EQ) =>
-     BsAbstract.Interface.EQ with type t = t(EqA.t);
+    (EqA: BsBastet.Interface.EQ) =>
+     BsBastet.Interface.EQ with type t = t(EqA.t);
 
   module Show:
-    (ShowA: BsAbstract.Interface.SHOW) =>
-     BsAbstract.Interface.SHOW with type t = t(ShowA.t);
+    (ShowA: BsBastet.Interface.SHOW) =>
+     BsBastet.Interface.SHOW with type t = t(ShowA.t);
 };
 
 /**
@@ -112,7 +112,7 @@ module type ISO_LIST = {
  * Module type signature for Ior-based zipping and unzipping
  */
 module type SEMIALIGN = {
-  include BsAbstract.Interface.FUNCTOR;
+  include BsBastet.Interface.FUNCTOR;
   let align: (t('a), t('b)) => t(Relude_Ior_Type.t('a, 'b));
   let alignWith: (Relude_Ior_Type.t('a, 'b) => 'c, t('a), t('b)) => t('c);
 };
@@ -121,9 +121,9 @@ module type SEMIALIGN = {
  * Module type signature for an extension of ALIGN that adds an empty `nil` value.
  *
  * Note that this has a parallel to the applicative typeclasses:
- * 
+ *
  * APPLY/APPLICATIVE/TRAVERSABLE
- * 
+ *
  * SEMIALIGN/ALIGN/CROSSWALK (or maybe ALIGNABLE?)
  */
 module type ALIGN = {
@@ -135,7 +135,7 @@ module type ALIGN = {
  * Module type signature for a Monad that can produce an error in a monadic context
  */
 module type MONAD_THROW = {
-  include BsAbstract.Interface.MONAD;
+  include BsBastet.Interface.MONAD;
   type e;
   let throwError: e => t('a);
 };
@@ -169,7 +169,7 @@ module type UPPER_BOUNDED = {
  * a lawful chain of successors and predecessors
  */
 module type ENUM = {
-  include BsAbstract.Interface.ORD;
+  include BsBastet.Interface.ORD;
   let succ: t => option(t);
   let pred: t => option(t);
 };
@@ -179,7 +179,7 @@ module type ENUM = {
  * a lawful chain of successors and predecessors, and there is a top and bottom bound.
  */
 module type BOUNDED_ENUM = {
-  include BsAbstract.Interface.BOUNDED;
+  include BsBastet.Interface.BOUNDED;
   include ENUM with type t := t;
   let cardinality: int;
   let fromEnum: t => int;

--- a/src/Relude_Interface.re
+++ b/src/Relude_Interface.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
  * Module type signature for a type constructor with a single type hole.
  */
@@ -16,8 +18,7 @@ module type FUNCTION_1 = {
  * Module type functor which captures a simple a => b function
  */
 module type FUNCTION_1_F =
-  (A: BsBastet.Interface.TYPE, B: BsBastet.Interface.TYPE) =>
-   FUNCTION_1 with type a = A.t and type b = B.t;
+  (A: TYPE, B: TYPE) => FUNCTION_1 with type a = A.t and type b = B.t;
 
 /**
  * Captures a natural tranformation
@@ -31,8 +32,8 @@ module type NATURAL_TRANSFORMATION = {
   let f: f('a) => g('a);
   // Another encoding would be using FUNCTOR modules here, but the f('a)/g('a) version seems easier to work with inline,
   // and we've already gone off the deep end, so let's not make it any more clunky.
-  //module F: BsBastet.Interface.FUNCTOR;
-  //module G: BsBastet.Interface.FUNCTOR;
+  //module F: FUNCTOR;
+  //module G: FUNCTOR;
   //let f: F.t('a) => G.t('a);
 };
 
@@ -64,30 +65,25 @@ module type SEQUENCE = {
   let eqBy: (('a, 'a) => bool, t('a), t('a)) => bool;
   let showBy: ('a => string, t('a)) => string;
 
-  module Functor: BsBastet.Interface.FUNCTOR with type t('a) := t('a);
+  module Functor: FUNCTOR with type t('a) := t('a);
 
-  module Apply: BsBastet.Interface.APPLY with type t('a) := t('a);
+  module Apply: APPLY with type t('a) := t('a);
 
-  module Applicative:
-    BsBastet.Interface.APPLICATIVE with type t('a) := t('a);
+  module Applicative: APPLICATIVE with type t('a) := t('a);
 
-  module Monad: BsBastet.Interface.MONAD with type t('a) := t('a);
+  module Monad: MONAD with type t('a) := t('a);
 
-  module Foldable: BsBastet.Interface.FOLDABLE with type t('a) := t('a);
+  module Foldable: FOLDABLE with type t('a) := t('a);
 
   module Traversable:
-    (A: BsBastet.Interface.APPLICATIVE) =>
+    (A: APPLICATIVE) =>
 
-      BsBastet.Interface.TRAVERSABLE with
+      TRAVERSABLE with
         type t('a) = t('a) and type applicative_t('a) = A.t('a);
 
-  module Eq:
-    (EqA: BsBastet.Interface.EQ) =>
-     BsBastet.Interface.EQ with type t = t(EqA.t);
+  module Eq: (EqA: EQ) => EQ with type t = t(EqA.t);
 
-  module Show:
-    (ShowA: BsBastet.Interface.SHOW) =>
-     BsBastet.Interface.SHOW with type t = t(ShowA.t);
+  module Show: (ShowA: SHOW) => SHOW with type t = t(ShowA.t);
 };
 
 /**
@@ -112,7 +108,7 @@ module type ISO_LIST = {
  * Module type signature for Ior-based zipping and unzipping
  */
 module type SEMIALIGN = {
-  include BsBastet.Interface.FUNCTOR;
+  include FUNCTOR;
   let align: (t('a), t('b)) => t(Relude_Ior_Type.t('a, 'b));
   let alignWith: (Relude_Ior_Type.t('a, 'b) => 'c, t('a), t('b)) => t('c);
 };
@@ -135,7 +131,7 @@ module type ALIGN = {
  * Module type signature for a Monad that can produce an error in a monadic context
  */
 module type MONAD_THROW = {
-  include BsBastet.Interface.MONAD;
+  include MONAD;
   type e;
   let throwError: e => t('a);
 };
@@ -169,7 +165,7 @@ module type UPPER_BOUNDED = {
  * a lawful chain of successors and predecessors
  */
 module type ENUM = {
-  include BsBastet.Interface.ORD;
+  include ORD;
   let succ: t => option(t);
   let pred: t => option(t);
 };
@@ -179,7 +175,7 @@ module type ENUM = {
  * a lawful chain of successors and predecessors, and there is a top and bottom bound.
  */
 module type BOUNDED_ENUM = {
-  include BsBastet.Interface.BOUNDED;
+  include BOUNDED;
   include ENUM with type t := t;
   let cardinality: int;
   let fromEnum: t => int;

--- a/src/Relude_Ior.re
+++ b/src/Relude_Ior.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
  * Ior is similar to result, but it has the ability to collect "non-fatal
  * warning" information during applicative validation.
@@ -377,38 +379,29 @@ let mergeWith: 'a 'b 'c. ('a => 'c, 'b => 'c, ('c, 'c) => 'c, t('a, 'b)) => 'c =
  * Creates a module that locks in the That TYPE and SEMIGROUP_ANY modules, so
  * that we can implement the typeclass instances for the single-type-parameter typeclasses.
  */
-module WithThats =
-       (
-         Thats: BsAbstract.Interface.SEMIGROUP_ANY,
-         That: BsAbstract.Interface.TYPE,
-       ) => {
-  module Functor:
-    BsAbstract.Interface.FUNCTOR with type t('a) = t('a, Thats.t(That.t)) = {
+module WithThats = (Thats: SEMIGROUP_ANY, That: TYPE) => {
+  module Functor: FUNCTOR with type t('a) = t('a, Thats.t(That.t)) = {
     type nonrec t('a) = t('a, Thats.t(That.t));
     let map = map;
   };
   let map = Functor.map;
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-  module Apply:
-    BsAbstract.Interface.APPLY with type t('a) = t('a, Thats.t(That.t)) = {
+  module Apply: APPLY with type t('a) = t('a, Thats.t(That.t)) = {
     include Functor;
     let apply = (ff, fa) => applyWithAppendThats(Thats.append, ff, fa);
   };
   let apply = Apply.apply;
   include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-  module Applicative:
-    BsAbstract.Interface.APPLICATIVE with
-      type t('a) = t('a, Thats.t(That.t)) = {
+  module Applicative: APPLICATIVE with type t('a) = t('a, Thats.t(That.t)) = {
     include Apply;
     let pure = pure;
   };
   let pure = Applicative.pure;
   include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-  module Monad:
-    BsAbstract.Interface.MONAD with type t('a) = t('a, Thats.t(That.t)) = {
+  module Monad: MONAD with type t('a) = t('a, Thats.t(That.t)) = {
     include Applicative;
     let flat_map = bind;
   };

--- a/src/Relude_Map.re
+++ b/src/Relude_Map.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 type t('key, 'value, 'id) = Belt.Map.t('key, 'value, 'id);
 
 /**
@@ -20,8 +22,10 @@ let set: ('key, 'value, t('key, 'value, 'id)) => t('key, 'value, 'id) =
 /**
  * Contruct a new map from the provided key and value.
  */
-let singleton: (Belt.Id.comparable('key, 'id), 'key, 'value) => t('key, 'value, 'id) =
-  (comparable, key, value) => Belt.Map.make(~id=comparable) |> Belt.Map.set(_, key, value);
+let singleton:
+  (Belt.Id.comparable('key, 'id), 'key, 'value) => t('key, 'value, 'id) =
+  (comparable, key, value) =>
+    Belt.Map.make(~id=comparable) |> Belt.Map.set(_, key, value);
 
 /**
  * Determine whether a map is empty.
@@ -31,7 +35,8 @@ let isEmpty: t('key, 'value, 'id) => bool = Belt.Map.isEmpty;
 /**
  * Determine whether a map contains a given key.
  */
-let contains: ('key, t('key, 'value, 'id)) => bool = key => Belt.Map.has(_, key);
+let contains: ('key, t('key, 'value, 'id)) => bool =
+  key => Belt.Map.has(_, key);
 
 /**
  * Compare the ordering of two maps, given a comparator function capable of
@@ -39,7 +44,9 @@ let contains: ('key, t('key, 'value, 'id)) => bool = key => Belt.Map.has(_, key)
  * to return an int representing the comparison, and `compareInt` intself will
  * return an int.
  */
-let compareInt: (('value, 'value) => int, t('key, 'value, 'id), t('key, 'value, 'id)) => int =
+let compareInt:
+  (('value, 'value) => int, t('key, 'value, 'id), t('key, 'value, 'id)) =>
+  int =
   (comparator, a, b) => Belt.Map.cmp(a, b, comparator);
 
 /**
@@ -50,11 +57,11 @@ let compareInt: (('value, 'value) => int, t('key, 'value, 'id), t('key, 'value, 
  */
 let compareBy:
   (
-    ('value, 'value) => BsAbstract.Interface.ordering,
+    ('value, 'value) => ordering,
     t('key, 'value, 'id),
     t('key, 'value, 'id)
   ) =>
-  BsAbstract.Interface.ordering =
+  ordering =
   (comparator, a, b) =>
     compareInt((a, b) => Relude_Ordering.toInt(comparator(a, b)), a, b)
     |> Relude_Ordering.fromInt;
@@ -64,14 +71,17 @@ let compareBy:
  * determine whether two maps are equal by checking whether they have equal
  * keys, and equal values at each key.
  */
-let eqBy: (('value, 'value) => bool, t('key, 'value, 'id), t('key, 'value, 'id)) => bool =
+let eqBy:
+  (('value, 'value) => bool, t('key, 'value, 'id), t('key, 'value, 'id)) =>
+  bool =
   (comparator, a, b) => Belt.Map.eq(a, b, comparator);
 
 /**
  * Find (optionally) the first key/value pair in a map matching the provided
  * predicate function.
  */
-let find: (('key, 'value) => bool, t('key, 'value, 'id)) => option(('key, 'value)) =
+let find:
+  (('key, 'value) => bool, t('key, 'value, 'id)) => option(('key, 'value)) =
   by => Belt.Map.findFirstBy(_, by);
 
 /**
@@ -85,7 +95,8 @@ let forEach: (('key, 'value) => unit, t('key, 'value, 'id)) => unit =
 /**
  * Accumulate a map of key/value pairs into a single value.
  */
-let foldLeft: (('acc, 'key, 'value) => 'acc, 'acc, t('key, 'value, 'id)) => 'acc =
+let foldLeft:
+  (('acc, 'key, 'value) => 'acc, 'acc, t('key, 'value, 'id)) => 'acc =
   (fn, acc) => Belt.Map.reduce(_, acc, fn);
 
 /**
@@ -101,7 +112,8 @@ let all: (('key, 'value) => bool, t('key, 'value, 'id)) => bool =
  * whether at least one pair in the map satisfies the predicate. This will
  * always return `false` for empty maps.
  */
-let any: (('key, 'value) => bool, t('key, 'value, 'id)) => bool = cond => Belt.Map.some(_, cond);
+let any: (('key, 'value) => bool, t('key, 'value, 'id)) => bool =
+  cond => Belt.Map.some(_, cond);
 
 /**
  * The count of keys in the map.
@@ -118,7 +130,9 @@ let toArray: t('key, 'value, 'id) => array(('key, 'value)) = Belt.Map.toArray;
 /**
  * Convert an associated array (an array of (key, value) tuples) into a map.
  */
-let fromArray: (Belt.Id.comparable('key, 'id), array(('key, 'value))) => t('key, 'value, 'id) =
+let fromArray:
+  (Belt.Id.comparable('key, 'id), array(('key, 'value))) =>
+  t('key, 'value, 'id) =
   (comparable, arr) => Belt.Map.fromArray(~id=comparable, arr);
 
 /**
@@ -127,9 +141,13 @@ let fromArray: (Belt.Id.comparable('key, 'id), array(('key, 'value))) => t('key,
  * identified (and that identifier can be ordered).
  */
 let fromValueArray:
-  (Belt.Id.comparable('key, 'id), 'value => 'key, array('value)) => t('key, 'value, 'id) =
+  (Belt.Id.comparable('key, 'id), 'value => 'key, array('value)) =>
+  t('key, 'value, 'id) =
   (comparable, toKey) =>
-    Relude_Array_Instances.foldLeft((map, v) => set(toKey(v), v, map), make(comparable));
+    Relude_Array_Instances.foldLeft(
+      (map, v) => set(toKey(v), v, map),
+      make(comparable),
+    );
 
 /**
  * Convert a map to an associated list (a list of key/value tuples). Note that
@@ -141,8 +159,11 @@ let toList: t('key, 'value, 'id) => list(('key, 'value)) = Belt.Map.toList;
 /**
  * Convert an associated list (a list of (key, value) tuples) into a map.
  */
-let fromList: (Belt.Id.comparable('key, 'id), list(('key, 'value))) => t('key, 'value, 'id) =
-  (comparable, lst) => Belt.Map.fromArray(lst |> Belt.List.toArray, ~id=comparable);
+let fromList:
+  (Belt.Id.comparable('key, 'id), list(('key, 'value))) =>
+  t('key, 'value, 'id) =
+  (comparable, lst) =>
+    Belt.Map.fromArray(lst |> Belt.List.toArray, ~id=comparable);
 
 /**
  * Convert a list of values into a map, using the provided function from
@@ -150,9 +171,13 @@ let fromList: (Belt.Id.comparable('key, 'id), list(('key, 'value))) => t('key, '
  * identified (and that identifier can be ordered).
  */
 let fromValueList:
-  (Belt.Id.comparable('key, 'id), 'value => 'key, list('value)) => t('key, 'value, 'id) =
+  (Belt.Id.comparable('key, 'id), 'value => 'key, list('value)) =>
+  t('key, 'value, 'id) =
   (comparable, toKey) =>
-    Relude_List_Instances.foldLeft((map, v) => set(toKey(v), v, map), make(comparable));
+    Relude_List_Instances.foldLeft(
+      (map, v) => set(toKey(v), v, map),
+      make(comparable),
+    );
 
 /**
  * Return a sorted array containing each key in the map.
@@ -162,7 +187,8 @@ let keyArray: t('key, 'value, 'id) => array('key) = Belt.Map.keysToArray;
 /**
  * Return a sorted list containing each key in the map
  */
-let keys: t('key, 'value, 'id) => list('key) = map => keyArray(map) |> Belt.List.fromArray;
+let keys: t('key, 'value, 'id) => list('key) =
+  map => keyArray(map) |> Belt.List.fromArray;
 
 /**
  * Return an array of each value (sorted by key) in the map.
@@ -198,7 +224,8 @@ let max: t('key, 'value, 'id) => option(('key, 'value)) = Belt.Map.maximum;
 /**
  * Attempt to find a value in a map, given a key.
  */
-let get: ('key, t('key, 'value, 'id)) => option('value) = key => Belt.Map.get(_, key);
+let get: ('key, t('key, 'value, 'id)) => option('value) =
+  key => Belt.Map.get(_, key);
 
 /**
  * Attempt to find a value in a map, given a key. Use the provided fallback
@@ -228,7 +255,8 @@ let removeMany: (array('key), t('key, 'value, 'id)) => t('key, 'value, 'id) =
  * `None`, which will perform a `remove`.
  */
 let update:
-  ('key, option('value) => option('value), t('key, 'value, 'id)) => t('key, 'value, 'id) =
+  ('key, option('value) => option('value), t('key, 'value, 'id)) =>
+  t('key, 'value, 'id) =
   (key, updateFn) => Belt.Map.update(_, key, updateFn);
 
 /**
@@ -256,13 +284,15 @@ let merge:
  * TODO: it's not clear from the Belt docs what happens in the case of key
  * conflicts.
  */
-let mergeMany: (array(('key, 'value)), t('key, 'value, 'id)) => t('key, 'value, 'id) =
+let mergeMany:
+  (array(('key, 'value)), t('key, 'value, 'id)) => t('key, 'value, 'id) =
   arr => Belt.Map.mergeMany(_, arr);
 
 /**
  * Remove each key/value pair that doesn't pass the given predicate function.
  */
-let filter: (('key, 'value) => bool, t('key, 'value, 'id)) => t('key, 'value, 'id) =
+let filter:
+  (('key, 'value) => bool, t('key, 'value, 'id)) => t('key, 'value, 'id) =
   fn => Belt.Map.keep(_, fn);
 
 let partition:
@@ -273,26 +303,34 @@ let partition:
 /**
  * Transform each value in the map to a new value using the provided function.
  */
-let map: ('v1 => 'v2, t('key, 'v1, 'id)) => t('key, 'v2, 'id) = fn => Belt.Map.map(_, fn);
+let map: ('v1 => 'v2, t('key, 'v1, 'id)) => t('key, 'v2, 'id) =
+  fn => Belt.Map.map(_, fn);
 
 let mapWithKey: (('key, 'v1) => 'v2, t('key, 'v1, 'id)) => t('key, 'v2, 'id) =
   fn => Belt.Map.mapWithKey(_, fn);
 
 let groupListBy:
-  (Belt.Id.comparable('key, 'id), 'value => 'key, list('value)) => t('key, list('value), 'id) =
+  (Belt.Id.comparable('key, 'id), 'value => 'key, list('value)) =>
+  t('key, list('value), 'id) =
   (comparable, groupBy) => {
     open Relude_Function.Infix;
-    let addItemToGroup = x => getOrElse(x |> groupBy, []) >> (xs => [x, ...xs]);
-    let addItemToMap = (dict, x) => dict |> set(x |> groupBy, addItemToGroup(x, dict));
-    Belt.List.reduce(_, make(comparable), addItemToMap) >> map(Belt.List.reverse);
+    let addItemToGroup = x =>
+      getOrElse(x |> groupBy, []) >> (xs => [x, ...xs]);
+    let addItemToMap = (dict, x) =>
+      dict |> set(x |> groupBy, addItemToGroup(x, dict));
+    Belt.List.reduce(_, make(comparable), addItemToMap)
+    >> map(Belt.List.reverse);
   };
 
 let groupArrayBy:
-  (Belt.Id.comparable('key, 'id), 'value => 'key, array('value)) => t('key, array('value), 'id) =
+  (Belt.Id.comparable('key, 'id), 'value => 'key, array('value)) =>
+  t('key, array('value), 'id) =
   (comparable, groupBy) => {
     open Relude_Function.Infix;
-    let addItemToGroup = x => getOrElse(x |> groupBy, [||]) >> Belt.Array.concat(_, [|x|]);
-    let addItemToMap = (dict, x) => dict |> set(x |> groupBy, addItemToGroup(x, dict));
+    let addItemToGroup = x =>
+      getOrElse(x |> groupBy, [||]) >> Belt.Array.concat(_, [|x|]);
+    let addItemToMap = (dict, x) =>
+      dict |> set(x |> groupBy, addItemToGroup(x, dict));
     Belt.Array.reduce(_, make(comparable), addItemToMap);
   };
 
@@ -311,8 +349,7 @@ module type MAP = {
   let contains: (key, t('value)) => bool;
   let compareInt: (('value, 'value) => int, t('value), t('value)) => int;
   let compareBy:
-    (('value, 'value) => BsAbstract.Interface.ordering, t('value), t('value)) =>
-    BsAbstract.Interface.ordering;
+    (('value, 'value) => ordering, t('value), t('value)) => ordering;
 
   let eqBy: (('value, 'value) => bool, t('value), t('value)) => bool;
   let find: ((key, 'value) => bool, t('value)) => option((key, 'value));
@@ -339,21 +376,26 @@ module type MAP = {
   let getOrElse: (key, 'value, t('value)) => 'value;
   let remove: (key, t('value)) => t('value);
   let removeMany: (array(key), t('value)) => t('value);
-  let update: (key, option('value) => option('value), t('value)) => t('value);
+  let update:
+    (key, option('value) => option('value), t('value)) => t('value);
   let merge:
-    ((key, option('value), option('value)) => option('value), t('value), t('value)) =>
+    (
+      (key, option('value), option('value)) => option('value),
+      t('value),
+      t('value)
+    ) =>
     t('value);
   let mergeMany: (array((key, 'value)), t('value)) => t('value);
   let filter: ((key, 'value) => bool, t('value)) => t('value);
-  let partition: ((key, 'value) => bool, t('value)) => (t('value), t('value));
+  let partition:
+    ((key, 'value) => bool, t('value)) => (t('value), t('value));
   let map: ('v1 => 'v2, t('v1)) => t('v2);
   let mapWithKey: ((key, 'v1) => 'v2, t('v1)) => t('v2);
   let groupListBy: ('a => key, list('a)) => t(list('a));
   let groupArrayBy: ('a => key, array('a)) => t(array('a));
 };
 
-module WithOrd = (M: BsAbstract.Interface.ORD) : (MAP with type key = M.t) => {
-
+module WithOrd = (M: ORD) : (MAP with type key = M.t) => {
   type key = M.t;
 
   module Comparable =
@@ -365,12 +407,14 @@ module WithOrd = (M: BsAbstract.Interface.ORD) : (MAP with type key = M.t) => {
   type nonrec t('value) = t(key, 'value, Comparable.identity);
 
   let make: unit => t('value) = () => make((module Comparable));
-  let singleton: (key, 'value) => t('value) = (key, value) => make() |> set(key, value);
+  let singleton: (key, 'value) => t('value) =
+    (key, value) => make() |> set(key, value);
   let fromArray: array((key, 'value)) => t('value) =
     arr => fromArray((module Comparable), arr);
   let fromValueArray: ('value => key, array('value)) => t('value) =
     (toKey, arr) => fromValueArray((module Comparable), toKey, arr);
-  let fromList: list((key, 'value)) => t('value) = lst => fromList((module Comparable), lst);
+  let fromList: list((key, 'value)) => t('value) =
+    lst => fromList((module Comparable), lst);
   let fromValueList: ('value => key, list('value)) => t('value) =
     (toKey, lst) => fromValueList((module Comparable), toKey, lst);
   let groupListBy: ('value => key, list('value)) => t(list('value)) =
@@ -382,8 +426,7 @@ module WithOrd = (M: BsAbstract.Interface.ORD) : (MAP with type key = M.t) => {
   let contains: (key, t('value)) => bool = contains;
   let compareInt: (('value, 'value) => int, t('value), t('value)) => int = compareInt;
   let compareBy:
-    (('value, 'value) => BsAbstract.Interface.ordering, t('value), t('value)) =>
-    BsAbstract.Interface.ordering = compareBy;
+    (('value, 'value) => ordering, t('value), t('value)) => ordering = compareBy;
   let eqBy: (('value, 'value) => bool, t('value), t('value)) => bool = eqBy;
   let find: ((key, 'value) => bool, t('value)) => option((key, 'value)) = find;
   let forEach: ((key, 'value) => unit, t('value)) => unit = forEach;
@@ -405,20 +448,25 @@ module WithOrd = (M: BsAbstract.Interface.ORD) : (MAP with type key = M.t) => {
   let getOrElse: (key, 'value, t('value)) => 'value = getOrElse;
   let remove: (key, t('value)) => t('value) = remove;
   let removeMany: (array(key), t('value)) => t('value) = removeMany;
-  let update: (key, option('value) => option('value), t('value)) => t('value) = update;
+  let update:
+    (key, option('value) => option('value), t('value)) => t('value) = update;
   let merge:
-    ((key, option('value), option('value)) => option('value), t('value), t('value)) =>
+    (
+      (key, option('value), option('value)) => option('value),
+      t('value),
+      t('value)
+    ) =>
     t('value) = merge;
   let mergeMany: (array((key, 'value)), t('value)) => t('value) = mergeMany;
   let filter: ((key, 'value) => bool, t('value)) => t('value) = filter;
-  let partition: ((key, 'value) => bool, t('value)) => (t('value), t('value)) = partition;
+  let partition:
+    ((key, 'value) => bool, t('value)) => (t('value), t('value)) = partition;
   let map: ('v1 => 'v2, t('v1)) => t('v2) = map;
   let mapWithKey: ((key, 'v1) => 'v2, t('v1)) => t('v2) = mapWithKey;
 
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
-
 };

--- a/src/Relude_OptionT.re
+++ b/src/Relude_OptionT.re
@@ -1,7 +1,7 @@
 /**
  * Creates an OptionT monad with the given outer Monad
  */
-module WithMonad = (M: BsAbstract.Interface.MONAD) => {
+module WithMonad = (M: BsBastet.Interface.MONAD) => {
   type t('a) =
     | OptionT(M.t(option('a)));
 
@@ -20,7 +20,8 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
   let fromOption: 'a. option('a) => t('a) =
     optionA => OptionT(M.pure(optionA));
 
-  let liftF: 'a. M.t('a) => t('a) = mA => OptionT(M.map(a => Some(a), mA));
+  let liftF: 'a. M.t('a) => t('a) =
+    mA => OptionT(M.map(a => Some(a), mA));
 
   let map: 'a 'b. ('a => 'b, t('a)) => t('b) =
     (aToB, OptionT(mOptionA)) =>
@@ -28,9 +29,11 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
 
   let subflatMap: 'a 'b. ('a => option('b), t('a)) => t('b) =
     (aToB, OptionT(mOptionA)) =>
-      OptionT(M.map(optionA => Relude_Option.flatMap(aToB, optionA), mOptionA));
+      OptionT(
+        M.map(optionA => Relude_Option.flatMap(aToB, optionA), mOptionA),
+      );
 
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
@@ -50,7 +53,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
       );
     };
 
-  module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+  module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
     include Functor;
     let apply = apply;
   };
@@ -58,8 +61,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
 
   let pure: 'a. 'a => t('a) = a => OptionT(M.pure(Some(a)));
 
-  module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+  module Applicative: BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
     include Apply;
     let pure = pure;
   };
@@ -78,11 +80,11 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
         ),
       );
     };
-  
+
   let semiflatMap: 'a 'b. ('a => M.t('b), t('a)) => t('b) =
     (aToMB, optionTA) => bind(optionTA, a => liftF(aToMB(a)));
 
-  module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+  module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
     include Applicative;
     let flat_map = bind;
   };

--- a/src/Relude_OptionT.re
+++ b/src/Relude_OptionT.re
@@ -1,7 +1,9 @@
+open BsBastet.Interface;
+
 /**
  * Creates an OptionT monad with the given outer Monad
  */
-module WithMonad = (M: BsBastet.Interface.MONAD) => {
+module WithMonad = (M: MONAD) => {
   type t('a) =
     | OptionT(M.t(option('a)));
 
@@ -33,7 +35,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
         M.map(optionA => Relude_Option.flatMap(aToB, optionA), mOptionA),
       );
 
-  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
@@ -53,7 +55,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
       );
     };
 
-  module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
+  module Apply: APPLY with type t('a) = t('a) = {
     include Functor;
     let apply = apply;
   };
@@ -61,7 +63,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
 
   let pure: 'a. 'a => t('a) = a => OptionT(M.pure(Some(a)));
 
-  module Applicative: BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
+  module Applicative: APPLICATIVE with type t('a) = t('a) = {
     include Apply;
     let pure = pure;
   };
@@ -84,7 +86,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
   let semiflatMap: 'a 'b. ('a => M.t('b), t('a)) => t('b) =
     (aToMB, optionTA) => bind(optionTA, a => liftF(aToMB(a)));
 
-  module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
+  module Monad: MONAD with type t('a) = t('a) = {
     include Applicative;
     let flat_map = bind;
   };

--- a/src/Relude_Ord.re
+++ b/src/Relude_Ord.re
@@ -5,7 +5,7 @@
 /**
  * The ordering type represents the result of a comparison - `less_than, `equal_to, or `greater_than
  */
-type ordering = BsAbstract.Interface.ordering;
+type ordering = BsBastet.Interface.ordering;
 
 /**
  * The compare function is the heart of all comparison functions
@@ -36,7 +36,7 @@ let by: 'a 'b. ('b => 'a, compare('a)) => compare('b) =
 let cmap = by;
 
 module Contravariant:
-  BsAbstract.Interface.CONTRAVARIANT with type t('a) = compare('a) = {
+  BsBastet.Interface.CONTRAVARIANT with type t('a) = compare('a) = {
   type nonrec t('a) = compare('a);
   let cmap = by;
 };
@@ -70,12 +70,7 @@ let compareAsIntBy: 'a. (compare('a), 'a, 'a) => int =
  * Compares two values using the given ORD module
  */
 let compareAsInt =
-    (
-      type a,
-      ord: (module BsAbstract.Interface.ORD with type t = a),
-      a: a,
-      b: a,
-    )
+    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a: a, b: a)
     : int => {
   module Ord = (val ord);
   compareAsIntBy(Ord.compare, a, b);
@@ -95,8 +90,7 @@ let minBy: 'a. (compare('a), 'a, 'a) => 'a =
 /**
  * Finds the minimum of two values using the given ORD module
  */
-let min =
-    (type a, ord: (module BsAbstract.Interface.ORD with type t = a), a, b) => {
+let min = (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
   module Ord = (val ord);
   minBy(Ord.compare, a, b);
 };
@@ -115,8 +109,7 @@ let maxBy: 'a. (compare('a), 'a, 'a) => 'a =
 /**
  * Finds the maximum of two values using the given ORD module
  */
-let max =
-    (type a, ord: (module BsAbstract.Interface.ORD with type t = a), a, b) => {
+let max = (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
   module Ord = (val ord);
   maxBy(Ord.compare, a, b);
 };
@@ -136,7 +129,7 @@ let ltBy = lessThanBy;
  * Indicates if the item on the left is less than the item on the right using the given ORD module
  */
 let lessThan =
-    (type a, ord: (module BsAbstract.Interface.ORD with type t = a), a, b) => {
+    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
   module Ord = (val ord);
   lessThanBy(Ord.compare, a, b);
 };
@@ -161,7 +154,7 @@ let lteBy = lessThanOrEqBy;
  * Indicates if the item on the left is less than or equal to the item on the right using the given ORD module
  */
 let lessThanOrEq =
-    (type a, ord: (module BsAbstract.Interface.ORD with type t = a), a, b) => {
+    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
   module Ord = (val ord);
   lessThanOrEqBy(Ord.compare, a, b);
 };
@@ -186,7 +179,7 @@ let gtBy = greaterThanBy;
  * Indicates if the item on the left is greater than the item on the right using the given ORD module
  */
 let greaterThan =
-    (type a, ord: (module BsAbstract.Interface.ORD with type t = a), a, b) => {
+    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
   module Ord = (val ord);
   greaterThanBy(Ord.compare, a, b);
 };
@@ -211,7 +204,7 @@ let gteBy = greaterThanOrEqBy;
  * Indicates if the item on the left is greater than or equal to the item on the right using the given ORD module
  */
 let greaterThanOrEq =
-    (type a, ord: (module BsAbstract.Interface.ORD with type t = a), a, b) => {
+    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
   module Ord = (val ord);
   greaterThanOrEqBy(Ord.compare, a, b);
 };
@@ -243,7 +236,7 @@ let clampBy: 'a. (compare('a), ~min: 'a, ~max: 'a, 'a) => 'a =
 let clamp =
     (
       type a,
-      ord: (module BsAbstract.Interface.ORD with type t = a),
+      ord: (module BsBastet.Interface.ORD with type t = a),
       ~min: a,
       ~max: a,
       x,
@@ -265,7 +258,7 @@ let betweenBy: 'a. (compare('a), ~min: 'a, ~max: 'a, 'a) => bool =
 let between =
     (
       type a,
-      ord: (module BsAbstract.Interface.ORD with type t = a),
+      ord: (module BsBastet.Interface.ORD with type t = a),
       ~min: a,
       ~max: a,
       x,
@@ -280,8 +273,8 @@ let between =
 let abs =
     (
       type a,
-      ord: (module BsAbstract.Interface.ORD with type t = a),
-      ring: (module BsAbstract.Interface.RING with type t = a),
+      ord: (module BsBastet.Interface.ORD with type t = a),
+      ring: (module BsBastet.Interface.RING with type t = a),
       x,
     ) => {
   module Ring = (val ring);
@@ -295,8 +288,8 @@ let abs =
 let signum =
     (
       type a,
-      ord: (module BsAbstract.Interface.ORD with type t = a),
-      ring: (module BsAbstract.Interface.RING with type t = a),
+      ord: (module BsBastet.Interface.ORD with type t = a),
+      ring: (module BsBastet.Interface.RING with type t = a),
       x,
     )
     : a => {

--- a/src/Relude_Ord.re
+++ b/src/Relude_Ord.re
@@ -1,11 +1,13 @@
+open BsBastet.Interface;
+
 /**
  * Contains functions and modules for to help with comparing values
- */;
+ */
 
 /**
  * The ordering type represents the result of a comparison - `less_than, `equal_to, or `greater_than
  */
-type ordering = BsBastet.Interface.ordering;
+type nonrec ordering = ordering;
 
 /**
  * The compare function is the heart of all comparison functions
@@ -35,8 +37,7 @@ let by: 'a 'b. ('b => 'a, compare('a)) => compare('b) =
  */
 let cmap = by;
 
-module Contravariant:
-  BsBastet.Interface.CONTRAVARIANT with type t('a) = compare('a) = {
+module Contravariant: CONTRAVARIANT with type t('a) = compare('a) = {
   type nonrec t('a) = compare('a);
   let cmap = by;
 };
@@ -70,8 +71,7 @@ let compareAsIntBy: 'a. (compare('a), 'a, 'a) => int =
  * Compares two values using the given ORD module
  */
 let compareAsInt =
-    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a: a, b: a)
-    : int => {
+    (type a, ord: (module ORD with type t = a), a: a, b: a): int => {
   module Ord = (val ord);
   compareAsIntBy(Ord.compare, a, b);
 };
@@ -90,7 +90,7 @@ let minBy: 'a. (compare('a), 'a, 'a) => 'a =
 /**
  * Finds the minimum of two values using the given ORD module
  */
-let min = (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
+let min = (type a, ord: (module ORD with type t = a), a, b) => {
   module Ord = (val ord);
   minBy(Ord.compare, a, b);
 };
@@ -109,7 +109,7 @@ let maxBy: 'a. (compare('a), 'a, 'a) => 'a =
 /**
  * Finds the maximum of two values using the given ORD module
  */
-let max = (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
+let max = (type a, ord: (module ORD with type t = a), a, b) => {
   module Ord = (val ord);
   maxBy(Ord.compare, a, b);
 };
@@ -128,8 +128,7 @@ let ltBy = lessThanBy;
 /**
  * Indicates if the item on the left is less than the item on the right using the given ORD module
  */
-let lessThan =
-    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
+let lessThan = (type a, ord: (module ORD with type t = a), a, b) => {
   module Ord = (val ord);
   lessThanBy(Ord.compare, a, b);
 };
@@ -153,8 +152,7 @@ let lteBy = lessThanOrEqBy;
 /**
  * Indicates if the item on the left is less than or equal to the item on the right using the given ORD module
  */
-let lessThanOrEq =
-    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
+let lessThanOrEq = (type a, ord: (module ORD with type t = a), a, b) => {
   module Ord = (val ord);
   lessThanOrEqBy(Ord.compare, a, b);
 };
@@ -178,8 +176,7 @@ let gtBy = greaterThanBy;
 /**
  * Indicates if the item on the left is greater than the item on the right using the given ORD module
  */
-let greaterThan =
-    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
+let greaterThan = (type a, ord: (module ORD with type t = a), a, b) => {
   module Ord = (val ord);
   greaterThanBy(Ord.compare, a, b);
 };
@@ -203,8 +200,7 @@ let gteBy = greaterThanOrEqBy;
 /**
  * Indicates if the item on the left is greater than or equal to the item on the right using the given ORD module
  */
-let greaterThanOrEq =
-    (type a, ord: (module BsBastet.Interface.ORD with type t = a), a, b) => {
+let greaterThanOrEq = (type a, ord: (module ORD with type t = a), a, b) => {
   module Ord = (val ord);
   greaterThanOrEqBy(Ord.compare, a, b);
 };
@@ -233,14 +229,7 @@ let clampBy: 'a. (compare('a), ~min: 'a, ~max: 'a, 'a) => 'a =
 /**
  * First-class module version of clampBy
  */
-let clamp =
-    (
-      type a,
-      ord: (module BsBastet.Interface.ORD with type t = a),
-      ~min: a,
-      ~max: a,
-      x,
-    ) => {
+let clamp = (type a, ord: (module ORD with type t = a), ~min: a, ~max: a, x) => {
   module Ord = (val ord);
   clampBy(Ord.compare, ~min, ~max, x);
 };
@@ -255,14 +244,7 @@ let betweenBy: 'a. (compare('a), ~min: 'a, ~max: 'a, 'a) => bool =
 /**
  * First-class module version of betweenBy
  */
-let between =
-    (
-      type a,
-      ord: (module BsBastet.Interface.ORD with type t = a),
-      ~min: a,
-      ~max: a,
-      x,
-    ) => {
+let between = (type a, ord: (module ORD with type t = a), ~min: a, ~max: a, x) => {
   module Ord = (val ord);
   betweenBy(Ord.compare, ~min, ~max, x);
 };
@@ -273,8 +255,8 @@ let between =
 let abs =
     (
       type a,
-      ord: (module BsBastet.Interface.ORD with type t = a),
-      ring: (module BsBastet.Interface.RING with type t = a),
+      ord: (module ORD with type t = a),
+      ring: (module RING with type t = a),
       x,
     ) => {
   module Ring = (val ring);
@@ -288,8 +270,8 @@ let abs =
 let signum =
     (
       type a,
-      ord: (module BsBastet.Interface.ORD with type t = a),
-      ring: (module BsBastet.Interface.RING with type t = a),
+      ord: (module ORD with type t = a),
+      ring: (module RING with type t = a),
       x,
     )
     : a => {

--- a/src/Relude_Ordering.re
+++ b/src/Relude_Ordering.re
@@ -5,7 +5,7 @@
  * Functions that deal with comparing values don't belong here - these go in Relude_Ord/OrdExtensions.
  * This module is just for working with values of type `ordering`.
  */
-type t = BsAbstract.Interface.ordering;
+type t = BsBastet.Interface.ordering;
 
 /**
  * Converts an int to a type-safe ordering value
@@ -52,7 +52,7 @@ let eq: (t, t) => bool =
     | (`greater_than, _) => false
     };
 
-module Eq: BsAbstract.Interface.EQ with type t = t = {
+module Eq: BsBastet.Interface.EQ with type t = t = {
   type nonrec t = t;
   let eq = eq;
 };
@@ -75,7 +75,7 @@ let compare: (t, t) => t =
     | (`greater_than, `greater_than) => `equal_to
     };
 
-module Ord: BsAbstract.Interface.ORD with type t = t = {
+module Ord: BsBastet.Interface.ORD with type t = t = {
   include Eq;
   let compare = compare;
 };
@@ -85,7 +85,7 @@ let top = `greater_than;
 
 let bottom = `less_than;
 
-module Bounded: BsAbstract.Interface.BOUNDED with type t = t = {
+module Bounded: BsBastet.Interface.BOUNDED with type t = t = {
   include Ord;
   let top = top;
   let bottom = bottom;

--- a/src/Relude_RIO.re
+++ b/src/Relude_RIO.re
@@ -1,6 +1,7 @@
+open BsBastet.Interface;
 open Relude_Function.Infix;
 
-module WithError = (ERR: BsAbstract.Interface.TYPE) => {
+module WithError = (ERR: TYPE) => {
   module IOE = Relude_IO.WithError(ERR);
   module M = IOE.MonadError;
   type t('r, 'a) =
@@ -66,7 +67,7 @@ module WithError = (ERR: BsAbstract.Interface.TYPE) => {
    * Locks in the reader environment type, so that we can implement
    * the single-type-parameter typeclasses.
    */
-  module WithEnv = (R: BsAbstract.Interface.TYPE) => {
+  module WithEnv = (R: TYPE) => {
     type nonrec t('a) = t(R.t, 'a);
 
     let make = make;
@@ -78,29 +79,28 @@ module WithError = (ERR: BsAbstract.Interface.TYPE) => {
     let local = local;
     let semiflatMap = semiflatMap;
 
-    module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+    module Functor: FUNCTOR with type t('a) = t('a) = {
       type nonrec t('a) = t('a);
       let map = map;
     };
     let map = Functor.map;
     include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-    module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+    module Apply: APPLY with type t('a) = t('a) = {
       include Functor;
       let apply = apply;
     };
     let apply = Apply.apply;
     include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-    module Applicative:
-      BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+    module Applicative: APPLICATIVE with type t('a) = t('a) = {
       include Apply;
       let pure = pure;
     };
     let pure = Applicative.pure;
     include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-    module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+    module Monad: MONAD with type t('a) = t('a) = {
       include Applicative;
       let flat_map = bind;
     };
@@ -119,8 +119,7 @@ module WithError = (ERR: BsAbstract.Interface.TYPE) => {
  * Creates a RIO Monad with the given error and environment.
  * e.g. WithErrorAndEnv(ERR, ENV) = Rio(ENV.t => IO.t('a, ERR.t))
  */
-module WithErrorAndEnv =
-       (ERR: BsAbstract.Interface.TYPE, ENV: BsAbstract.Interface.TYPE) => {
+module WithErrorAndEnv = (ERR: TYPE, ENV: TYPE) => {
   module WithMonad = WithError(ERR);
   include WithMonad.WithEnv(ENV);
 };

--- a/src/Relude_ReaderT.re
+++ b/src/Relude_ReaderT.re
@@ -7,7 +7,7 @@ open Relude_Function.Infix;
 /**
  * Creates a ReaderT Monad with the given Monad module
  */
-module WithMonad = (M: BsAbstract.Interface.MONAD) => {
+module WithMonad = (M: BsBastet.Interface.MONAD) => {
   type t('r, 'a) =
     | ReaderT('r => M.t('a));
 
@@ -50,23 +50,17 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
               rToMB(r);
             },
           ),
-      )
+      );
 
   let semiflatMap: 'r 'a 'b. ('a => M.t('b), t('r, 'a)) => t('r, 'b) =
     (aToMA, ReaderT(rToMA)) =>
-      ReaderT(
-        r =>
-          M.flat_map(
-            rToMA(r),
-            a => aToMA(a),
-          ),
-      );
+      ReaderT(r => M.flat_map(rToMA(r), a => aToMA(a)));
 
   /**
    * Locks in the reader environment type, so that we can implement
    * the single-type-parameter typeclasses.
    */
-  module WithEnv = (R: BsAbstract.Interface.TYPE) => {
+  module WithEnv = (R: BsBastet.Interface.TYPE) => {
     type nonrec t('a) = t(R.t, 'a);
 
     let make = make;
@@ -78,14 +72,14 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
     let local = local;
     let semiflatMap = semiflatMap;
 
-    module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+    module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
       type nonrec t('a) = t('a);
       let map = map;
     };
     let map = Functor.map;
     include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-    module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+    module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
       include Functor;
       let apply = apply;
     };
@@ -93,14 +87,14 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
     include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
     module Applicative:
-      BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+      BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
       include Apply;
       let pure = pure;
     };
     let pure = Applicative.pure;
     include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-    module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+    module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
       include Applicative;
       let flat_map = bind;
     };
@@ -116,7 +110,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
 };
 
 module WithMonadAndEnv =
-       (M: BsAbstract.Interface.MONAD, E: BsAbstract.Interface.TYPE) => {
+       (M: BsBastet.Interface.MONAD, E: BsBastet.Interface.TYPE) => {
   module WithMonad = WithMonad(M);
   include WithMonad.WithEnv(E);
 };

--- a/src/Relude_ReaderT.re
+++ b/src/Relude_ReaderT.re
@@ -1,3 +1,4 @@
+open BsBastet.Interface;
 open Relude_Function.Infix;
 
 // TODO: not sure whether to just make this functor include the "Env" type R here along with the Monad, or
@@ -7,7 +8,7 @@ open Relude_Function.Infix;
 /**
  * Creates a ReaderT Monad with the given Monad module
  */
-module WithMonad = (M: BsBastet.Interface.MONAD) => {
+module WithMonad = (M: MONAD) => {
   type t('r, 'a) =
     | ReaderT('r => M.t('a));
 
@@ -60,7 +61,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
    * Locks in the reader environment type, so that we can implement
    * the single-type-parameter typeclasses.
    */
-  module WithEnv = (R: BsBastet.Interface.TYPE) => {
+  module WithEnv = (R: TYPE) => {
     type nonrec t('a) = t(R.t, 'a);
 
     let make = make;
@@ -72,29 +73,28 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
     let local = local;
     let semiflatMap = semiflatMap;
 
-    module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
+    module Functor: FUNCTOR with type t('a) = t('a) = {
       type nonrec t('a) = t('a);
       let map = map;
     };
     let map = Functor.map;
     include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-    module Apply: BsBastet.Interface.APPLY with type t('a) = t('a) = {
+    module Apply: APPLY with type t('a) = t('a) = {
       include Functor;
       let apply = apply;
     };
     let apply = Apply.apply;
     include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-    module Applicative:
-      BsBastet.Interface.APPLICATIVE with type t('a) = t('a) = {
+    module Applicative: APPLICATIVE with type t('a) = t('a) = {
       include Apply;
       let pure = pure;
     };
     let pure = Applicative.pure;
     include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-    module Monad: BsBastet.Interface.MONAD with type t('a) = t('a) = {
+    module Monad: MONAD with type t('a) = t('a) = {
       include Applicative;
       let flat_map = bind;
     };
@@ -109,8 +109,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
   };
 };
 
-module WithMonadAndEnv =
-       (M: BsBastet.Interface.MONAD, E: BsBastet.Interface.TYPE) => {
+module WithMonadAndEnv = (M: MONAD, E: TYPE) => {
   module WithMonad = WithMonad(M);
   include WithMonad.WithEnv(E);
 };

--- a/src/Relude_Result.re
+++ b/src/Relude_Result.re
@@ -1,42 +1,43 @@
+open BsBastet.Interface;
 open Relude_Function.Infix;
 
 type t('a, 'e) = result('a, 'e) = | Ok('a) | Error('e);
 
 /**
- `ok()` is a synonym for `pure()`.
-*/
+ * `ok()` is a synonym for `pure()`.
+ */
 let ok: 'a 'e. 'a => t('a, 'e) = a => Ok(a);
 
 /**
-  `error(x)` wraps its argument in `Error()`.
-
-  ### Example
-  ```re
-  error("Not even") == Error("Not even");
-  ```
-*/
+ * `error(x)` wraps its argument in `Error()`.
+ *
+ * ### Example
+ * ```re
+ * error("Not even") == Error("Not even");
+ * ```
+ */
 let error: 'a 'e. 'e => t('a, 'e) = e => Error(e);
 
 /**
-  `unit is a shortcut for `Ok(())`.
-
-  ### Example
-  ```re
-  unit == Ok(());
-  ```
-*/
+ * `unit is a shortcut for `Ok(())`.
+ *
+ * ### Example
+ * ```re
+ * unit == Ok(());
+ * ```
+ */
 let unit: 'e. t(unit, 'e) = Ok();
 
 /**
-  `getOk(result)` returns `Some(v)` when `result` is
-  of the form `Ok(v)`; otherwise it returns `None`.
-
-  ### Example
-  ```re
-  getOk(Ok(1066)) == Some(1066);
-  getOk(Error("bad value")) == None;
-  ```
-*/
+ * `getOk(result)` returns `Some(v)` when `result` is
+ * of the form `Ok(v)`; otherwise it returns `None`.
+ *
+ * ### Example
+ * ```re
+ * getOk(Ok(1066)) == Some(1066);
+ * getOk(Error("bad value")) == None;
+ * ```
+ */
 let getOk: 'a 'e. t('a, 'e) => option('a) =
   fun
   | Ok(a) => Some(a)
@@ -48,51 +49,51 @@ let getOk: 'a 'e. t('a, 'e) => option('a) =
 let toOption: 'a 'e. t('a, 'e) => option('a) = getOk;
 
 /**
-  `getError(result)` returns `Some(e)` when `result` is
-  of the form `Error(e)`; otherwise it returns `None`.
+ * `getError(result)` returns `Some(e)` when `result` is
+ * of the form `Error(e)`; otherwise it returns `None`.
 
-  ### Example
-  ```re
-  getError(Ok(1066)) == None;
-  getError(Error("bad value")) == Some("bad value");
-  ```
-*/
+ * ### Example
+ * ```re
+ * getError(Ok(1066)) == None;
+ * getError(Error("bad value")) == Some("bad value");
+ * ```
+ */
 let getError: 'a 'e. t('a, 'e) => option('e) =
   fun
   | Ok(_) => None
   | Error(e) => Some(e);
 
 /**
-  `isOK(result)` returns `true` if `result` is of the form `Ok(val)`,
-  `false` otherwise.
-*/
+ * `isOK(result)` returns `true` if `result` is of the form `Ok(val)`,
+ * `false` otherwise.
+ */
 let isOk: 'a 'e. t('a, 'e) => bool =
   fun
   | Ok(_) => true
   | Error(_) => false;
 
 /**
-  `isError(result)` returns `true` if `result` is of the form `Error(err)`,
-  `false` otherwise.
-*/
+ * `isError(result)` returns `true` if `result` is of the form `Error(err)`,
+ * `false` otherwise.
+ */
 let isError: 'a 'e. t('a, 'e) => bool =
   fun
   | Ok(_) => false
   | Error(_) => true;
 
 /**
-  `fold(errFcn, okFcn, x)` returns `okFcn(v)` when
-  `x` is of the form `Ok(v)`; it returns `errFcn(e)` when
-  `x` is of the form `Error(e)`.
-
-  ### Example
-  ```re
-  let errToInt = (_) => {-1};
-  let cube = (x) => {x * x * x};
-  fold(errToInt, cube, Ok(12)) == 1728;
-  fold(errToInt, cube, Error("bad")) == -1;
-  ```
-*/
+ * `fold(errFcn, okFcn, x)` returns `okFcn(v)` when
+ * `x` is of the form `Ok(v)`; it returns `errFcn(e)` when
+ * `x` is of the form `Error(e)`.
+ *
+ * ### Example
+ * ```re
+ * let errToInt = (_) => {-1};
+ * let cube = (x) => {x * x * x};
+ * fold(errToInt, cube, Ok(12)) == 1728;
+ * fold(errToInt, cube, Error("bad")) == -1;
+ * ```
+ */
 let fold: 'a 'e 'c. ('e => 'c, 'a => 'c, t('a, 'e)) => 'c =
   (ec, ac, r) =>
     switch (r) {
@@ -101,24 +102,24 @@ let fold: 'a 'e 'c. ('e => 'c, 'a => 'c, t('a, 'e)) => 'c =
     };
 
 /**
-  `getOrElse(default, result)` returns `v` when
-  `result` is of the form `Ok(v)`; otherwise, it
-  returns `default`.
-
-  ### Example
-  ```re
-  let safeAvg = (total, n): Relude.Result.t(float, string) => {
-    if (n > 0) {
-      Ok(total /. float_of_int(n));
-    } else {
-      Error("Cannot calcuate average");
-    };
-  };
-
-  getOrElse(0.0, safeAvg(32.0, 4)) == 8.0;
-  getOrElse(0.0, safeAvg(0.0, 0)) == 0.0;
-  ```
-*/
+ * `getOrElse(default, result)` returns `v` when
+ * `result` is of the form `Ok(v)`; otherwise, it
+ * returns `default`.
+ *
+ * ### Example
+ * ```re
+ * let safeAvg = (total, n): Relude.Result.t(float, string) => {
+ *   if (n > 0) {
+ *     Ok(total /. float_of_int(n));
+ *   } else {
+ *     Error("Cannot calcuate average");
+ *   };
+ * };
+ *
+ * getOrElse(0.0, safeAvg(32.0, 4)) == 8.0;
+ * getOrElse(0.0, safeAvg(0.0, 0)) == 0.0;
+ * ```
+ */
 let getOrElse: 'a 'e. ('a, t('a, 'e)) => 'a =
   (default, fa) =>
     switch (fa) {
@@ -126,6 +127,12 @@ let getOrElse: 'a 'e. ('a, t('a, 'e)) => 'a =
     | Error(_) => default
     };
 
+/**
+ * `getOrElseLazy` returns the `Ok` value inside the `result` or calls the
+ * provided function to get a value if the result is `Error`. Unlike
+ * `getOrElse`, this only constructs the fallback value if it's needed, which
+ * may be useful if the fallback is expensive to construct.
+ */
 let getOrElseLazy: 'a 'e. (unit => 'a, t('a, 'e)) => 'a =
   (getDefault, fa) =>
     switch (fa) {
@@ -134,31 +141,31 @@ let getOrElseLazy: 'a 'e. (unit => 'a, t('a, 'e)) => 'a =
     };
 
 /**
-  `merge(x)` “unwraps” its argument. If `x` is of the form
-  `Ok(v)`, the result is `v`. If `x` is of the form Error(e),
-  the result is `e`.
-
-  ### Example
-  ```re
-  merge(Ok(2)) == 2;
-  merge(Error("message")) == "message";
-  ```
-*/
+ * `merge(x)` “unwraps” its argument. If `x` is of the form
+ * `Ok(v)`, the result is `v`. If `x` is of the form Error(e),
+ * the result is `e`.
+ *
+ * ### Example
+ * ```re
+ * merge(Ok(2)) == 2;
+ * merge(Error("message")) == "message";
+ * ```
+ */
 let merge: 'a. t('a, 'a) => 'a =
   fun
   | Ok(a) => a
   | Error(a) => a;
 
 /**
-  `flip(x)` flips the values between the `Ok` and `Error` variants.
-  `Ok(val)`.
-
-  ### Example
-  ```re
-  flip(Ok(3)) == Error(3);
-  flip(Error(-1)) == Ok(-1);
-  ```
-*/
+ * `flip(x)` flips the values between the `Ok` and `Error` constructors.
+ * `Ok(val)`.
+ *
+ * ### Example
+ * ```re
+ * flip(Ok(3)) == Error(3);
+ * flip(Error(-1)) == Ok(-1);
+ * ```
+ */
 let flip: 'a 'e. t('a, 'e) => t('e, 'a) =
   fun
   | Ok(a) => Error(a)
@@ -226,20 +233,20 @@ let map: 'a 'b 'e. ('a => 'b, t('a, 'e)) => t('b, 'e) =
     };
 
 /**
-  `mapOk` is a synonym for `map`
-*/
+ * `mapOk` is a synonym for `map`
+ */
 let mapOk = map;
 
 /**
-  `mapError(f, x)` returns `Ok(v)` if `x` is of the form `OK(v)`.
-  It returns `Error(f(e))` if `x` is of the form `Error(e)`.
-
-  ### Example
-  ```re
-  mapError((x) => {"Err: " ++ x}, Ok(4)) == Ok(4);
-  mapError((x) => {"Err: " ++ x}, Error("bad")) == Error("Err: bad");
-  ```
-*/
+ * `mapError(f, x)` returns `Ok(v)` if `x` is of the form `OK(v)`.
+ * It returns `Error(f(e))` if `x` is of the form `Error(e)`.
+ *
+ * ### Example
+ * ```re
+ * mapError((x) => {"Err: " ++ x}, Ok(4)) == Ok(4);
+ * mapError((x) => {"Err: " ++ x}, Error("bad")) == Error("Err: bad");
+ * ```
+ */
 let mapError: 'a 'e1 'e2. ('e1 => 'e2, t('a, 'e1)) => t('a, 'e2) =
   (f, ra) =>
     switch (ra) {
@@ -248,17 +255,17 @@ let mapError: 'a 'e1 'e2. ('e1 => 'e2, t('a, 'e1)) => t('a, 'e2) =
     };
 
 /**
-  `bimap(f, g, x)` returns `Ok(f(v))` if `x` is of the form `Ok(v)`;
-  it returns `Error(g(e))` if `x` is of the form `Error(e)`.
-
-  ### Example
-  ```re
-  let cube = (x) => {x * x * x};
-  let label = (x) => {"Err: " ++ x};
-  bimap(cube, label, Ok(12)) == Ok(1728);
-  bimap(cube, label, Error("bad")) == Error("Err: bad");
-  ```
-*/
+ * `bimap(f, g, x)` returns `Ok(f(v))` if `x` is of the form `Ok(v)`;
+ * it returns `Error(g(e))` if `x` is of the form `Error(e)`.
+ *
+ * ### Example
+ * ```re
+ * let cube = (x) => {x * x * x};
+ * let label = (x) => {"Err: " ++ x};
+ * bimap(cube, label, Ok(12)) == Ok(1728);
+ * bimap(cube, label, Error("bad")) == Error("Err: bad");
+ * ```
+ */
 let bimap: 'a 'b 'e1 'e2. ('a => 'b, 'e1 => 'e2, t('a, 'e1)) => t('b, 'e2) =
   (mapA, mapE, result) =>
     switch (result) {
@@ -799,53 +806,51 @@ let toValidationNea:
   | Error(error) =>
     Relude_Validation.VError(Relude_NonEmpty.Array.pure(error));
 
-module Bifunctor:
-  BsAbstract.Interface.BIFUNCTOR with type t('a, 'e) = t('a, 'e) = {
+module Bifunctor: BIFUNCTOR with type t('a, 'e) = t('a, 'e) = {
   type nonrec t('a, 'e) = t('a, 'e);
   let bimap = bimap;
 };
 let bimap = Bifunctor.bimap;
 include Relude_Extensions_Bifunctor.BifunctorExtensions(Bifunctor);
 
-module Bifoldable:
-  BsAbstract.Interface.BIFOLDABLE with type t('a, 'e) = t('a, 'e) = {
-  include BsAbstract.Result.Bifoldable;
+module Bifoldable: BIFOLDABLE with type t('a, 'e) = t('a, 'e) = {
+  include BsBastet.Result.Bifoldable;
 };
 let bifoldLeft = Bifoldable.bifold_left;
 let bifoldRight = Bifoldable.bifold_right;
 include Relude_Extensions_Bifoldable.BifoldableExtensions(Bifoldable);
 
 /**
-Because Result is a bi-functor, we need to capture the error type in order
-to implement many of the single-type-parameter typeclasses.  Doing it like this
-allows us to unlock a bunch of stuff at once using a single module functor.
+ * Because Result is a bi-functor, we need to capture the error type in order
+ * to implement many of the single-type-parameter typeclasses. Doing it like
+ * this allows us to unlock a bunch of stuff at once using a single module
+ * functor.
  */
-module WithError = (E: BsAbstract.Interface.TYPE) => {
+module WithError = (E: TYPE) => {
   type nonrec t('a) = t('a, E.t);
 
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
   let map = Functor.map;
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-  module Alt: BsAbstract.Interface.ALT with type t('a) = t('a) = {
+  module Alt: ALT with type t('a) = t('a) = {
     include Functor;
     let alt = alt;
   };
   let alt = Alt.alt;
   include Relude_Extensions_Alt.AltExtensions(Alt);
 
-  module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+  module Apply: APPLY with type t('a) = t('a) = {
     include Functor;
     let apply = apply;
   };
   let apply = Apply.apply;
   include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-  module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+  module Applicative: APPLICATIVE with type t('a) = t('a) = {
     include Apply;
     let pure = pure;
   };
@@ -859,7 +864,7 @@ module WithError = (E: BsAbstract.Interface.TYPE) => {
   };
   include Relude_Extensions_Semialign.SemialignExtensions(Semialign);
 
-  module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+  module Monad: MONAD with type t('a) = t('a) = {
     include Applicative;
     let flat_map = bind;
   };
@@ -883,31 +888,29 @@ module WithError = (E: BsAbstract.Interface.TYPE) => {
   let catchError = MonadError.catchError;
   include Relude_Extensions_MonadError.MonadErrorExtensions(MonadError);
 
-  module Semigroupoid:
-    BsAbstract.Interface.SEMIGROUPOID with type t('a, 'b) = t('a => 'b) = {
+  module Semigroupoid: SEMIGROUPOID with type t('a, 'b) = t('a => 'b) = {
     type nonrec t('a, 'b) = t('a => 'b);
     let compose = compose;
   };
   let compose = compose;
   include Relude_Extensions_Semigroupoid.SemigroupoidExtensions(Semigroupoid);
 
-  module Foldable: BsAbstract.Interface.FOLDABLE with type t('a) = t('a) = {
-    include BsAbstract.Result.Foldable(E);
+  module Foldable: FOLDABLE with type t('a) = t('a) = {
+    include BsBastet.Result.Foldable(E);
   };
   let foldLeft = Foldable.fold_left;
   let foldRight = Foldable.fold_right;
   include Relude_Extensions_Foldable.FoldableExtensions(Foldable);
 
-  module WithApplicative = (A: BsAbstract.Interface.APPLICATIVE) => {
-    module Traversable: BsAbstract.Interface.TRAVERSABLE = {
-      include BsAbstract.Result.Traversable(E, A);
+  module WithApplicative = (A: APPLICATIVE) => {
+    module Traversable: TRAVERSABLE = {
+      include BsBastet.Result.Traversable(E, A);
     };
     let traverse = Traversable.traverse;
     let sequence = Traversable.sequence;
     include Relude_Extensions_Traversable.TraversableExtensions(Traversable);
-
-    module Bitraversable: BsAbstract.Interface.BITRAVERSABLE = {
-      include BsAbstract.Result.Bitraversable(A);
+    module Bitraversable: BITRAVERSABLE = {
+      include BsBastet.Result.Bitraversable(A);
     };
     let bitraverse = Bitraversable.bitraverse;
     let bisequence = Bitraversable.bisequence;
@@ -916,11 +919,11 @@ module WithError = (E: BsAbstract.Interface.TYPE) => {
             );
   };
 
-  module Eq = BsAbstract.Result.Eq;
+  module Eq = BsBastet.Result.Eq;
 
-  module Ord = BsAbstract.Result.Ord;
+  module Ord = BsBastet.Result.Ord;
 
-  module Show = BsAbstract.Result.Show;
+  module Show = BsBastet.Result.Show;
 
   module Infix = {
     include Relude_Extensions_Functor.FunctorInfix(Functor);

--- a/src/Relude_ResultT.re
+++ b/src/Relude_ResultT.re
@@ -1,7 +1,9 @@
+open BsBastet.Interface;
+
 /**
  * Creates a ResultT Monad with the given outer Monad module.
  */
-module WithMonad = (M: BsBastet.Interface.MONAD) => {
+module WithMonad = (M: MONAD) => {
   type t('a, 'e) =
     | ResultT(M.t(result('a, 'e)));
 
@@ -118,7 +120,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
   let semiflatMap: 'a 'b 'e. ('a => M.t('b), t('a, 'e)) => t('b, 'e) =
     (aToMB, resultTA) => bind(resultTA, a => liftF(aToMB(a)));
 
-  module WithError = (E: BsBastet.Interface.TYPE) => {
+  module WithError = (E: TYPE) => {
     let make = make;
     let runResultT = runResultT;
     let withResultT = withResultT;
@@ -130,37 +132,35 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
     let cond = cond;
     let condError = condError;
 
-    module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a, E.t) = {
+    module Functor: FUNCTOR with type t('a) = t('a, E.t) = {
       type nonrec t('a) = t('a, E.t);
       let map = map;
     };
     let map = Functor.map;
     include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-    module Bifunctor:
-      BsBastet.Interface.BIFUNCTOR with type t('a, 'e) = t('a, 'e) = {
+    module Bifunctor: BIFUNCTOR with type t('a, 'e) = t('a, 'e) = {
       type nonrec t('a, 'e) = t('a, 'e);
       let bimap = bimap;
     };
     let bimap = Bifunctor.bimap;
     include Relude_Extensions_Bifunctor.BifunctorExtensions(Bifunctor);
 
-    module Apply: BsBastet.Interface.APPLY with type t('a) = t('a, E.t) = {
+    module Apply: APPLY with type t('a) = t('a, E.t) = {
       include Functor;
       let apply = apply;
     };
     let apply = Apply.apply;
     include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-    module Applicative:
-      BsBastet.Interface.APPLICATIVE with type t('a) = t('a, E.t) = {
+    module Applicative: APPLICATIVE with type t('a) = t('a, E.t) = {
       include Apply;
       let pure = pure;
     };
     let pure = Applicative.pure;
     include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-    module Monad: BsBastet.Interface.MONAD with type t('a) = t('a, E.t) = {
+    module Monad: MONAD with type t('a) = t('a, E.t) = {
       include Applicative;
       let flat_map = bind;
     };
@@ -176,8 +176,7 @@ module WithMonad = (M: BsBastet.Interface.MONAD) => {
   };
 };
 
-module WithMonadAndError =
-       (M: BsBastet.Interface.MONAD, E: BsBastet.Interface.TYPE) => {
+module WithMonadAndError = (M: MONAD, E: TYPE) => {
   module WithMonad = WithMonad(M);
   include WithMonad.WithError(E);
 };

--- a/src/Relude_ResultT.re
+++ b/src/Relude_ResultT.re
@@ -1,7 +1,7 @@
 /**
  * Creates a ResultT Monad with the given outer Monad module.
  */
-module WithMonad = (M: BsAbstract.Interface.MONAD) => {
+module WithMonad = (M: BsBastet.Interface.MONAD) => {
   type t('a, 'e) =
     | ResultT(M.t(result('a, 'e)));
 
@@ -118,7 +118,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
   let semiflatMap: 'a 'b 'e. ('a => M.t('b), t('a, 'e)) => t('b, 'e) =
     (aToMB, resultTA) => bind(resultTA, a => liftF(aToMB(a)));
 
-  module WithError = (E: BsAbstract.Interface.TYPE) => {
+  module WithError = (E: BsBastet.Interface.TYPE) => {
     let make = make;
     let runResultT = runResultT;
     let withResultT = withResultT;
@@ -130,7 +130,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
     let cond = cond;
     let condError = condError;
 
-    module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a, E.t) = {
+    module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a, E.t) = {
       type nonrec t('a) = t('a, E.t);
       let map = map;
     };
@@ -138,14 +138,14 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
     include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
     module Bifunctor:
-      BsAbstract.Interface.BIFUNCTOR with type t('a, 'e) = t('a, 'e) = {
+      BsBastet.Interface.BIFUNCTOR with type t('a, 'e) = t('a, 'e) = {
       type nonrec t('a, 'e) = t('a, 'e);
       let bimap = bimap;
     };
     let bimap = Bifunctor.bimap;
     include Relude_Extensions_Bifunctor.BifunctorExtensions(Bifunctor);
 
-    module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a, E.t) = {
+    module Apply: BsBastet.Interface.APPLY with type t('a) = t('a, E.t) = {
       include Functor;
       let apply = apply;
     };
@@ -153,14 +153,14 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
     include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
     module Applicative:
-      BsAbstract.Interface.APPLICATIVE with type t('a) = t('a, E.t) = {
+      BsBastet.Interface.APPLICATIVE with type t('a) = t('a, E.t) = {
       include Apply;
       let pure = pure;
     };
     let pure = Applicative.pure;
     include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-    module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a, E.t) = {
+    module Monad: BsBastet.Interface.MONAD with type t('a) = t('a, E.t) = {
       include Applicative;
       let flat_map = bind;
     };
@@ -177,7 +177,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
 };
 
 module WithMonadAndError =
-       (M: BsAbstract.Interface.MONAD, E: BsAbstract.Interface.TYPE) => {
+       (M: BsBastet.Interface.MONAD, E: BsBastet.Interface.TYPE) => {
   module WithMonad = WithMonad(M);
   include WithMonad.WithError(E);
 };

--- a/src/Relude_Sequence.re
+++ b/src/Relude_Sequence.re
@@ -21,7 +21,7 @@ module List: Relude_Interface.SEQUENCE with type t('a) = list('a) = {
   let eqBy = Relude_List_Instances.eqBy;
   let showBy = Relude_List_Instances.showBy;
   let mkString =
-    Relude_List_Instances.intercalate((module BsAbstract.String.Monoid));
+    Relude_List_Instances.intercalate((module BsBastet.String.Monoid));
   module Functor = Relude_List_Instances.Functor;
   module Apply = Relude_List_Instances.Apply;
   module Applicative = Relude_List_Instances.Applicative;
@@ -55,7 +55,7 @@ module Array: Relude_Interface.SEQUENCE with type t('a) = array('a) = {
   let eqBy = Relude_Array_Instances.eqBy;
   let showBy = Relude_Array_Instances.showBy;
   let mkString =
-    Relude_Array_Instances.intercalate((module BsAbstract.String.Monoid));
+    Relude_Array_Instances.intercalate((module BsBastet.String.Monoid));
   module Functor = Relude_Array_Instances.Functor;
   module Apply = Relude_Array_Instances.Apply;
   module Applicative = Relude_Array_Instances.Applicative;

--- a/src/Relude_Set.re
+++ b/src/Relude_Set.re
@@ -14,7 +14,10 @@ let empty:
  * ordered by the comparator function `Comparable.cmp`.
  */
 let fromArray:
-  ((module Belt.Id.Comparable with type t = 'value and type identity = 'id), array('value)) =>
+  (
+    (module Belt.Id.Comparable with type t = 'value and type identity = 'id),
+    array('value)
+  ) =>
   Belt.Set.t('value, 'id) =
   (id, value) => Belt.Set.fromArray(~id, value);
 
@@ -24,7 +27,10 @@ let fromArray:
  * ordered by the comparator function `Comparable.cmp`.
  */
 let fromList:
-  ((module Belt.Id.Comparable with type t = 'value and type identity = 'id), list('value)) =>
+  (
+    (module Belt.Id.Comparable with type t = 'value and type identity = 'id),
+    list('value)
+  ) =>
   Belt.Set.t('value, 'id) =
   (id, value) => Belt.Set.fromArray(~id, Belt.List.toArray(value));
 
@@ -36,7 +42,8 @@ let isEmpty: t('value, 'id) => bool = Belt.Set.isEmpty;
 /**
  * Determine whether a set contains a given value.
  */
-let contains: ('value, t('value, 'id)) => bool = (value, set) => Belt.Set.has(set, value);
+let contains: ('value, t('value, 'id)) => bool =
+  (value, set) => Belt.Set.has(set, value);
 
 /**
  * Immutably add a value to a set. If the value already exists
@@ -44,7 +51,8 @@ let contains: ('value, t('value, 'id)) => bool = (value, set) => Belt.Set.has(se
  * unchanged. Otherwise, a new copy of the set is returned
  * containing the value.
  */
-let add: ('value, t('value, 'id)) => t('value, 'id) = (value, set) => Belt.Set.add(set, value);
+let add: ('value, t('value, 'id)) => t('value, 'id) =
+  (value, set) => Belt.Set.add(set, value);
 
 /**
  * Immutably merge an array of values into a set. Note: unlike `add`
@@ -146,7 +154,7 @@ let subset: (t('value, 'id), t('value, 'id)) => bool = Belt.Set.subset;
  * ordering between two sets. This can be used as a comparator function
  * to determine the ordering of nested sets (e.g. `Set.t(Set.t('a))`);
  * **Note: The argument order is significant for this function**. E.g.:
- * 
+ *
  * ```
  * let s0 = Test1.fromList([1, 2, 3, 4]);
  * let s1 = Test1.fromList([1, 2, 3, 4]);
@@ -171,7 +179,8 @@ let eq: (t('value, 'id), t('value, 'id)) => bool = Belt.Set.eq;
  * Apply a function to each element of a set, in increasing
  * order.
  */
-let forEach: ('value => unit, t('value, 'id)) => unit = (fn, set) => Belt.Set.forEach(set, fn);
+let forEach: ('value => unit, t('value, 'id)) => unit =
+  (fn, set) => Belt.Set.forEach(set, fn);
 
 /**
  * Iterate over the values of a set in increasing order,
@@ -214,7 +223,8 @@ let filter: ('value => bool, t('value, 'id)) => t('value, 'id) =
  * set contains all the values which pass the predicate function test,
  * and the second one contains all the values which fail.
  */
-let partition: ('value => bool, t('value, 'id)) => (t('value, 'id), t('value, 'id)) =
+let partition:
+  ('value => bool, t('value, 'id)) => (t('value, 'id), t('value, 'id)) =
   (predicate, set) => Belt.Set.partition(set, predicate);
 
 /**
@@ -251,28 +261,30 @@ let maximum: t('value, 'id) => option('value) = Belt.Set.maximum;
  * Returns `None` if no equivalent element is found, or the
  * set is empty.
  */
-let get: ('value, t('value, 'id)) => option('value) = (value, set) => Belt.Set.get(set, value);
+let get: ('value, t('value, 'id)) => option('value) =
+  (value, set) => Belt.Set.get(set, value);
 
 /**
  * Returns an equivalent element from a set if one exists,
  * or else returns a specified default value.
  */
 let getOrElse: ('value, 'value, t('value, 'id)) => 'value =
-  (value, default, set) => Relude_Option_Base.getOrElse(default, Belt.Set.get(set, value));
+  (value, default, set) =>
+    Relude_Option_Base.getOrElse(default, Belt.Set.get(set, value));
 
 /**
  * TODO: Needs documentation. Belt doesn't provide much description.
  */
-let split: ('value, t('value, 'id)) => ((t('value, 'id), t('value, 'id)), bool) =
+let split:
+  ('value, t('value, 'id)) => ((t('value, 'id), t('value, 'id)), bool) =
   (value, set) => Belt.Set.split(set, value);
 
 module type SET = {
-  
   module Comparable: {
     type identity;
     type t;
   };
-  
+
   type value;
   type t = Belt.Set.t(value, Comparable.identity);
   let empty: t;
@@ -309,18 +321,17 @@ module type SET = {
   let split: (value, t) => ((t, t), bool);
 };
 
-module WithOrd = (M: BsAbstract.Interface.ORD) : (SET with type value = M.t) => {
-
+module WithOrd = (M: BsBastet.Interface.ORD) : (SET with type value = M.t) => {
   type value = M.t;
-  
+
   module Comparable =
     Belt.Id.MakeComparable({
       type t = value;
       let cmp = (a, b) => M.compare(a, b) |> Relude_Ordering.toInt;
     });
-    
+
   type nonrec t = t(value, Comparable.identity);
-  
+
   let empty: t = empty((module Comparable));
   let fromArray: array(value) => t = fromArray((module Comparable));
   let fromList: list(value) => t = fromList((module Comparable));

--- a/src/Relude_StateT.re
+++ b/src/Relude_StateT.re
@@ -1,6 +1,7 @@
+open BsBastet.Interface;
 open Relude_Function.Infix;
 
-module WithMonad = (M: BsAbstract.Interface.MONAD) => {
+module WithMonad = (M: MONAD) => {
   /**
   StateT represents an effectful function from a state value of type 's to a result value 'a and a next state of type 's.
   This version of StateT has 'a on the left for consistency with other Reason types like Result/IO/Validation/etc.
@@ -113,7 +114,7 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
       );
     };
 
-  module WithState = (S: BsAbstract.Interface.TYPE) => {
+  module WithState = (S: TYPE) => {
     type nonrec t('a) = t('a, S.t);
 
     let runStateT = runStateT;
@@ -127,29 +128,28 @@ module WithMonad = (M: BsAbstract.Interface.MONAD) => {
     let modify = modify;
     let modify_ = modify_;
 
-    module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+    module Functor: FUNCTOR with type t('a) = t('a) = {
       type nonrec t('a) = t('a);
       let map = map;
     };
     let map = Functor.map;
     include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-    module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+    module Apply: APPLY with type t('a) = t('a) = {
       include Functor;
       let apply = apply;
     };
     let apply = Apply.apply;
     include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-    module Applicative:
-      BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+    module Applicative: APPLICATIVE with type t('a) = t('a) = {
       include Apply;
       let pure = pure;
     };
     let pure = Applicative.pure;
     include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 
-    module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+    module Monad: MONAD with type t('a) = t('a) = {
       include Applicative;
       let flat_map = bind;
     };

--- a/src/Relude_String.re
+++ b/src/Relude_String.re
@@ -1,3 +1,5 @@
+type t = string;
+
 /**
 Returns the empty string
 */

--- a/src/Relude_String.re
+++ b/src/Relude_String.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 type t = string;
 
 /**
@@ -113,13 +115,13 @@ let toNonWhitespace: string => option(string) =
 */
 let concat: (string, string) => string = (a, b) => a ++ b;
 
-module Semigroup: BsAbstract.Interface.SEMIGROUP with type t = string = {
+module Semigroup: SEMIGROUP with type t = string = {
   type t = string;
   let append = concat;
 };
 include Relude_Extensions_Semigroup.SemigroupExtensions(Semigroup);
 
-module Monoid: BsAbstract.Interface.MONOID with type t = string = {
+module Monoid: MONOID with type t = string = {
   include Semigroup;
   let empty = empty;
 };
@@ -430,7 +432,7 @@ let show: string => string = a => a;
 /**
  * SHOW module for string
  */
-module Show: BsAbstract.Interface.SHOW with type t = string = {
+module Show: SHOW with type t = string = {
   type t = string;
   let show = show;
 };
@@ -440,7 +442,7 @@ module Show: BsAbstract.Interface.SHOW with type t = string = {
 */
 let eq: (string, string) => bool = (a, b) => a == b;
 
-module Eq: BsAbstract.Interface.EQ with type t = string = {
+module Eq: EQ with type t = string = {
   type t = string;
   let eq = eq;
 };
@@ -449,9 +451,9 @@ include Relude_Extensions_Eq.EqExtensions(Eq);
 /**
  * Compares two strings
  */
-let compare = BsAbstract.String.Ord.compare;
+let compare = BsBastet.String.Ord.compare;
 
-module Ord: BsAbstract.Interface.ORD with type t = string = {
+module Ord: ORD with type t = string = {
   include Eq;
   let compare = compare;
 };

--- a/src/Relude_TreeZipper.re
+++ b/src/Relude_TreeZipper.re
@@ -585,7 +585,7 @@ let map: 'a 'b. ('a => 'b, t('a)) => t('b) =
     };
   };
 
-module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
   type nonrec t('a) = t('a);
   let map = map;
 };

--- a/src/Relude_Tuple2.re
+++ b/src/Relude_Tuple2.re
@@ -1,43 +1,45 @@
+open BsBastet.Interface;
+
 /**
-   * Constructs a tuple-2 from 2 values
-   */
+ * Constructs a tuple-2 from 2 values
+ */
 let make: 'a 'b. ('a, 'b) => ('a, 'b) = (a, b) => (a, b);
 
 /**
-   * Constructs a tuple-2 from an array of exactly 2 values
-   */
+ * Constructs a tuple-2 from an array of exactly 2 values
+ */
 let fromArray: 'a. array('a) => option(('a, 'a)) =
   fun
   | [|a, b|] => Some((a, b))
   | _ => None;
 
 /**
-   * Constructs a tuple-2 from an array of at least 2 values
-   */
+ * Constructs a tuple-2 from an array of at least 2 values
+ */
 let fromArrayAtLeast: 'a. array('a) => option(('a, 'a)) =
   xs => Relude_Array.take(2, xs) |> fromArray;
 
 /**
-   * Constructs a tuple-2 from a list of exactly 2 values
-   */
+ * Constructs a tuple-2 from a list of exactly 2 values
+ */
 let fromList: 'a. list('a) => option(('a, 'a)) =
   xs => Relude_List.(take(3, xs) |> toArray) |> fromArray;
 
 /**
-   * Constructs a tuple-2 from a list of at least 2 values
-   */
+ * Constructs a tuple-2 from a list of at least 2 values
+ */
 let fromListAtLeast: 'a. list('a) => option(('a, 'a)) =
   xs => Relude_List.take(2, xs) |> fromList;
 
 /**
-   * Shows a tuple ('a, 'b) using show functions for 'a and 'b
-   */
+ * Shows a tuple ('a, 'b) using show functions for 'a and 'b
+ */
 let showBy: 'a 'b. ('a => string, 'b => string, ('a, 'b)) => string =
   (showA, showB, (a, b)) => "(" ++ showA(a) ++ ", " ++ showB(b) ++ ")";
 
 /**
-   * Compares two tuples of type ('a, 'b) for equality using equality functions for 'a and 'b
-   */
+ * Compares two tuples of type ('a, 'b) for equality using equality functions for 'a and 'b
+ */
 let eqBy:
   'a 'b.
   (('a, 'a) => bool, ('b, 'b) => bool, ('a, 'b), ('a, 'b)) => bool
@@ -45,12 +47,12 @@ let eqBy:
   (eqA, eqB, (a1, b1), (a2, b2)) => eqA(a1, a2) && eqB(b1, b2);
 
 /**
-   * Creates a module containing helpers and an Eq module and extensions for the type (a, b)
-   */
-module WithEqs = (EqA: BsAbstract.Interface.EQ, EqB: BsAbstract.Interface.EQ) => {
+ * Creates a module containing helpers and an Eq module and extensions for the type (a, b)
+ */
+module WithEqs = (EqA: EQ, EqB: EQ) => {
   type t = (EqA.t, EqB.t);
   let eq = eqBy(EqA.eq, EqB.eq);
-  module Eq: BsAbstract.Interface.EQ with type t = t = {
+  module Eq: EQ with type t = t = {
     type nonrec t = t;
     let eq = eq;
   };
@@ -58,20 +60,20 @@ module WithEqs = (EqA: BsAbstract.Interface.EQ, EqB: BsAbstract.Interface.EQ) =>
 };
 
 /**
-   * Creates an Eq module for a type t, given an Arrow from t => (a, b) and EQ modules for a and b
-   */
+ * Creates an Eq module for a type t, given an Arrow from t => (a, b) and EQ modules for a and b
+ */
 module type EQ_BY_F =
   (
-    EqA: BsAbstract.Interface.EQ,
-    EqB: BsAbstract.Interface.EQ,
+    EqA: EQ,
+    EqB: EQ,
     A: Relude_Interface.FUNCTION_1 with type b = (EqA.t, EqB.t),
   ) =>
-   BsAbstract.Interface.EQ with type t = A.a;
+   EQ with type t = A.a;
 
 module EqBy: EQ_BY_F =
   (
-    EqA: BsAbstract.Interface.EQ,
-    EqB: BsAbstract.Interface.EQ,
+    EqA: EQ,
+    EqB: EQ,
     A: Relude_Interface.FUNCTION_1 with type b = (EqA.t, EqB.t),
   ) => {
     type t = A.a;
@@ -81,10 +83,10 @@ module EqBy: EQ_BY_F =
   };
 
 /**
-   * Compares two tuples of type ('a, 'b) for ordering, given comparison functions for 'a and 'b
-   *
-   * The 'a value is checked first, and if the 'as are equal, the 'b compare is checked.
-   */
+ * Compares two tuples of type ('a, 'b) for ordering, given comparison functions for 'a and 'b
+ *
+ * The 'a value is checked first, and if the 'as are equal, the 'b compare is checked.
+ */
 let compareBy:
   'a 'b.
   (
@@ -103,13 +105,12 @@ let compareBy:
     };
 
 /**
-   * Creates an Ord module for (a, b), given Ord instances for a and b
-   */
-module WithOrds =
-       (OrdA: BsAbstract.Interface.ORD, OrdB: BsAbstract.Interface.ORD) => {
+ * Creates an Ord module for (a, b), given Ord instances for a and b
+ */
+module WithOrds = (OrdA: ORD, OrdB: ORD) => {
   include WithEqs(OrdA, OrdB);
   let compare = compareBy(OrdA.compare, OrdB.compare);
-  module Ord: BsAbstract.Interface.ORD with type t = t = {
+  module Ord: ORD with type t = t = {
     include Eq;
     let compare = compare;
   };
@@ -117,20 +118,20 @@ module WithOrds =
 };
 
 /**
-   * Creates an Ord instance for a type t, given an arrow from t => (a, b) and Ord instances for a and b
-   */
+ * Creates an Ord instance for a type t, given an arrow from t => (a, b) and Ord instances for a and b
+ */
 module type ORD_BY_F =
   (
-    OrdA: BsAbstract.Interface.ORD,
-    OrdB: BsAbstract.Interface.ORD,
+    OrdA: ORD,
+    OrdB: ORD,
     A: Relude_Interface.FUNCTION_1 with type b = (OrdA.t, OrdB.t),
   ) =>
-   BsAbstract.Interface.ORD with type t = A.a;
+   ORD with type t = A.a;
 
 module OrdBy: ORD_BY_F =
   (
-    OrdA: BsAbstract.Interface.ORD,
-    OrdB: BsAbstract.Interface.ORD,
+    OrdA: ORD,
+    OrdB: ORD,
     A: Relude_Interface.FUNCTION_1 with type b = (OrdA.t, OrdB.t),
   ) => {
     include EqBy(OrdA, OrdB, A);

--- a/src/Relude_Tuple3.re
+++ b/src/Relude_Tuple3.re
@@ -1,31 +1,33 @@
+open BsBastet.Interface;
+
 /**
-   * Constructs a tuple-3 from 3 values
-   */
+ * Constructs a tuple-3 from 3 values
+ */
 let make: 'a 'b 'c. ('a, 'b, 'c) => ('a, 'b, 'c) = (a, b, c) => (a, b, c);
 
 /**
-   * Constructs a tuple-3 from an array of exactly 3 values
-   */
+ * Constructs a tuple-3 from an array of exactly 3 values
+ */
 let fromArray: 'a. array('a) => option(('a, 'a, 'a)) =
   fun
   | [|a, b, c|] => Some((a, b, c))
   | _ => None;
 
 /**
-   * Constructs a tuple-3 from an array of at least 3 values
-   */
+ * Constructs a tuple-3 from an array of at least 3 values
+ */
 let fromArrayAtLeast: 'a. array('a) => option(('a, 'a, 'a)) =
   xs => Relude_Array.take(3, xs) |> fromArray;
 
 /**
-   * Constructs a tuple-3 from a list of exactly 3 values
-   */
+ * Constructs a tuple-3 from a list of exactly 3 values
+ */
 let fromList: 'a. list('a) => option(('a, 'a, 'a)) =
   xs => Relude_List.(take(4, xs) |> toArray) |> fromArray;
 
 /**
-   * Constructs a tuple-3 from a list of at least 3 values
-   */
+ * Constructs a tuple-3 from a list of at least 3 values
+ */
 let fromListAtLeast: 'a. list('a) => option(('a, 'a, 'a)) =
   xs => Relude_List.take(3, xs) |> fromList;
 
@@ -50,16 +52,11 @@ let eqBy:
   (eqA, eqB, eqC, (a1, b1, c1), (a2, b2, c2)) =>
     eqA(a1, a2) && eqB(b1, b2) && eqC(c1, c2);
 
-module WithEqs =
-       (
-         EqA: BsAbstract.Interface.EQ,
-         EqB: BsAbstract.Interface.EQ,
-         EqC: BsAbstract.Interface.EQ,
-       ) => {
+module WithEqs = (EqA: EQ, EqB: EQ, EqC: EQ) => {
   type t = (EqA.t, EqB.t, EqC.t);
   let eq = eqBy(EqA.eq, EqB.eq, EqC.eq);
 
-  module Eq: BsAbstract.Interface.EQ with type t = t = {
+  module Eq: EQ with type t = t = {
     type nonrec t = t;
     let eq = eq;
   };
@@ -68,18 +65,18 @@ module WithEqs =
 
 module type EQ_BY_F =
   (
-    EqA: BsAbstract.Interface.EQ,
-    EqB: BsAbstract.Interface.EQ,
-    EqC: BsAbstract.Interface.EQ,
+    EqA: EQ,
+    EqB: EQ,
+    EqC: EQ,
     A: Relude_Interface.FUNCTION_1 with type b = (EqA.t, EqB.t, EqC.t),
   ) =>
-   BsAbstract.Interface.EQ with type t = A.a;
+   EQ with type t = A.a;
 
 module EqBy: EQ_BY_F =
   (
-    EqA: BsAbstract.Interface.EQ,
-    EqB: BsAbstract.Interface.EQ,
-    EqC: BsAbstract.Interface.EQ,
+    EqA: EQ,
+    EqB: EQ,
+    EqC: EQ,
     A: Relude_Interface.FUNCTION_1 with type b = (EqA.t, EqB.t, EqC.t),
   ) => {
     type t = A.a;
@@ -111,16 +108,11 @@ let compareBy:
       }
     };
 
-module WithOrds =
-       (
-         OrdA: BsAbstract.Interface.ORD,
-         OrdB: BsAbstract.Interface.ORD,
-         OrdC: BsAbstract.Interface.ORD,
-       ) => {
+module WithOrds = (OrdA: ORD, OrdB: ORD, OrdC: ORD) => {
   include WithEqs(OrdA, OrdB, OrdC);
   let compare = compareBy(OrdA.compare, OrdB.compare, OrdC.compare);
 
-  module Ord: BsAbstract.Interface.ORD with type t = t = {
+  module Ord: ORD with type t = t = {
     include Eq;
     let compare = compare;
   };
@@ -129,18 +121,18 @@ module WithOrds =
 
 module type ORD_BY_F =
   (
-    OrdA: BsAbstract.Interface.ORD,
-    OrdB: BsAbstract.Interface.ORD,
-    OrdC: BsAbstract.Interface.ORD,
+    OrdA: ORD,
+    OrdB: ORD,
+    OrdC: ORD,
     A: Relude_Interface.FUNCTION_1 with type b = (OrdA.t, OrdB.t, OrdC.t),
   ) =>
-   BsAbstract.Interface.ORD with type t = A.a;
+   ORD with type t = A.a;
 
 module OrdBy: ORD_BY_F =
   (
-    OrdA: BsAbstract.Interface.ORD,
-    OrdB: BsAbstract.Interface.ORD,
-    OrdC: BsAbstract.Interface.ORD,
+    OrdA: ORD,
+    OrdB: ORD,
+    OrdC: ORD,
     A: Relude_Interface.FUNCTION_1 with type b = (OrdA.t, OrdB.t, OrdC.t),
   ) => {
     include EqBy(OrdA, OrdB, OrdC, A);

--- a/src/Relude_Tuple4.re
+++ b/src/Relude_Tuple4.re
@@ -1,32 +1,34 @@
+open BsBastet.Interface;
+
 /**
-   * Constructs a tuple-4 from 4 values
-   */
+ * Constructs a tuple-4 from 4 values
+ */
 let make: 'a 'b 'c 'd. ('a, 'b, 'c, 'd) => ('a, 'b, 'c, 'd) =
   (a, b, c, d) => (a, b, c, d);
 
 /**
-   * Constructs a tuple-4 from an array of exactly 4 values
-   */
+ * Constructs a tuple-4 from an array of exactly 4 values
+ */
 let fromArray: 'a. array('a) => option(('a, 'a, 'a, 'a)) =
   fun
   | [|a, b, c, d|] => Some((a, b, c, d))
   | _ => None;
 
 /**
-   * Constructs a tuple-4 from an array of at least 4 values
-   */
+ * Constructs a tuple-4 from an array of at least 4 values
+ */
 let fromArrayAtLeast: 'a. array('a) => option(('a, 'a, 'a, 'a)) =
   xs => Relude_Array.take(4, xs) |> fromArray;
 
 /**
-   * Constructs a tuple-4 from a list of exactly 4 values
-   */
+ * Constructs a tuple-4 from a list of exactly 4 values
+ */
 let fromList: 'a. list('a) => option(('a, 'a, 'a, 'a)) =
   xs => Relude_List.(take(5, xs) |> toArray) |> fromArray;
 
 /**
-   * Constructs a tuple-4 from a list of at least 4 values
-   */
+ * Constructs a tuple-4 from a list of at least 4 values
+ */
 let fromListAtLeast: 'a. list('a) => option(('a, 'a, 'a, 'a)) =
   xs => Relude_List.take(4, xs) |> fromList;
 
@@ -67,17 +69,11 @@ let eqBy:
   (eqA, eqB, eqC, eqD, (a1, b1, c1, d1), (a2, b2, c2, d2)) =>
     eqA(a1, a2) && eqB(b1, b2) && eqC(c1, c2) && eqD(d1, d2);
 
-module WithEqs =
-       (
-         EqA: BsAbstract.Interface.EQ,
-         EqB: BsAbstract.Interface.EQ,
-         EqC: BsAbstract.Interface.EQ,
-         EqD: BsAbstract.Interface.EQ,
-       ) => {
+module WithEqs = (EqA: EQ, EqB: EQ, EqC: EQ, EqD: EQ) => {
   type t = (EqA.t, EqB.t, EqC.t, EqD.t);
   let eq = eqBy(EqA.eq, EqB.eq, EqC.eq, EqD.eq);
 
-  module Eq: BsAbstract.Interface.EQ with type t = t = {
+  module Eq: EQ with type t = t = {
     type nonrec t = t;
     let eq = eq;
   };
@@ -86,20 +82,20 @@ module WithEqs =
 
 module type EQ_BY_F =
   (
-    EqA: BsAbstract.Interface.EQ,
-    EqB: BsAbstract.Interface.EQ,
-    EqC: BsAbstract.Interface.EQ,
-    EqD: BsAbstract.Interface.EQ,
+    EqA: EQ,
+    EqB: EQ,
+    EqC: EQ,
+    EqD: EQ,
     A: Relude_Interface.FUNCTION_1 with type b = (EqA.t, EqB.t, EqC.t, EqD.t),
   ) =>
-   BsAbstract.Interface.EQ with type t = A.a;
+   EQ with type t = A.a;
 
 module EqBy: EQ_BY_F =
   (
-    EqA: BsAbstract.Interface.EQ,
-    EqB: BsAbstract.Interface.EQ,
-    EqC: BsAbstract.Interface.EQ,
-    EqD: BsAbstract.Interface.EQ,
+    EqA: EQ,
+    EqB: EQ,
+    EqC: EQ,
+    EqD: EQ,
     A: Relude_Interface.FUNCTION_1 with type b = (EqA.t, EqB.t, EqC.t, EqD.t),
   ) => {
     type t = A.a;
@@ -144,18 +140,12 @@ let compareBy:
       }
     };
 
-module WithOrds =
-       (
-         OrdA: BsAbstract.Interface.ORD,
-         OrdB: BsAbstract.Interface.ORD,
-         OrdC: BsAbstract.Interface.ORD,
-         OrdD: BsAbstract.Interface.ORD,
-       ) => {
+module WithOrds = (OrdA: ORD, OrdB: ORD, OrdC: ORD, OrdD: ORD) => {
   include WithEqs(OrdA, OrdB, OrdC, OrdD);
   let compare =
     compareBy(OrdA.compare, OrdB.compare, OrdC.compare, OrdD.compare);
 
-  module Ord: BsAbstract.Interface.ORD with type t = t = {
+  module Ord: ORD with type t = t = {
     include Eq;
     let compare = compare;
   };
@@ -164,21 +154,25 @@ module WithOrds =
 
 module type ORD_BY_F =
   (
-    OrdA: BsAbstract.Interface.ORD,
-    OrdB: BsAbstract.Interface.ORD,
-    OrdC: BsAbstract.Interface.ORD,
-    OrdD: BsAbstract.Interface.ORD,
-    A: Relude_Interface.FUNCTION_1 with type b = (OrdA.t, OrdB.t, OrdC.t, OrdD.t),
+    OrdA: ORD,
+    OrdB: ORD,
+    OrdC: ORD,
+    OrdD: ORD,
+    A:
+      Relude_Interface.FUNCTION_1 with
+        type b = (OrdA.t, OrdB.t, OrdC.t, OrdD.t),
   ) =>
-   BsAbstract.Interface.ORD with type t = A.a;
+   ORD with type t = A.a;
 
 module OrdBy: ORD_BY_F =
   (
-    OrdA: BsAbstract.Interface.ORD,
-    OrdB: BsAbstract.Interface.ORD,
-    OrdC: BsAbstract.Interface.ORD,
-    OrdD: BsAbstract.Interface.ORD,
-    A: Relude_Interface.FUNCTION_1 with type b = (OrdA.t, OrdB.t, OrdC.t, OrdD.t),
+    OrdA: ORD,
+    OrdB: ORD,
+    OrdC: ORD,
+    OrdD: ORD,
+    A:
+      Relude_Interface.FUNCTION_1 with
+        type b = (OrdA.t, OrdB.t, OrdC.t, OrdD.t),
   ) => {
     include EqBy(OrdA, OrdB, OrdC, OrdD, A);
     let compare = (t1, t2) => {

--- a/src/Relude_Tuple5.re
+++ b/src/Relude_Tuple5.re
@@ -1,38 +1,40 @@
+open BsBastet.Interface;
+
 /**
-   * Constructs a tuple-5 from 5 values
-   */
+ * Constructs a tuple-5 from 5 values
+ */
 let make: 'a 'b 'c 'd 'e. ('a, 'b, 'c, 'd, 'e) => ('a, 'b, 'c, 'd, 'e) =
   (a, b, c, d, e) => (a, b, c, d, e);
 
 /**
-   * Constructs a tuple-5 from an array of exactly 5 values
-   */
+ * Constructs a tuple-5 from an array of exactly 5 values
+ */
 let fromArray: 'a. array('a) => option(('a, 'a, 'a, 'a, 'a)) =
   fun
   | [|a, b, c, d, e|] => Some((a, b, c, d, e))
   | _ => None;
 
 /**
-   * Constructs a tuple-5 from an array of at least 5 values
-   */
+ * Constructs a tuple-5 from an array of at least 5 values
+ */
 let fromArrayAtLeast: 'a. array('a) => option(('a, 'a, 'a, 'a, 'a)) =
   xs => Relude_Array.take(5, xs) |> fromArray;
 
 /**
-   * Constructs a tuple-5 from a list of exactly 5 values
-   */
+ * Constructs a tuple-5 from a list of exactly 5 values
+ */
 let fromList: 'a. list('a) => option(('a, 'a, 'a, 'a, 'a)) =
   xs => Relude_List.(take(6, xs) |> toArray) |> fromArray;
 
 /**
-   * Constructs a tuple-5 from a list of at least 5 values
-   */
+ * Constructs a tuple-5 from a list of at least 5 values
+ */
 let fromListAtLeast: 'a. list('a) => option(('a, 'a, 'a, 'a, 'a)) =
   xs => Relude_List.take(5, xs) |> fromList;
 
 /**
-   * Applies a normal 5-argument function to arguments contained in a tuple-5
-   */
+ * Applies a normal 5-argument function to arguments contained in a tuple-5
+ */
 let apply:
   'a 'b 'c 'd 'e 'f.
   (('a, 'b, 'c, 'd, 'e) => 'f, ('a, 'b, 'c, 'd, 'e)) => 'f
@@ -84,18 +86,11 @@ let eqBy:
     && eqD(d1, d2)
     && eqE(e1, e2);
 
-module WithEqs =
-       (
-         EqA: BsAbstract.Interface.EQ,
-         EqB: BsAbstract.Interface.EQ,
-         EqC: BsAbstract.Interface.EQ,
-         EqD: BsAbstract.Interface.EQ,
-         EqE: BsAbstract.Interface.EQ,
-       ) => {
+module WithEqs = (EqA: EQ, EqB: EQ, EqC: EQ, EqD: EQ, EqE: EQ) => {
   type t = (EqA.t, EqB.t, EqC.t, EqD.t, EqE.t);
   let eq = eqBy(EqA.eq, EqB.eq, EqC.eq, EqD.eq, EqE.eq);
 
-  module Eq: BsAbstract.Interface.EQ with type t = t = {
+  module Eq: EQ with type t = t = {
     type nonrec t = t;
     let eq = eq;
   };
@@ -104,24 +99,24 @@ module WithEqs =
 
 module type EQ_BY_F =
   (
-    EqA: BsAbstract.Interface.EQ,
-    EqB: BsAbstract.Interface.EQ,
-    EqC: BsAbstract.Interface.EQ,
-    EqD: BsAbstract.Interface.EQ,
-    EqE: BsAbstract.Interface.EQ,
+    EqA: EQ,
+    EqB: EQ,
+    EqC: EQ,
+    EqD: EQ,
+    EqE: EQ,
     A:
       Relude_Interface.FUNCTION_1 with
         type b = (EqA.t, EqB.t, EqC.t, EqD.t, EqE.t),
   ) =>
-   BsAbstract.Interface.EQ with type t = A.a;
+   EQ with type t = A.a;
 
 module EqBy: EQ_BY_F =
   (
-    EqA: BsAbstract.Interface.EQ,
-    EqB: BsAbstract.Interface.EQ,
-    EqC: BsAbstract.Interface.EQ,
-    EqD: BsAbstract.Interface.EQ,
-    EqE: BsAbstract.Interface.EQ,
+    EqA: EQ,
+    EqB: EQ,
+    EqC: EQ,
+    EqD: EQ,
+    EqE: EQ,
     A:
       Relude_Interface.FUNCTION_1 with
         type b = (EqA.t, EqB.t, EqC.t, EqD.t, EqE.t),
@@ -175,14 +170,7 @@ let compareBy:
       }
     };
 
-module WithOrds =
-       (
-         OrdA: BsAbstract.Interface.ORD,
-         OrdB: BsAbstract.Interface.ORD,
-         OrdC: BsAbstract.Interface.ORD,
-         OrdD: BsAbstract.Interface.ORD,
-         OrdE: BsAbstract.Interface.ORD,
-       ) => {
+module WithOrds = (OrdA: ORD, OrdB: ORD, OrdC: ORD, OrdD: ORD, OrdE: ORD) => {
   include WithEqs(OrdA, OrdB, OrdC, OrdD, OrdE);
   let compare =
     compareBy(
@@ -193,7 +181,7 @@ module WithOrds =
       OrdE.compare,
     );
 
-  module Ord: BsAbstract.Interface.ORD with type t = t = {
+  module Ord: ORD with type t = t = {
     include Eq;
     let compare = compare;
   };
@@ -202,24 +190,24 @@ module WithOrds =
 
 module type ORD_BY_F =
   (
-    OrdA: BsAbstract.Interface.ORD,
-    OrdB: BsAbstract.Interface.ORD,
-    OrdC: BsAbstract.Interface.ORD,
-    OrdD: BsAbstract.Interface.ORD,
-    OrdE: BsAbstract.Interface.ORD,
+    OrdA: ORD,
+    OrdB: ORD,
+    OrdC: ORD,
+    OrdD: ORD,
+    OrdE: ORD,
     A:
       Relude_Interface.FUNCTION_1 with
         type b = (OrdA.t, OrdB.t, OrdC.t, OrdD.t, OrdE.t),
   ) =>
-   BsAbstract.Interface.ORD with type t = A.a;
+   ORD with type t = A.a;
 
 module OrdBy: ORD_BY_F =
   (
-    OrdA: BsAbstract.Interface.ORD,
-    OrdB: BsAbstract.Interface.ORD,
-    OrdC: BsAbstract.Interface.ORD,
-    OrdD: BsAbstract.Interface.ORD,
-    OrdE: BsAbstract.Interface.ORD,
+    OrdA: ORD,
+    OrdB: ORD,
+    OrdC: ORD,
+    OrdD: ORD,
+    OrdE: ORD,
     A:
       Relude_Interface.FUNCTION_1 with
         type b = (OrdA.t, OrdB.t, OrdC.t, OrdD.t, OrdE.t),

--- a/src/Relude_Unit.re
+++ b/src/Relude_Unit.re
@@ -1,8 +1,10 @@
+open BsBastet.Interface;
+
 type t = unit;
 
 let show: t => string = _ => "()";
 
-module Show: BsAbstract.Interface.SHOW with type t = t = {
+module Show: SHOW with type t = t = {
   type nonrec t = unit;
   let show = show;
 };
@@ -10,21 +12,21 @@ include Relude_Extensions_Show.ShowExtensions(Show);
 
 let eq: (t, t) => bool = ((), ()) => true;
 
-module Eq: BsAbstract.Interface.EQ with type t = t = {
+module Eq: EQ with type t = t = {
   type nonrec t = t;
   let eq = eq;
 };
 include Relude_Extensions_Eq.EqExtensions(Eq);
 
-let compare: (t, t) => BsAbstract.Interface.ordering = ((), ()) => `equal_to;
+let compare: (t, t) => ordering = ((), ()) => `equal_to;
 
-module Ord: BsAbstract.Interface.ORD with type t = t = {
+module Ord: ORD with type t = t = {
   include Eq;
   let compare = compare;
 };
 include Relude_Extensions_Ord.OrdExtensions(Ord);
 
-module Bounded: BsAbstract.Interface.BOUNDED with type t = unit = {
+module Bounded: BOUNDED with type t = unit = {
   include Ord;
   let top = ();
   let bottom = ();

--- a/src/Relude_Validation.re
+++ b/src/Relude_Validation.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
  * Similar to result, but has an Applicative instance that collects the errors
  * using a semigroup, rather than fail-fast semantics.
@@ -429,29 +431,24 @@ let map5:
       fe,
     );
 
-module WithErrors =
-       (
-         Errors: BsAbstract.Interface.SEMIGROUP_ANY,
-         Error: BsAbstract.Interface.TYPE,
-       ) => {
+module WithErrors = (Errors: SEMIGROUP_ANY, Error: TYPE) => {
   type nonrec t('a) = t('a, Errors.t(Error.t));
 
-  module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };
   let map = Functor.map;
   include Relude_Extensions_Functor.FunctorExtensions(Functor);
 
-  module Apply: BsAbstract.Interface.APPLY with type t('a) = t('a) = {
+  module Apply: APPLY with type t('a) = t('a) = {
     include Functor;
     let apply = (ff, fa) => applyWithAppendErrors(Errors.append, ff, fa);
   };
   let apply = Apply.apply;
   include Relude_Extensions_Apply.ApplyExtensions(Apply);
 
-  module Applicative:
-    BsAbstract.Interface.APPLICATIVE with type t('a) = t('a) = {
+  module Applicative: APPLICATIVE with type t('a) = t('a) = {
     include Apply;
     let pure = pure;
   };
@@ -466,7 +463,7 @@ module WithErrors =
   };
   include Relude_Extensions_Semialign.SemialignExtensions(Semialign);
 
-  module Monad: BsAbstract.Interface.MONAD with type t('a) = t('a) = {
+  module Monad: MONAD with type t('a) = t('a) = {
     include Applicative;
     let flat_map = bind;
   };

--- a/src/array/Relude_Array_Base.re
+++ b/src/array/Relude_Array_Base.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
  * Prepends a single item to the start of an array.
  */
@@ -382,20 +384,14 @@ let sortWithInt: (('a, 'a) => int, array('a)) => array('a) =
 /**
  * Sorts an array using a compare function.
  */
-let sortBy:
-  (('a, 'a) => BsAbstract.Interface.ordering, array('a)) => array('a) =
+let sortBy: (('a, 'a) => ordering, array('a)) => array('a) =
   (f, xs) => sortWithInt((a, b) => f(a, b) |> Relude_Ordering.toInt, xs);
 
 /**
  * Sorts an array using an ORD module.
  */
 let sort =
-    (
-      type a,
-      ordA: (module BsAbstract.Interface.ORD with type t = a),
-      xs: array(a),
-    )
-    : array(a) => {
+    (type a, ordA: (module ORD with type t = a), xs: array(a)): array(a) => {
   module OrdA = (val ordA);
   sortBy(OrdA.compare, xs);
 };
@@ -443,8 +439,7 @@ let removeEachBy: 'a. (('a, 'a) => bool, 'a, array('a)) => array('a) =
 /**
  * Creates a new array with only the distinct values from the array, using the given EQ module.
  */
-let distinct =
-    (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), xs) => {
+let distinct = (type a, eqA: (module EQ with type t = a), xs) => {
   module EqA = (val eqA);
   distinctBy(EqA.eq, xs);
 };
@@ -452,8 +447,7 @@ let distinct =
 /**
  * Removes the first occurrence of the given value from the array, using the given EQ module
  */
-let removeFirst =
-    (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), x, xs) => {
+let removeFirst = (type a, eqA: (module EQ with type t = a), x, xs) => {
   module EqA = (val eqA);
   removeFirstBy(EqA.eq, x, xs);
 };
@@ -461,8 +455,7 @@ let removeFirst =
 /**
  * Removes all occurrences of the given value from the array, using the given EQ module
  */
-let removeEach =
-    (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), x, xs) => {
+let removeEach = (type a, eqA: (module EQ with type t = a), x, xs) => {
   module EqA = (val eqA);
   removeEachBy(EqA.eq, x, xs);
 };

--- a/src/array/Relude_Array_Instances.re
+++ b/src/array/Relude_Array_Instances.re
@@ -1,10 +1,11 @@
+open BsBastet.Interface;
+
 /**
  * Concatenates two arrays with the left side array first, and the right side last
  */
 let concat: 'a. (array('a), array('a)) => array('a) = Belt.Array.concat;
 
-module SemigroupAny:
-  BsAbstract.Interface.SEMIGROUP_ANY with type t('a) = array('a) = {
+module SemigroupAny: SEMIGROUP_ANY with type t('a) = array('a) = {
   type t('a) = array('a);
   let append = concat;
 };
@@ -13,9 +14,9 @@ include Relude_Extensions_SemigroupAny.SemigroupAnyExtensions(SemigroupAny);
 /**
  * Applies a pure function to each value in the array
  */
-let map: 'a 'b. ('a => 'b, array('a)) => array('b) = BsAbstract.Array.Functor.map;
+let map: 'a 'b. ('a => 'b, array('a)) => array('b) = BsBastet.Array.Functor.map;
 
-module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = array('a) = {
+module Functor: FUNCTOR with type t('a) = array('a) = {
   type t('a) = array('a);
   let map = map;
 };
@@ -24,9 +25,9 @@ include Relude_Extensions_Functor.FunctorExtensions(Functor);
 /**
  * Applies an array of functions to an array of values to produce a new array of values.
  */
-let apply: 'a 'b. (array('a => 'b), array('a)) => array('b) = BsAbstract.Array.Apply.apply;
+let apply: 'a 'b. (array('a => 'b), array('a)) => array('b) = BsBastet.Array.Apply.apply;
 
-module Apply: BsAbstract.Interface.APPLY with type t('a) = array('a) = {
+module Apply: APPLY with type t('a) = array('a) = {
   include Functor;
   let apply = apply;
 };
@@ -37,8 +38,7 @@ include Relude_Extensions_Apply.ApplyExtensions(Apply);
  */
 let pure: 'a. 'a => array('a) = a => [|a|];
 
-module Applicative:
-  BsAbstract.Interface.APPLICATIVE with type t('a) = array('a) = {
+module Applicative: APPLICATIVE with type t('a) = array('a) = {
   include Apply;
   let pure = pure;
 };
@@ -47,9 +47,9 @@ include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 /**
  * Maps a monadic function over each element of the array, and flattens (concatenates) the result.
  */
-let bind: 'a 'b. (array('a), 'a => array('b)) => array('b) = BsAbstract.Array.Monad.flat_map;
+let bind: 'a 'b. (array('a), 'a => array('b)) => array('b) = BsBastet.Array.Monad.flat_map;
 
-module Monad: BsAbstract.Interface.MONAD with type t('a) = array('a) = {
+module Monad: MONAD with type t('a) = array('a) = {
   include Applicative;
   let flat_map = bind;
 };
@@ -58,9 +58,9 @@ include Relude_Extensions_Monad.MonadExtensions(Monad);
 /**
  * Alt for arrays concatenates the two arrays
  */
-let alt: 'a. (array('a), array('a)) => array('a) = BsAbstract.Array.Alt.alt;
+let alt: 'a. (array('a), array('a)) => array('a) = BsBastet.Array.Alt.alt;
 
-module Alt: BsAbstract.Interface.ALT with type t('a) = array('a) = {
+module Alt: ALT with type t('a) = array('a) = {
   include Functor;
   let alt = alt;
 };
@@ -69,9 +69,9 @@ include Relude_Extensions_Alt.AltExtensions(Alt);
 /**
  * Imap is the invariant map function for arrays.
  */
-let imap: 'a 'b. ('a => 'b, 'b => 'a, array('a)) => array('b) = BsAbstract.Array.Invariant.imap;
+let imap: 'a 'b. ('a => 'b, 'b => 'a, array('a)) => array('b) = BsBastet.Array.Invariant.imap;
 
-module Invariant: BsAbstract.Interface.INVARIANT with type t('a) = array('a) = {
+module Invariant: INVARIANT with type t('a) = array('a) = {
   type t('a) = array('a);
   let imap = imap;
 };
@@ -79,9 +79,9 @@ module Invariant: BsAbstract.Interface.INVARIANT with type t('a) = array('a) = {
 /**
  * Extend is the dual of the monadic bind function.
  */
-let extend: 'a 'b. (array('a) => 'b, array('a)) => array('b) = BsAbstract.Array.Extend.extend;
+let extend: 'a 'b. (array('a) => 'b, array('a)) => array('b) = BsBastet.Array.Extend.extend;
 
-module Extend: BsAbstract.Interface.EXTEND with type t('a) = array('a) = {
+module Extend: EXTEND with type t('a) = array('a) = {
   include Functor;
   let extend = extend;
 };
@@ -89,21 +89,21 @@ module Extend: BsAbstract.Interface.EXTEND with type t('a) = array('a) = {
 /**
  * Folds an array from left to right into an accumulator value
  */
-let foldLeft = BsAbstract.Array.Foldable.fold_left;
+let foldLeft = BsBastet.Array.Foldable.fold_left;
 
 /**
  * Folds an array from right-to-left into an accumulator value
  */
-let foldRight = BsAbstract.Array.Foldable.fold_right;
+let foldRight = BsBastet.Array.Foldable.fold_right;
 
-module Foldable: BsAbstract.Interface.FOLDABLE with type t('a) = array('a) = {
-  include BsAbstract.Array.Foldable;
+module Foldable: FOLDABLE with type t('a) = array('a) = {
+  include BsBastet.Array.Foldable;
   let fold_left = foldLeft;
   let fold_right = foldRight;
 };
 include Relude_Extensions_Foldable.FoldableExtensions(Foldable);
 
-module Traversable = BsAbstract.Array.Traversable;
+module Traversable = BsBastet.Array.Traversable;
 
 /**
  * Indicates if two arrays are pair-wise equal, using the given equality function
@@ -123,18 +123,17 @@ let rec eqBy: 'a. (('a, 'a) => bool, array('a), array('a)) => bool =
 /**
  * Indicates if two arrays are pair-wise equal, using the given EQ module
  */
-let eq =
-    (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), xs, ys) => {
+let eq = (type a, eqA: (module EQ with type t = a), xs, ys) => {
   module EqA = (val eqA);
   eqBy(EqA.eq, xs, ys);
 };
 
-module Eq = (EqA: BsAbstract.Interface.EQ) => {
+module Eq = (EqA: EQ) => {
   type t = array(EqA.t);
   let eq = eqBy(EqA.eq);
 };
 
-module Ord = BsAbstract.Array.Ord;
+module Ord = BsBastet.Array.Ord;
 
 /**
  * Converts an array to a string, using the given show function for converting the array items
@@ -142,20 +141,19 @@ module Ord = BsAbstract.Array.Ord;
 let showBy: 'a. ('a => string, array('a)) => string =
   (innerShow, xs) => {
     // TODO
-    let join = intercalate((module BsAbstract.String.Monoid));
+    let join = intercalate((module BsBastet.String.Monoid));
     "[" ++ join(", ", map(innerShow, xs)) ++ "]";
   };
 
 /**
  * Converts an array to a string, using the given SHOW module for converting the array items
  */
-let show =
-    (type a, showA: (module BsAbstract.Interface.SHOW with type t = a), xs) => {
+let show = (type a, showA: (module SHOW with type t = a), xs) => {
   module ShowA = (val showA);
   showBy(ShowA.show, xs);
 };
 
-module Show = (ShowA: BsAbstract.Interface.SHOW) => {
+module Show = (ShowA: SHOW) => {
   type t = array(ShowA.t);
   let show = showBy(ShowA.show);
 };

--- a/src/array/Relude_Array_Specializations.re
+++ b/src/array/Relude_Array_Specializations.re
@@ -1,7 +1,9 @@
+open BsBastet.Interface;
+
 /**
  * Array extensions for when you have an EQ instance.
  */
-module ArrayEqExtensions = (E: BsAbstract.Interface.EQ) => {
+module ArrayEqExtensions = (E: EQ) => {
   include Relude_Array_Instances.FoldableEqExtensions(E);
   /**
    * Finds the distinct items of the array, based on the given EQ module.
@@ -31,7 +33,7 @@ module ArrayEqExtensions = (E: BsAbstract.Interface.EQ) => {
 /**
  * Array extensions for when you have an ORD instance.
  */
-module ArrayOrdExtensions = (O: BsAbstract.Interface.ORD) => {
+module ArrayOrdExtensions = (O: ORD) => {
   include ArrayEqExtensions(O);
   include Relude_Array_Instances.FoldableOrdExtensions(O);
 
@@ -44,7 +46,7 @@ module ArrayOrdExtensions = (O: BsAbstract.Interface.ORD) => {
 /**
  * Array extensions for when you have an MONOID instance.
  */
-module ArrayMonoidExtensions = (M: BsAbstract.Interface.MONOID) => {
+module ArrayMonoidExtensions = (M: MONOID) => {
   include Relude_Array_Instances.FoldableMonoidExtensions(M);
 };
 
@@ -207,17 +209,13 @@ module IO = {
  * Array extensions for `array(Validation.t('a, 'e))`
  */
 module Validation = {
-  module WithErrors =
-         (
-           Errors: BsAbstract.Interface.SEMIGROUP_ANY,
-           Error: BsAbstract.Interface.TYPE,
-         ) => {
+  module WithErrors = (Errors: SEMIGROUP_ANY, Error: TYPE) => {
     module ValidationE = Relude_Validation.WithErrors(Errors, Error);
     module Traversable =
       Relude_Array_Instances.Traversable(ValidationE.Applicative);
   };
 
-  module WithErrorsAsArray = (Error: BsAbstract.Interface.TYPE) => {
+  module WithErrorsAsArray = (Error: TYPE) => {
     module ValidationE =
       Relude_Validation.WithErrors(
         Relude_Array_Instances.SemigroupAny,
@@ -232,7 +230,7 @@ module Validation = {
       type t = string;
     });
 
-  module WithErrorsAsNonEmptyArray = (Error: BsAbstract.Interface.TYPE) => {
+  module WithErrorsAsNonEmptyArray = (Error: TYPE) => {
     module ValidationE =
       Relude_Validation.WithErrors(Relude_NonEmpty.Array.SemigroupAny, Error);
     module Traversable =

--- a/src/extensions/Relude_Extensions_Alt.re
+++ b/src/extensions/Relude_Extensions_Alt.re
@@ -1,7 +1,7 @@
 /**
  * Extensions for any ALT
  */
-module AltExtensions = (A: BsAbstract.Interface.ALT) => {
+module AltExtensions = (A: BsBastet.Interface.ALT) => {
   /**
    * Alternative form of `alt` that uses a named argument for disambiguation
    */
@@ -14,7 +14,7 @@ module AltExtensions = (A: BsAbstract.Interface.ALT) => {
 /**
  * Infix operator extensions for any ALT
  */
-module AltInfix = (A: BsAbstract.Interface.ALT) => {
+module AltInfix = (A: BsBastet.Interface.ALT) => {
   /**
    * Operator version for the `alt` function.
    */

--- a/src/extensions/Relude_Extensions_Alternative.re
+++ b/src/extensions/Relude_Extensions_Alternative.re
@@ -1,4 +1,4 @@
 /**
  * Extensions for any ALTERNATIVE
  */
-module AlternativeExtensions = (A: BsAbstract.Interface.ALTERNATIVE) => {};
+module AlternativeExtensions = (A: BsBastet.Interface.ALTERNATIVE) => {};

--- a/src/extensions/Relude_Extensions_Applicative.re
+++ b/src/extensions/Relude_Extensions_Applicative.re
@@ -1,8 +1,8 @@
 /**
  * Extensions for any APPLICATIVE
  */
-module ApplicativeExtensions = (A: BsAbstract.Interface.APPLICATIVE) => {
-  module BsApplicativeExtensions = BsAbstract.Functions.Applicative(A);
+module ApplicativeExtensions = (A: BsBastet.Interface.APPLICATIVE) => {
+  module BsApplicativeExtensions = BsBastet.Functions.Applicative(A);
 
   /**
    * Lifts a pure function `'a => 'b` into an applicative context `A.t('a) => A.t('b)`

--- a/src/extensions/Relude_Extensions_Apply.re
+++ b/src/extensions/Relude_Extensions_Apply.re
@@ -1,8 +1,8 @@
 /**
  * Extensions for any APPLY
  */
-module ApplyExtensions = (A: BsAbstract.Interface.APPLY) => {
-  module BsApplyExtensions = BsAbstract.Functions.Apply(A);
+module ApplyExtensions = (A: BsBastet.Interface.APPLY) => {
+  module BsApplyExtensions = BsBastet.Functions.Apply(A);
 
   /**
    * Runs the two applicative effects, but only keeps the result from the left side.
@@ -125,7 +125,7 @@ module ApplyExtensions = (A: BsAbstract.Interface.APPLY) => {
 /**
  * Infix operator extensions for any APPLY
  */
-module ApplyInfix = (A: BsAbstract.Interface.APPLY) => {
+module ApplyInfix = (A: BsBastet.Interface.APPLY) => {
   module ApplyExtensions = ApplyExtensions(A);
 
   /**

--- a/src/extensions/Relude_Extensions_Bifoldable.re
+++ b/src/extensions/Relude_Extensions_Bifoldable.re
@@ -1,4 +1,4 @@
 /**
  * Extensions for any Bifoldable
  */
-module BifoldableExtensions = (B: BsAbstract.Interface.BIFOLDABLE) => {};
+module BifoldableExtensions = (B: BsBastet.Interface.BIFOLDABLE) => {};

--- a/src/extensions/Relude_Extensions_Bifunctor.re
+++ b/src/extensions/Relude_Extensions_Bifunctor.re
@@ -1,7 +1,7 @@
 /**
  * Extensions for any Bifunctor
  */
-module BifunctorExtensions = (B: BsAbstract.Interface.BIFUNCTOR) => {
+module BifunctorExtensions = (B: BsBastet.Interface.BIFUNCTOR) => {
   /**
    * Maps a function over the left-side type.
    */
@@ -26,7 +26,7 @@ module BifunctorExtensions = (B: BsAbstract.Interface.BIFUNCTOR) => {
 /**
  * Infix operator extensions for any BIFUNCTOR
  */
-module BifunctorInfix = (B: BsAbstract.Interface.BIFUNCTOR) => {
+module BifunctorInfix = (B: BsBastet.Interface.BIFUNCTOR) => {
   /**
    * Operator version of bimap
    */

--- a/src/extensions/Relude_Extensions_Bitraversable.re
+++ b/src/extensions/Relude_Extensions_Bitraversable.re
@@ -1,4 +1,4 @@
 /**
  * Extensions for any BITRAVERSABLE
  */
-module BitraversableExtensions = (B: BsAbstract.Interface.BITRAVERSABLE) => {};
+module BitraversableExtensions = (B: BsBastet.Interface.BITRAVERSABLE) => {};

--- a/src/extensions/Relude_Extensions_Bounded.re
+++ b/src/extensions/Relude_Extensions_Bounded.re
@@ -1,1 +1,1 @@
-module BoundedExtensions = (B: BsAbstract.Interface.BOUNDED) => {};
+module BoundedExtensions = (B: BsBastet.Interface.BOUNDED) => {};

--- a/src/extensions/Relude_Extensions_Comonad.re
+++ b/src/extensions/Relude_Extensions_Comonad.re
@@ -1,3 +1,3 @@
-module ComonadExtensions = (C: BsAbstract.Interface.COMONAD) => {};
+module ComonadExtensions = (C: BsBastet.Interface.COMONAD) => {};
 
-module ComonadInfix = (C: BsAbstract.Interface.COMONAD) => {};
+module ComonadInfix = (C: BsBastet.Interface.COMONAD) => {};

--- a/src/extensions/Relude_Extensions_Contravariant.re
+++ b/src/extensions/Relude_Extensions_Contravariant.re
@@ -1,3 +1,3 @@
-module ContravariantExtensions = (C: BsAbstract.Interface.CONTRAVARIANT) => {};
+module ContravariantExtensions = (C: BsBastet.Interface.CONTRAVARIANT) => {};
 
-module ContravariantInfix = (C: BsAbstract.Interface.CONTRAVARIANT) => {};
+module ContravariantInfix = (C: BsBastet.Interface.CONTRAVARIANT) => {};

--- a/src/extensions/Relude_Extensions_Eq.re
+++ b/src/extensions/Relude_Extensions_Eq.re
@@ -1,9 +1,11 @@
+open BsBastet.Interface;
+
 type eq('a) = ('a, 'a) => bool;
 
 /**
  * Extensions for any EQ
  */
-module EqExtensions = (Eq: BsAbstract.Interface.EQ) => {
+module EqExtensions = (Eq: EQ) => {
   /**
    * Creates a new equality function by contramapping the given conversion function
    */
@@ -23,14 +25,14 @@ module EqExtensions = (Eq: BsAbstract.Interface.EQ) => {
   /**
    * An Eq module which is the inverse of the given Eq module
    */
-  module EqInverted: BsAbstract.Interface.EQ with type t = Eq.t = {
+  module EqInverted: EQ with type t = Eq.t = {
     type t = Eq.t;
     let eq = eqInverted;
   };
 
   module type EQ_BY_F =
     (A: Relude_Interface.FUNCTION_1 with type b = Eq.t) =>
-     BsAbstract.Interface.EQ with type t = A.a;
+     EQ with type t = A.a;
 
   /**
    * Creates a new Eq for a type b, given an Eq for type a and a Arrow for `b => a`
@@ -56,7 +58,7 @@ module EqExtensions = (Eq: BsAbstract.Interface.EQ) => {
 /**
  * Infix operator extensions for any EQ
  */
-module EqInfix = (Eq: BsAbstract.Interface.EQ) => {
+module EqInfix = (Eq: EQ) => {
   module EqExtensions = EqExtensions(Eq);
 
   // Note: if we want to change these, try for consistency with ORD operators

--- a/src/extensions/Relude_Extensions_Extend.re
+++ b/src/extensions/Relude_Extensions_Extend.re
@@ -1,3 +1,3 @@
-module ExtendExtensions = (E: BsAbstract.Interface.EXTEND) => {};
+module ExtendExtensions = (E: BsBastet.Interface.EXTEND) => {};
 
-module ExtendInfix = (E: BsAbstract.Interface.EXTEND) => {};
+module ExtendInfix = (E: BsBastet.Interface.EXTEND) => {};

--- a/src/extensions/Relude_Extensions_Foldable.re
+++ b/src/extensions/Relude_Extensions_Foldable.re
@@ -188,9 +188,7 @@ module FoldableExtensions = (F: FOLDABLE) => {
   module FoldableSemigroupExtensions = (S: SEMIGROUP) => {
     module BsFoldableSemigroupExtensions = BsFoldableExtensions.Semigroup(S);
 
-    // Note: Bug in bs-abstract - the universal quantification of 'a here doesn't jive
-    //let surroundMap: 'a. (~delimiter: S.t, 'a => S.t, F.t('a)) => S.t = BsFoldableSemigroupExtensions.surround_map;
-    let surroundMap: (~delimiter: S.t, 'a => S.t, F.t('a)) => S.t = BsFoldableSemigroupExtensions.surround_map;
+    let surroundMap: 'a. (~delimiter: S.t, 'a => S.t, F.t('a)) => S.t = BsFoldableSemigroupExtensions.surround_map;
 
     let surround: (~delimiter: S.t, F.t(S.t)) => S.t = BsFoldableSemigroupExtensions.surround;
   };

--- a/src/extensions/Relude_Extensions_Foldable.re
+++ b/src/extensions/Relude_Extensions_Foldable.re
@@ -1,4 +1,4 @@
-type ordering = BsAbstract.Interface.ordering;
+open BsBastet.Interface;
 
 // break circular dependency
 let optionAlt: (option('a), option('a)) => option('a) =
@@ -11,8 +11,8 @@ let optionAlt: (option('a), option('a)) => option('a) =
 /**
  * Extensions for any FOLDABLE
  */
-module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
-  module BsFoldableExtensions = BsAbstract.Functions.Foldable(F);
+module FoldableExtensions = (F: FOLDABLE) => {
+  module BsFoldableExtensions = BsBastet.Functions.Foldable(F);
 
   /**
    * Indicates if any item in the foldable satisfies the given predicate
@@ -35,8 +35,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Indicates if the foldable contains the given item, using the given EQ module
    */
-  let contains =
-      (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), x, xs) => {
+  let contains = (type a, eqA: (module EQ with type t = a), x, xs) => {
     module EqA = (val eqA);
     containsBy(EqA.eq, x, xs);
   };
@@ -58,8 +57,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
    * Finds the index of the given item in the foldable using the given EQ module.
    * If the item is not found, the result is None.
    */
-  let indexOf =
-      (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), x, xs) => {
+  let indexOf = (type a, eqA: (module EQ with type t = a), x, xs) => {
     module EqA = (val eqA);
     indexOfBy(EqA.eq, x, xs);
   };
@@ -82,8 +80,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Finds the minimum item in the foldable, using the given ORD module.
    */
-  let min =
-      (type a, ordA: (module BsAbstract.Interface.ORD with type t = a), xs) => {
+  let min = (type a, ordA: (module ORD with type t = a), xs) => {
     module OrdA = (val ordA);
     minBy(OrdA.compare, xs);
   };
@@ -106,8 +103,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Finds the maximum item in the foldable, using the given ORD module.
    */
-  let max =
-      (type a, ordA: (module BsAbstract.Interface.ORD with type t = a), xs) => {
+  let max = (type a, ordA: (module ORD with type t = a), xs) => {
     module OrdA = (val ordA);
     maxBy(OrdA.compare, xs);
   };
@@ -120,7 +116,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
 
   /**
    * Gets the length of the foldable.
-   * 
+   *
    * Alias of size/count
    */
   let length: 'a. F.t('a) => int = xs => countBy(_ => true, xs);
@@ -189,7 +185,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Foldable extensions for when you have a Semigroup instance
    */
-  module FoldableSemigroupExtensions = (S: BsAbstract.Interface.SEMIGROUP) => {
+  module FoldableSemigroupExtensions = (S: SEMIGROUP) => {
     module BsFoldableSemigroupExtensions = BsFoldableExtensions.Semigroup(S);
 
     // Note: Bug in bs-abstract - the universal quantification of 'a here doesn't jive
@@ -202,7 +198,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Foldable extensions for when you have a Monoid instance
    */
-  module FoldableMonoidExtensions = (M: BsAbstract.Interface.MONOID) => {
+  module FoldableMonoidExtensions = (M: MONOID) => {
     module BsFoldableMonoidExtensions = BsFoldableExtensions.Monoid(M);
 
     /**
@@ -233,13 +229,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Maps a function over a foldable, and accumulates the results using the given Monoid module.
    */
-  let foldMap =
-      (
-        type a,
-        monoidA: (module BsAbstract.Interface.MONOID with type t = a),
-        f,
-        xs,
-      ) => {
+  let foldMap = (type a, monoidA: (module MONOID with type t = a), f, xs) => {
     module FoldableMonoidExtensions = FoldableMonoidExtensions((val monoidA));
     FoldableMonoidExtensions.foldMap(f, xs);
   };
@@ -248,11 +238,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
    * Folds a foldable of a monoidal type, accumulating the result using the given Monoid module.
    */
   let foldWithMonoid =
-      (
-        type a,
-        monoidA: (module BsAbstract.Interface.MONOID with type t = a),
-        xs: F.t(a),
-      ) => {
+      (type a, monoidA: (module MONOID with type t = a), xs: F.t(a)) => {
     module FoldableMonoidExtensions = FoldableMonoidExtensions((val monoidA));
     FoldableMonoidExtensions.foldWithMonoid(xs);
   };
@@ -262,12 +248,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
    * separator.
    */
   let intercalate =
-      (
-        type a,
-        monoidA: (module BsAbstract.Interface.MONOID with type t = a),
-        sep,
-        xs,
-      ) => {
+      (type a, monoidA: (module MONOID with type t = a), sep, xs) => {
     module FoldableMonoidExtensions = FoldableMonoidExtensions((val monoidA));
     FoldableMonoidExtensions.intercalate(sep, xs);
   };
@@ -275,7 +256,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Foldable extensions for when you additionally have an Applicative instance.
    */
-  module FoldableApplicativeExtensions = (A: BsAbstract.Interface.APPLICATIVE) => {
+  module FoldableApplicativeExtensions = (A: APPLICATIVE) => {
     module BsFoldableApplicativeExtensions =
       BsFoldableExtensions.Applicative(A);
 
@@ -293,7 +274,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Foldable extensions for when you additionally have a MONAD instance.
    */
-  module FoldableMonadExtensions = (M: BsAbstract.Interface.MONAD) => {
+  module FoldableMonadExtensions = (M: MONAD) => {
     module BsFoldableMonadExtensions = BsFoldableExtensions.Monad(M);
 
     /**
@@ -308,7 +289,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Foldable extensions for when you additionally have an EQ instance.
    */
-  module FoldableEqExtensions = (E: BsAbstract.Interface.EQ) => {
+  module FoldableEqExtensions = (E: EQ) => {
     /**
      * Indicates of the foldable contains the given item using the given EQ module.
      */
@@ -323,7 +304,7 @@ module FoldableExtensions = (F: BsAbstract.Interface.FOLDABLE) => {
   /**
    * Foldable extensions for when you additionally have an ORD instance.
    */
-  module FoldableOrdExtensions = (O: BsAbstract.Interface.ORD) => {
+  module FoldableOrdExtensions = (O: ORD) => {
     /**
      * Gets the minimum value of the foldable, using the given ORD module.
      */

--- a/src/extensions/Relude_Extensions_Functor.re
+++ b/src/extensions/Relude_Extensions_Functor.re
@@ -1,8 +1,8 @@
 /**
  * Extensions for any FUNCTOR
  */
-module FunctorExtensions = (F: BsAbstract.Interface.FUNCTOR) => {
-  module BsFunctorExtensions = BsAbstract.Functions.Functor(F);
+module FunctorExtensions = (F: BsBastet.Interface.FUNCTOR) => {
+  module BsFunctorExtensions = BsBastet.Functions.Functor(F);
 
   /**
    * Flipped version of the map function which has the functor on the left, and the function on the right.
@@ -34,7 +34,7 @@ module FunctorExtensions = (F: BsAbstract.Interface.FUNCTOR) => {
 /**
  * Infix operator extensions for any FUNCTOR
  */
-module FunctorInfix = (F: BsAbstract.Interface.FUNCTOR) => {
+module FunctorInfix = (F: BsBastet.Interface.FUNCTOR) => {
   module FunctorExtensions = FunctorExtensions(F);
 
   /**

--- a/src/extensions/Relude_Extensions_Monad.re
+++ b/src/extensions/Relude_Extensions_Monad.re
@@ -1,8 +1,8 @@
 /**
  * Extensions for any MONAD
  */
-module MonadExtensions = (M: BsAbstract.Interface.MONAD) => {
-  module BsMonadExtensions = BsAbstract.Functions.Monad(M);
+module MonadExtensions = (M: BsBastet.Interface.MONAD) => {
+  module BsMonadExtensions = BsBastet.Functions.Monad(M);
 
   /**
    * Flipped version of `bind` which has the function on the left and the monad on the right.
@@ -54,7 +54,7 @@ module MonadExtensions = (M: BsAbstract.Interface.MONAD) => {
 /**
  * Infix operator extensions for MONAD
  */
-module MonadInfix = (M: BsAbstract.Interface.MONAD) => {
+module MonadInfix = (M: BsBastet.Interface.MONAD) => {
   module MonadExtensions = MonadExtensions(M);
 
   /**

--- a/src/extensions/Relude_Extensions_Monoid.re
+++ b/src/extensions/Relude_Extensions_Monoid.re
@@ -1,8 +1,8 @@
 /**
  * Extensions for any MONOID
  */
-module MonoidExtensions = (M: BsAbstract.Interface.MONOID) => {
-  module BsMonoidExtensions = BsAbstract.Functions.Monoid(M);
+module MonoidExtensions = (M: BsBastet.Interface.MONOID) => {
+  module BsMonoidExtensions = BsBastet.Functions.Monoid(M);
 
   /**
    * Returns the monoidal value if the given condition is true, otherwise empty.

--- a/src/extensions/Relude_Extensions_MonoidAny.re
+++ b/src/extensions/Relude_Extensions_MonoidAny.re
@@ -1,7 +1,7 @@
 /**
  * Extensions for any MONOID_ANY
  */
-module MonoidAnyExtensions = (M: BsAbstract.Interface.MONOID_ANY) => {
+module MonoidAnyExtensions = (M: BsBastet.Interface.MONOID_ANY) => {
   /**
    * Returns the monoidal value if the given condition is true, otherwise empty.
    */

--- a/src/extensions/Relude_Extensions_Ord.re
+++ b/src/extensions/Relude_Extensions_Ord.re
@@ -1,7 +1,8 @@
-type ordering = BsAbstract.Interface.ordering;
+open BsBastet.Interface;
+
 type compare('a) = ('a, 'a) => ordering;
 
-module OrdExtensions = (O: BsAbstract.Interface.ORD) => {
+module OrdExtensions = (O: ORD) => {
   let compareWithConversion: ('b => O.t) => compare('b) =
     bToA => Relude_Ord.by(bToA, O.compare);
 
@@ -10,7 +11,7 @@ module OrdExtensions = (O: BsAbstract.Interface.ORD) => {
   /**
    * Creates a new Ord module which is the reverse of the given Ord
    */
-  module OrdReversed: BsAbstract.Interface.ORD with type t = O.t = {
+  module OrdReversed: ORD with type t = O.t = {
     type t = O.t;
     let eq = O.eq;
     let compare = compareReversed;
@@ -49,7 +50,7 @@ module OrdExtensions = (O: BsAbstract.Interface.ORD) => {
   let between: (~min: O.t, ~max: O.t, O.t) => bool =
     (~min, ~max, v) => Relude_Ord.betweenBy(O.compare, ~min, ~max, v);
 
-  module OrdRingExtensions = (R: BsAbstract.Interface.RING with type t = O.t) => {
+  module OrdRingExtensions = (R: RING with type t = O.t) => {
     let abs: R.t => R.t = v => Relude_Ord.abs((module O), (module R), v);
 
     let signum: R.t => R.t =
@@ -91,7 +92,7 @@ module OrdExtensions = (O: BsAbstract.Interface.ORD) => {
 
   module type ORD_BY_F =
     (A: Relude_Interface.FUNCTION_1 with type b = O.t) =>
-     BsAbstract.Interface.ORD with type t = A.a;
+     ORD with type t = A.a;
 
   /**
    * Creates an ORD for type b given this ORD of type a and an ARROW `b => a` to act as the contravariant
@@ -115,7 +116,7 @@ module OrdExtensions = (O: BsAbstract.Interface.ORD) => {
     };
 };
 
-module OrdInfix = (O: BsAbstract.Interface.ORD) => {
+module OrdInfix = (O: ORD) => {
   module OrdExtensions = OrdExtensions(O);
 
   // Note: if we want to change these, try for consistency with EQ operators

--- a/src/extensions/Relude_Extensions_Plus.re
+++ b/src/extensions/Relude_Extensions_Plus.re
@@ -1,4 +1,4 @@
 /**
  * Extensions for any PLUS
  */
-module PlusExtensions = (P: BsAbstract.Interface.PLUS) => {};
+module PlusExtensions = (P: BsBastet.Interface.PLUS) => {};

--- a/src/extensions/Relude_Extensions_Ring.re
+++ b/src/extensions/Relude_Extensions_Ring.re
@@ -1,7 +1,7 @@
 /**
  * Extensions for any RING
  */
-module RingExtensions = (R: BsAbstract.Interface.RING) => {
+module RingExtensions = (R: BsBastet.Interface.RING) => {
   let (-) = R.subtract;
   let negate = v => R.zero - v;
 };

--- a/src/extensions/Relude_Extensions_Semigroup.re
+++ b/src/extensions/Relude_Extensions_Semigroup.re
@@ -1,13 +1,13 @@
 /**
  * Extensions for any SEMIGROUP
  */
-module SemigroupExtensions = (S: BsAbstract.Interface.SEMIGROUP) => {
+module SemigroupExtensions = (S: BsBastet.Interface.SEMIGROUP) => {
   let concatNamed = (~prefix: S.t, suffix: S.t) => S.append(prefix, suffix);
 };
 
 /**
  * Infix operator extensions for any SEMIGROUP
  */
-module SemigroupInfix = (S: BsAbstract.Interface.SEMIGROUP) => {
+module SemigroupInfix = (S: BsBastet.Interface.SEMIGROUP) => {
   let (|+|) = S.append;
 };

--- a/src/extensions/Relude_Extensions_SemigroupAny.re
+++ b/src/extensions/Relude_Extensions_SemigroupAny.re
@@ -1,7 +1,7 @@
 /**
  * Extensions for any SEMIGROUP_ANY
  */
-module SemigroupAnyExtensions = (S: BsAbstract.Interface.SEMIGROUP_ANY) => {
+module SemigroupAnyExtensions = (S: BsBastet.Interface.SEMIGROUP_ANY) => {
   let concatNamed = (~prefix: S.t('a), suffix: S.t('a)): S.t('a) =>
     S.append(prefix, suffix);
 };
@@ -9,6 +9,6 @@ module SemigroupAnyExtensions = (S: BsAbstract.Interface.SEMIGROUP_ANY) => {
 /**
  * Infix operator extensions for any SEMIGROUP_ANY
  */
-module SemigroupAnyInfix = (S: BsAbstract.Interface.SEMIGROUP_ANY) => {
+module SemigroupAnyInfix = (S: BsBastet.Interface.SEMIGROUP_ANY) => {
   let (|+|) = S.append;
 };

--- a/src/extensions/Relude_Extensions_Semigroupoid.re
+++ b/src/extensions/Relude_Extensions_Semigroupoid.re
@@ -1,8 +1,8 @@
-module SemigroupoidExtensions = (S: BsAbstract.Interface.SEMIGROUPOID) => {
+module SemigroupoidExtensions = (S: BsBastet.Interface.SEMIGROUPOID) => {
   let andThen = (aToB, bToC) => S.compose(bToC, aToB);
 };
 
-module SemigroupoidInfix = (S: BsAbstract.Interface.SEMIGROUPOID) => {
+module SemigroupoidInfix = (S: BsBastet.Interface.SEMIGROUPOID) => {
   module SE = SemigroupoidExtensions(S);
   let (<<<) = S.compose;
   let (>>>) = SE.andThen;

--- a/src/extensions/Relude_Extensions_Semiring.re
+++ b/src/extensions/Relude_Extensions_Semiring.re
@@ -1,4 +1,4 @@
 /**
  * Extensions for any SEMIRING
  */
-module SemiringExtensions = (S: BsAbstract.Interface.SEMIRING) => {};
+module SemiringExtensions = (S: BsBastet.Interface.SEMIRING) => {};

--- a/src/extensions/Relude_Extensions_Show.re
+++ b/src/extensions/Relude_Extensions_Show.re
@@ -1,4 +1,4 @@
-module ShowExtensions = (S: BsAbstract.Interface.SHOW) => {
+module ShowExtensions = (S: BsBastet.Interface.SHOW) => {
   let logShow: S.t => unit = a => Js.log(S.show(a));
 
   let infoShow: S.t => unit = a => Js.Console.info(S.show(a));
@@ -8,4 +8,4 @@ module ShowExtensions = (S: BsAbstract.Interface.SHOW) => {
   let errorShow: S.t => unit = a => Js.Console.error(S.show(a));
 };
 
-module ShowInfix = (S: BsAbstract.Interface.SHOW) => {};
+module ShowInfix = (S: BsBastet.Interface.SHOW) => {};

--- a/src/extensions/Relude_Extensions_Traversable.re
+++ b/src/extensions/Relude_Extensions_Traversable.re
@@ -1,4 +1,4 @@
 /**
  * Extensions for any TRAVERSABLE
  */
-module TraversableExtensions = (T: BsAbstract.Interface.TRAVERSABLE) => {};
+module TraversableExtensions = (T: BsBastet.Interface.TRAVERSABLE) => {};

--- a/src/extensions/Relude_Extensions_Unfoldable.re
+++ b/src/extensions/Relude_Extensions_Unfoldable.re
@@ -1,3 +1,3 @@
-module UnfoldableExtensions = (U: BsAbstract.Interface.UNFOLDABLE) => {};
+module UnfoldableExtensions = (U: BsBastet.Interface.UNFOLDABLE) => {};
 
-module UnfoldableInfix = (U: BsAbstract.Interface.UNFOLDABLE) => {};
+module UnfoldableInfix = (U: BsBastet.Interface.UNFOLDABLE) => {};

--- a/src/js/Relude_Js_Exn.re
+++ b/src/js/Relude_Js_Exn.re
@@ -1,15 +1,15 @@
 /**
  * Creates a JS Error with the given string message.
  */
-let make: string => Js.Exn.t = [%raw message =>
-  {| return new Error(message);  |}
+let make: string => Js.Exn.t = [%raw
+  {| function(message) { return new Error(message); } |}
 ];
 
 /**
  * Creates and throw a JS Error with the given string message.
  */
-let throw: string => unit = [%raw message =>
-  {| throw new Error(message); |}
+let throw: string => unit = [%raw
+  {| function(message) { throw new Error(message); } |}
 ];
 
 /**
@@ -17,8 +17,8 @@ let throw: string => unit = [%raw message =>
  */
 let unsafeFromExn: exn => Js.Exn.t =
   exn => {
-    let makeUnknownJsExn: exn => Js.Exn.t = [%raw exn =>
-      {| return new Error("Unexpected error: " + exn); |}
+    let makeUnknownJsExn: exn => Js.Exn.t = [%raw
+      {| function(exn) { return new Error("Unexpected error: " + exn); } |}
     ];
     switch (exn) {
     | Js.Exn.Error(jsExn) => jsExn

--- a/src/js/Relude_Js_Json.re
+++ b/src/js/Relude_Js_Json.re
@@ -2,7 +2,7 @@
  * Relude.Js.Json contains helper functions for dealing with Js.Json.t values
  */;
 
- open Relude_Function.Infix;
+open Relude_Function.Infix;
 
 /**
 Type alias for Js.Json.t.
@@ -104,7 +104,8 @@ let fromArrayOfJsonBy: 'a. ('a => json, array('a)) => json =
 /**
 Creates a Js.Json.t array value from an list of Js.Json.t values
 */
-let fromListOfJson: list(json) => json = Relude_List.toArray >> fromArrayOfJson;
+let fromListOfJson: list(json) => json =
+  Relude_List.toArray >> fromArrayOfJson;
 
 /**
 Creates a Js.Json.t array value from an list of values that can be converted to Js.Json.t values with the given function
@@ -186,7 +187,8 @@ let toArrayOfJson: json => option(array(json)) = Js.Json.decodeArray;
 Attempts to decode the given `Js.Json.t` value as an array of `Js.Json.t` values, with a fallback.
 */
 let toArrayOfJsonOrElse: (array(json), json) => array(json) =
-  (default, json) => json |> toArrayOfJson |> Relude_Option.getOrElse(default);
+  (default, json) =>
+    json |> toArrayOfJson |> Relude_Option.getOrElse(default);
 
 /**
 Attempts to decode the given `Js.Json.t` value as an array of `Js.Json.t` values, with a fallback of an empty array.
@@ -249,7 +251,7 @@ let toDictOfJsonOrEmpty: json => dict = toDictOfJsonOrElse(Js.Dict.empty());
 module Error = {
   type t = string;
 
-  module Type: BsAbstract.Interface.TYPE with type t = t = {
+  module Type: BsBastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };
@@ -265,7 +267,8 @@ module Errors = {
   module SemigroupAny = Relude_NonEmpty.Array.SemigroupAny;
 };
 
-module ValidationE = Relude_Validation.WithErrors(Errors.SemigroupAny, Error.Type);
+module ValidationE =
+  Relude_Validation.WithErrors(Errors.SemigroupAny, Error.Type);
 module ArrayValidationE =
   Relude_Array.Validation.WithErrors(Errors.SemigroupAny, Error.Type);
 module TraversableE = ArrayValidationE.Traversable;
@@ -411,7 +414,9 @@ let validateBoolAtIndex: (int, json) => Relude_Validation.t(bool, Errors.t) =
       index,
       json =>
         validateBool(json)
-        |> Relude_Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
+        |> Relude_Validation.mapErrorsNea(e =>
+             string_of_int(index) ++ ": " ++ e
+           ),
       json,
     );
 
@@ -424,7 +429,9 @@ let validateIntAtIndex: (int, json) => Relude_Validation.t(int, Errors.t) =
       index,
       json =>
         validateInt(json)
-        |> Relude_Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
+        |> Relude_Validation.mapErrorsNea(e =>
+             string_of_int(index) ++ ": " ++ e
+           ),
       json,
     );
 
@@ -437,20 +444,25 @@ let validateFloatAtIndex: (int, json) => Relude_Validation.t(float, Errors.t) =
       index,
       json =>
         validateFloat(json)
-        |> Relude_Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
+        |> Relude_Validation.mapErrorsNea(e =>
+             string_of_int(index) ++ ": " ++ e
+           ),
       json,
     );
 
 /**
  * Validates that the given Js.Json.t value is an array with a string at the given index.
  */
-let validateStringAtIndex: (int, json) => Relude_Validation.t(string, Errors.t) =
+let validateStringAtIndex:
+  (int, json) => Relude_Validation.t(string, Errors.t) =
   (index, json) =>
     validateJsonAtIndex(
       index,
       json =>
         validateString(json)
-        |> Relude_Validation.mapErrorsNea(e => string_of_int(index) ++ ": " ++ e),
+        |> Relude_Validation.mapErrorsNea(e =>
+             string_of_int(index) ++ ": " ++ e
+           ),
       json,
     );
 
@@ -507,7 +519,10 @@ let validateOptionalAtIndex =
     } else {
       Relude_Validation.error(
         Errors.pure(
-          "No value was found at index " ++ string_of_int(index) ++ " for JSON: " ++ show(json),
+          "No value was found at index "
+          ++ string_of_int(index)
+          ++ " for JSON: "
+          ++ show(json),
         ),
       );
     }
@@ -615,7 +630,8 @@ let validateObjectAtIndex:
  */
 let getJsonForKey: (string, json) => option(json) =
   (key, json) => {
-    toDictOfJson(json) |> Relude_Option.flatMap(dict => Js.Dict.get(dict, key));
+    toDictOfJson(json)
+    |> Relude_Option.flatMap(dict => Js.Dict.get(dict, key));
   };
 
 /**
@@ -644,7 +660,8 @@ let validateNullForKey: (string, json) => Relude_Validation.t(unit, Errors.t) =
     validateJsonForKey(
       key,
       json =>
-        validateNull(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateNull(json)
+        |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 
@@ -656,7 +673,8 @@ let validateBoolForKey: (string, json) => Relude_Validation.t(bool, Errors.t) =
     validateJsonForKey(
       key,
       json =>
-        validateBool(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateBool(json)
+        |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 
@@ -668,31 +686,36 @@ let validateIntForKey: (string, json) => Relude_Validation.t(int, Errors.t) =
     validateJsonForKey(
       key,
       json =>
-        validateInt(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateInt(json)
+        |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 
 /**
  * Validates the given Js.Json.t value is an object with a float at the given key.
  */
-let validateFloatForKey: (string, json) => Relude_Validation.t(float, Errors.t) =
+let validateFloatForKey:
+  (string, json) => Relude_Validation.t(float, Errors.t) =
   (key, json) =>
     validateJsonForKey(
       key,
       json =>
-        validateFloat(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateFloat(json)
+        |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 
 /**
  * Validates the given Js.Json.t value is an object with a string at the given key.
  */
-let validateStringForKey: (string, json) => Relude_Validation.t(string, Errors.t) =
+let validateStringForKey:
+  (string, json) => Relude_Validation.t(string, Errors.t) =
   (key, json) =>
     validateJsonForKey(
       key,
       json =>
-        validateString(json) |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
+        validateString(json)
+        |> Relude_Validation.mapErrorsNea(e => key ++ ": " ++ e),
       json,
     );
 

--- a/src/list/Relude_List_Base.re
+++ b/src/list/Relude_List_Base.re
@@ -1,3 +1,5 @@
+open BsBastet.Interface;
+
 /**
  * Prepends the given item to the start of the given list.
  */
@@ -342,22 +344,14 @@ let sortWithInt: 'a. (('a, 'a) => int, list('a)) => list('a) =
 /**
  * Sorts a list with the given ordering-based compare function.
  */
-let sortBy:
-  'a.
-  (('a, 'a) => BsAbstract.Interface.ordering, list('a)) => list('a)
- =
+let sortBy: 'a. (('a, 'a) => ordering, list('a)) => list('a) =
   (f, xs) => sortWithInt((a, b) => f(a, b) |> Relude_Ordering.toInt, xs);
 
 /**
  * Sorts a list with the given ORD module
  */
 let sort =
-    (
-      type a,
-      ordA: (module BsAbstract.Interface.ORD with type t = a),
-      xs: list(a),
-    )
-    : list(a) => {
+    (type a, ordA: (module ORD with type t = a), xs: list(a)): list(a) => {
   module OrdA = (val ordA);
   sortBy(OrdA.compare, xs);
 };
@@ -404,8 +398,7 @@ let removeEachBy: 'a. (('a, 'a) => bool, 'a, list('a)) => list('a) =
  * Creates a new list containing only the distinct values of the list, based on the given
  * equality function
  */
-let distinct =
-    (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), xs) => {
+let distinct = (type a, eqA: (module EQ with type t = a), xs) => {
   module EqA = (val eqA);
   distinctBy(EqA.eq, xs);
 };
@@ -413,8 +406,7 @@ let distinct =
 /**
  * Removes the first occurrence of the given item from the list, based on the given EQ module
  */
-let removeFirst =
-    (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), x, xs) => {
+let removeFirst = (type a, eqA: (module EQ with type t = a), x, xs) => {
   module EqA = (val eqA);
   removeFirstBy(EqA.eq, x, xs);
 };
@@ -422,8 +414,7 @@ let removeFirst =
 /**
  * Removes all occurrences of the given item from the list, based on the given EQ module
  */
-let removeEach =
-    (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), x, xs) => {
+let removeEach = (type a, eqA: (module EQ with type t = a), x, xs) => {
   module EqA = (val eqA);
   removeEachBy(EqA.eq, x, xs);
 };

--- a/src/list/Relude_List_Instances.re
+++ b/src/list/Relude_List_Instances.re
@@ -1,11 +1,12 @@
+open BsBastet.Interface;
+
 /**
  * Concatenates two lists with the left-side first and the right-side last.
  */
 let concat: 'a. (list('a), list('a)) => list('a) =
   (xs, ys) => Belt.List.concat(xs, ys);
 
-module SemigroupAny:
-  BsAbstract.Interface.SEMIGROUP_ANY with type t('a) = list('a) = {
+module SemigroupAny: SEMIGROUP_ANY with type t('a) = list('a) = {
   type t('a) = list('a);
   let append = concat;
 };
@@ -16,7 +17,7 @@ include Relude_Extensions_SemigroupAny.SemigroupAnyExtensions(SemigroupAny);
  */
 let empty: 'a. list('a) = [];
 
-module MonoidAny: BsAbstract.Interface.MONOID_ANY with type t('a) = list('a) = {
+module MonoidAny: MONOID_ANY with type t('a) = list('a) = {
   include SemigroupAny;
   let empty = empty;
 };
@@ -25,9 +26,9 @@ include Relude_Extensions_MonoidAny.MonoidAnyExtensions(MonoidAny);
 /**
  * Maps a pure function over a list
  */
-let map = BsAbstract.List.Functor.map;
+let map = BsBastet.List.Functor.map;
 
-module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = list('a) = {
+module Functor: FUNCTOR with type t('a) = list('a) = {
   type t('a) = list('a);
   let map = map;
 };
@@ -36,9 +37,9 @@ include Relude_Extensions_Functor.FunctorExtensions(Functor);
 /**
  * Applies a list of functions to a list of values.
  */
-let apply = BsAbstract.List.Apply.apply;
+let apply = BsBastet.List.Apply.apply;
 
-module Apply: BsAbstract.Interface.APPLY with type t('a) = list('a) = {
+module Apply: APPLY with type t('a) = list('a) = {
   include Functor;
   let apply = apply;
 };
@@ -47,10 +48,9 @@ include Relude_Extensions_Apply.ApplyExtensions(Apply);
 /**
  * Lifts a single pure value into a list of one value.
  */
-let pure = BsAbstract.List.Applicative.pure;
+let pure = BsBastet.List.Applicative.pure;
 
-module Applicative:
-  BsAbstract.Interface.APPLICATIVE with type t('a) = list('a) = {
+module Applicative: APPLICATIVE with type t('a) = list('a) = {
   include Apply;
   let pure = pure;
 };
@@ -59,9 +59,9 @@ include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 /**
  * Maps a monadic function over a list of values and flattens the result.
  */
-let bind = BsAbstract.List.Monad.flat_map;
+let bind = BsBastet.List.Monad.flat_map;
 
-module Monad: BsAbstract.Interface.MONAD with type t('a) = list('a) = {
+module Monad: MONAD with type t('a) = list('a) = {
   include Applicative;
   let flat_map = bind;
 };
@@ -70,23 +70,22 @@ include Relude_Extensions_Monad.MonadExtensions(Monad);
 /**
  * alt for lists concatenates the lists.
  */
-let alt = BsAbstract.List.Alt.alt;
+let alt = BsBastet.List.Alt.alt;
 
-module Alt: BsAbstract.Interface.ALT with type t('a) = list('a) = {
+module Alt: ALT with type t('a) = list('a) = {
   include Functor;
   let alt = alt;
 };
 include Relude_Extensions_Alt.AltExtensions(Alt);
 
-module Plus: BsAbstract.Interface.PLUS with type t('a) = list('a) = {
+module Plus: PLUS with type t('a) = list('a) = {
   include MonoidAny;
   let map = map;
   let alt = alt;
 };
 include Relude_Extensions_Plus.PlusExtensions(Plus);
 
-module Alternative:
-  BsAbstract.Interface.ALTERNATIVE with type t('a) = list('a) = {
+module Alternative: ALTERNATIVE with type t('a) = list('a) = {
   include Plus;
   let apply = apply;
   let pure = pure;
@@ -96,21 +95,21 @@ include Relude_Extensions_Alternative.AlternativeExtensions(Alternative);
 /**
  * Folds a list from left-to-right into a single value using an accumulator
  */
-let foldLeft = BsAbstract.List.Foldable.fold_left;
+let foldLeft = BsBastet.List.Foldable.fold_left;
 
 /**
  * Folds a list from right-to-left into a single value using an accumulator
  */
-let foldRight = BsAbstract.List.Foldable.fold_right;
+let foldRight = BsBastet.List.Foldable.fold_right;
 
-module Foldable: BsAbstract.Interface.FOLDABLE with type t('a) = list('a) = {
-  include BsAbstract.List.Foldable;
+module Foldable: FOLDABLE with type t('a) = list('a) = {
+  include BsBastet.List.Foldable;
   let fold_left = foldLeft;
   let fold_right = foldRight;
 };
 include Relude_Extensions_Foldable.FoldableExtensions(Foldable);
 
-module Traversable: BsAbstract.List.TRAVERSABLE_F = BsAbstract.List.Traversable;
+module Traversable: BsBastet.List.TRAVERSABLE_F = BsBastet.List.Traversable;
 
 /**
  * Compares two lists for length and pair-wise equality using the given equality function
@@ -126,13 +125,12 @@ let rec eqBy: (('a, 'a) => bool, list('a), list('a)) => bool =
 /**
  * Compares two lists for length and pair-wise equality using the given EQ module
  */
-let eq =
-    (type a, eqA: (module BsAbstract.Interface.EQ with type t = a), xs, ys) => {
+let eq = (type a, eqA: (module EQ with type t = a), xs, ys) => {
   module EqA = (val eqA);
   eqBy(EqA.eq, xs, ys);
 };
 
-module Eq = (EqA: BsAbstract.Interface.EQ) => {
+module Eq = (EqA: EQ) => {
   type t = list(EqA.t);
   let eq = (xs, ys) => eqBy(EqA.eq, xs, ys);
 };
@@ -142,20 +140,19 @@ module Eq = (EqA: BsAbstract.Interface.EQ) => {
  */
 let showBy: ('a => string, list('a)) => string =
   (innerShow, xs) => {
-    let join = intercalate((module BsAbstract.String.Monoid));
+    let join = intercalate((module BsBastet.String.Monoid));
     "[" ++ join(", ", map(innerShow, xs)) ++ "]";
   };
 
 /**
  * Converts a list to a string using the given SHOW module
  */
-let show =
-    (type a, showA: (module BsAbstract.Interface.SHOW with type t = a), xs) => {
+let show = (type a, showA: (module SHOW with type t = a), xs) => {
   module ShowA = (val showA);
   showBy(ShowA.show, xs);
 };
 
-module Show = (ShowA: BsAbstract.Interface.SHOW) => {
+module Show = (ShowA: SHOW) => {
   type t = list(ShowA.t);
   let show = xs => showBy(ShowA.show, xs);
 };

--- a/src/list/Relude_List_Specializations.re
+++ b/src/list/Relude_List_Specializations.re
@@ -1,7 +1,9 @@
+open BsBastet.Interface;
+
 /**
  * List extensions for when you have an EQ instance.
  */
-module ListEqExtensions = (E: BsAbstract.Interface.EQ) => {
+module ListEqExtensions = (E: EQ) => {
   include Relude_List_Instances.FoldableEqExtensions(E);
   /**
    * Gets the distinct items of the list, based on the given EQ module
@@ -29,7 +31,7 @@ module ListEqExtensions = (E: BsAbstract.Interface.EQ) => {
 /**
  * List extensions for when you have an ORD instance.
  */
-module ListOrdExtensions = (O: BsAbstract.Interface.ORD) => {
+module ListOrdExtensions = (O: ORD) => {
   include ListEqExtensions(O);
   include Relude_List_Instances.FoldableOrdExtensions(O);
   /**
@@ -41,7 +43,7 @@ module ListOrdExtensions = (O: BsAbstract.Interface.ORD) => {
 /**
  * List extensions for when you have an MONOID instance.
  */
-module ListMonoidExtensions = (M: BsAbstract.Interface.MONOID) => {
+module ListMonoidExtensions = (M: MONOID) => {
   include Relude_List_Instances.FoldableMonoidExtensions(M);
 };
 
@@ -196,17 +198,13 @@ module IO = {
  * List extensions for `Validation.t('a, 'e)`
  */
 module Validation = {
-  module Traversable =
-         (
-           Errors: BsAbstract.Interface.SEMIGROUP_ANY,
-           Error: BsAbstract.Interface.TYPE,
-         ) => {
+  module Traversable = (Errors: SEMIGROUP_ANY, Error: TYPE) => {
     module ValidationE = Relude_Validation.WithErrors(Errors, Error);
     module ValidationEApplicative = ValidationE.Applicative;
-    include BsAbstract.List.Traversable(ValidationEApplicative);
+    include BsBastet.List.Traversable(ValidationEApplicative);
   };
 
-  module TraversableWithErrorsAsList = (Error: BsAbstract.Interface.TYPE) =>
+  module TraversableWithErrorsAsList = (Error: TYPE) =>
     Traversable(Relude_List_Instances.SemigroupAny, Error);
 
   module TraversableWithErrorsAsListOfStrings =
@@ -214,8 +212,7 @@ module Validation = {
       type t = string;
     });
 
-  module TraversableWithErrorsAsNonEmptyList =
-         (Error: BsAbstract.Interface.TYPE) =>
+  module TraversableWithErrorsAsNonEmptyList = (Error: TYPE) =>
     Traversable(Relude_NonEmpty.List.SemigroupAny, Error);
 
   /**

--- a/src/option/Relude_Option_Instances.re
+++ b/src/option/Relude_Option_Instances.re
@@ -309,21 +309,7 @@ module Eq: BsBastet.Option.EQ_F =
     let eq = (xs: t, ys: t) => eqBy(EqA.eq, xs, ys);
   };
 
-// TODO: the actual implementation should come from upstream... currently
-// waiting on a bs-abstract release
-module type ORD_F = (O: ORD) => ORD with type t = option(O.t);
-
-module Ord: ORD_F =
-  (O: ORD) => {
-    include Eq(O);
-    let compare = (a, b) =>
-      switch (a, b) {
-      | (Some(a'), Some(b')) => O.compare(a', b')
-      | (None, None) => `equal_to
-      | (None, Some(_)) => `less_than
-      | (Some(_), None) => `greater_than
-      };
-  };
+module Ord: BsBastet.Option.ORD_F = BsBastet.Option.Ord;
 
 /**
  * Converts the option to a string using the given show function

--- a/src/option/Relude_Option_Instances.re
+++ b/src/option/Relude_Option_Instances.re
@@ -1,3 +1,4 @@
+open BsBastet.Interface;
 open Relude_Function.Infix;
 
 let compose:
@@ -13,8 +14,7 @@ let compose:
     };
   };
 
-module Semigroupoid:
-  BsAbstract.Interface.SEMIGROUPOID with type t('a, 'b) = option('a => 'b) = {
+module Semigroupoid: SEMIGROUPOID with type t('a, 'b) = option('a => 'b) = {
   type t('a, 'b) = option('a => 'b);
   let compose = compose;
 };
@@ -36,7 +36,7 @@ let map: 'a 'b. ('a => 'b, option('a)) => option('b) =
     | Some(x) => Some(f(x))
     | None => None;
 
-module Functor: BsAbstract.Interface.FUNCTOR with type t('a) = option('a) = {
+module Functor: FUNCTOR with type t('a) = option('a) = {
   type nonrec t('a) = option('a);
   let map = map;
 };
@@ -56,9 +56,9 @@ include Relude_Extensions_Functor.FunctorExtensions(Functor);
   apply(None, None) == None;
   ```
 */
-let apply: 'a 'b. (option('a => 'b), option('a)) => option('b) = BsAbstract.Option.Apply.apply;
+let apply: 'a 'b. (option('a => 'b), option('a)) => option('b) = BsBastet.Option.Apply.apply;
 
-module Apply: BsAbstract.Interface.APPLY with type t('a) = option('a) = {
+module Apply: APPLY with type t('a) = option('a) = {
   include Functor;
   let apply = apply;
 };
@@ -74,8 +74,7 @@ include Relude_Extensions_Apply.ApplyExtensions(Apply);
 */
 let pure: 'a. 'a => option('a) = v => Some(v);
 
-module Applicative:
-  BsAbstract.Interface.APPLICATIVE with type t('a) = option('a) = {
+module Applicative: APPLICATIVE with type t('a) = option('a) = {
   include Apply;
   let pure = pure;
 };
@@ -105,7 +104,7 @@ let bind: 'a 'b. (option('a), 'a => option('b)) => option('b) =
     | None => None
     };
 
-module Monad: BsAbstract.Interface.MONAD with type t('a) = option('a) = {
+module Monad: MONAD with type t('a) = option('a) = {
   include Applicative;
   let flat_map = bind;
 };
@@ -162,7 +161,7 @@ include Relude_Extensions_Align.AlignExtensions(Align);
   ```
 */
 let foldLeft: 'a 'b. (('b, 'a) => 'b, 'b, option('a)) => 'b =
-  (fn, default) => BsAbstract.Option.Foldable.fold_left(fn, default);
+  (fn, default) => BsBastet.Option.Foldable.fold_left(fn, default);
 
 /**
   `foldRight(f, init, opt)` takes as its first argument a function `f`
@@ -182,9 +181,9 @@ let foldLeft: 'a 'b. (('b, 'a) => 'b, 'b, option('a)) => 'b =
   ```
 */
 let foldRight: 'a 'b. (('a, 'b) => 'b, 'b, option('a)) => 'b =
-  (fn, default) => BsAbstract.Option.Foldable.fold_right(fn, default);
+  (fn, default) => BsBastet.Option.Foldable.fold_right(fn, default);
 
-module Foldable = BsAbstract.Option.Foldable;
+module Foldable = BsBastet.Option.Foldable;
 include Relude_Extensions_Foldable.FoldableExtensions(Foldable);
 
 /**
@@ -220,7 +219,7 @@ let altLazy: 'a. (option('a), unit => option('a)) => option('a) =
     | None => getFA2()
     };
 
-module Semigroup_Any: BsAbstract.Interface.SEMIGROUP_ANY = {
+module Semigroup_Any: SEMIGROUP_ANY = {
   type t('a) = option('a);
   let append = alt;
 };
@@ -230,16 +229,16 @@ module Monoid_Any = {
   let empty = None;
 };
 
-module Alt = BsAbstract.Option.Alt;
+module Alt = BsBastet.Option.Alt;
 include Relude_Extensions_Alt.AltExtensions(Alt);
 
-module Plus = BsAbstract.Option.Plus;
+module Plus = BsBastet.Option.Plus;
 include Relude_Extensions_Plus.PlusExtensions(Plus);
 
-module Alternative = BsAbstract.Option.Alternative;
+module Alternative = BsBastet.Option.Alternative;
 include Relude_Extensions_Alternative.AlternativeExtensions(Alternative);
 
-module Traversable: BsAbstract.Option.TRAVERSABLE_F = BsAbstract.Option.Traversable;
+module Traversable: BsBastet.Option.TRAVERSABLE_F = BsBastet.Option.Traversable;
 
 /**
   In `eqBy(f, opt1, opt2)`, `f` is a function that compares two arguments
@@ -295,29 +294,27 @@ let eqBy: (('a, 'a) => bool, option('a), option('a)) => bool =
 let eq =
     (
       type a,
-      showA: (module BsAbstract.Interface.EQ with type t = a),
+      showA: (module EQ with type t = a),
       fa1: option(a),
       fa2: option(a),
     )
     : bool => {
-  module Eq = BsAbstract.Option.Eq((val showA));
+  module Eq = BsBastet.Option.Eq((val showA));
   Eq.eq(fa1, fa2);
 };
 
-module Eq: BsAbstract.Option.EQ_F =
-  (EqA: BsAbstract.Interface.EQ) => {
+module Eq: BsBastet.Option.EQ_F =
+  (EqA: EQ) => {
     type t = option(EqA.t);
     let eq = (xs: t, ys: t) => eqBy(EqA.eq, xs, ys);
   };
 
 // TODO: the actual implementation should come from upstream... currently
 // waiting on a bs-abstract release
-module type ORD_F =
-  (O: BsAbstract.Interface.ORD) =>
-   BsAbstract.Interface.ORD with type t = option(O.t);
+module type ORD_F = (O: ORD) => ORD with type t = option(O.t);
 
 module Ord: ORD_F =
-  (O: BsAbstract.Interface.ORD) => {
+  (O: ORD) => {
     include Eq(O);
     let compare = (a, b) =>
       switch (a, b) {
@@ -341,27 +338,22 @@ let showBy: 'a. ('a => string, option('a)) => string =
  * Converts the option to a string using the given SHOW module
  */
 let show =
-    (
-      type a,
-      showA: (module BsAbstract.Interface.SHOW with type t = a),
-      fa: option(a),
-    )
-    : string => {
-  module Show = BsAbstract.Option.Show((val showA));
+    (type a, showA: (module SHOW with type t = a), fa: option(a)): string => {
+  module Show = BsBastet.Option.Show((val showA));
   Show.show(fa);
 };
 
-module Show = BsAbstract.Option.Show;
+module Show = BsBastet.Option.Show;
 
-module WithSemigroup = (S: BsAbstract.Interface.SEMIGROUP) => {
-  module Semigroup = BsAbstract.Option.Semigroup(S);
+module WithSemigroup = (S: SEMIGROUP) => {
+  module Semigroup = BsBastet.Option.Semigroup(S);
   include Relude_Extensions_Semigroup.SemigroupExtensions(Semigroup);
 
-  module Monoid = BsAbstract.Option.Monoid(S);
+  module Monoid = BsBastet.Option.Monoid(S);
   include Relude_Extensions_Monoid.MonoidExtensions(Monoid);
 };
 
-module WithApplicative = (A: BsAbstract.Interface.APPLICATIVE) => {
-  module Traversable = BsAbstract.Option.Traversable(A);
+module WithApplicative = (A: APPLICATIVE) => {
+  module Traversable = BsBastet.Option.Traversable(A);
   include Relude_Extensions_Traversable.TraversableExtensions(Traversable);
 };

--- a/src/option/Relude_Option_Specializations.re
+++ b/src/option/Relude_Option_Specializations.re
@@ -1,9 +1,9 @@
-module OptionEqExtensions = (E: BsAbstract.Interface.EQ) => {
+module OptionEqExtensions = (E: BsBastet.Interface.EQ) => {
   let eq: (option(E.t), option(E.t)) => bool =
     Relude_Option_Instances.eqBy(E.eq);
 };
 
-module OptionOrdExtensions = (O: BsAbstract.Interface.ORD) => {
+module OptionOrdExtensions = (O: BsBastet.Interface.ORD) => {
   module OptionOrd = Relude_Option_Instances.Ord(O);
 
   let compare = OptionOrd.compare;
@@ -32,7 +32,7 @@ module IO = {
       Relude_IO.WithError({
         type t = e;
       });
-    module TraverseIO = BsAbstract.Option.Traversable(IoE.Applicative);
+    module TraverseIO = BsBastet.Option.Traversable(IoE.Applicative);
     TraverseIO.traverse(f, opt);
   };
 
@@ -43,7 +43,7 @@ module IO = {
       Relude_IO.WithError({
         type t = e;
       });
-    module TraverseIO = BsAbstract.Option.Traversable(IoE.Applicative);
+    module TraverseIO = BsBastet.Option.Traversable(IoE.Applicative);
     TraverseIO.sequence(opt);
   };
 };


### PR DESCRIPTION
- Update `bs-platform` to 7.2.2
- Update `bs-abstract` to `bs-bastet@1.2.3`
- Update tons of `BsAbstract` references to `BsBastet` (I tried to factor out repeated `BsAbstract.Interface.` into `open`s in cases where it didn't conflict with anything)
- There are a couple `Extensions.*` modules that re-aliased `ordering`, and now they just use the definition from `BsBastet.Interface` instead (which is technically a breaking change)

This PR doesn't (yet) build on native, but at this point it should just be a matter of splitting the JS-specific stuff into its own separate library. Also, it might be worth waiting for Risto-Stevcev/bastet#26 to be fixed, as currently the branch doesn't build unless you manually install `bisect_ppx`.