### PR TITLE
Add special let syntax

### DIFF
--- a/__tests__/Relude_IO_test.re
+++ b/__tests__/Relude_IO_test.re
@@ -3506,6 +3506,22 @@ describe("IO FS examples", () => {
        )
   );
 
+  testAsync("read and writeFileSync, with letops", onDone => {
+    let fileIO = {
+      open IOJsExn;
+      let* _ = FS.IO.writeFileSync(testFilePath, "IO Eff test");
+      let* content = FS.IO.readFileSync(testFilePath);
+      pure(expect(content) |> toEqual("IO Eff test"));
+    };
+
+    fileIO
+    |> IO.unsafeRunAsync(
+         fun
+         | Ok(assertion) => onDone(assertion)
+         | Error(_jsExn) => onDone(fail("Failed")),
+       );
+  });
+
   testAsync("readFile", onDone =>
     FS.IO.writeFile(testFilePath, "IO Aff test")
     >>= (_ => FS.IO.readFile(testFilePath))

--- a/__tests__/Relude_Validation_test.re
+++ b/__tests__/Relude_Validation_test.re
@@ -490,4 +490,5 @@ describe("Validation", () => {
         [Error.InvalidAge(200), Error.InvalidLanguage("French")],
       );
     expect(validation) |> toEqual(Validation.VError(expected));
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1539,9 +1539,8 @@
       }
     },
     "bs-platform": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.2.2.tgz",
-      "integrity": "sha512-PWcFfN+jCTtT/rMaHDhKh+W9RUTpaRunmSF9vbLYcrJbpgCNW6aFKAY33u0P3mLxwuhshN3b4FxqGUBPj6exZQ==",
+      "version": "github:bucklescript/bucklescript#1b6678bf7d354a70e2984971719a7396ba9e1400",
+      "from": "github:bucklescript/bucklescript#1b6678b",
       "dev": true
     },
     "bs-stdlib-shims": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   "devDependencies": {
     "@glennsl/bs-jest": "^0.5.1",
     "bs-bastet": "^1.2.5",
-    "bs-platform": "^7.2.2",
+    "bs-platform": "github:bucklescript/bucklescript#1b6678b",
     "docsify-cli": "~4.4.0"
   },
   "peerDependencies": {
     "bs-bastet": "^1.2.5",
-    "bs-platform": "^7.2.2"
+    "bs-platform": "github:bucklescript/bucklescript#1b6678b"
   },
   "dependencies": {},
   "jest": {

--- a/src/extensions/Relude_Extensions_Apply.re
+++ b/src/extensions/Relude_Extensions_Apply.re
@@ -53,9 +53,21 @@ module ApplyExtensions = (A: BsBastet.Interface.APPLY) => {
    = BsApplyExtensions.lift5;
 
   /**
+   * Runs the applicative effects and combines the result in a tuple. Alias for
+   * `tuple2`.
+   */
+  let product: 'a 'b. (A.t('a), A.t('b)) => A.t(('a, 'b)) = BsApplyExtensions.apply_both;
+
+  /**
+   * Special let-like operator that allows easier non-nested chaining of
+   * applicatives.
+   */
+  let (and+) = product;
+
+  /**
    * Runs the applicative effects and combines the results into a tuple.
    */
-  let tuple2: 'a 'b. (A.t('a), A.t('b)) => A.t(('a, 'b)) = BsApplyExtensions.apply_both;
+  let tuple2: 'a 'b. (A.t('a), A.t('b)) => A.t(('a, 'b)) = product;
 
   /**
    * Runs the applicative effects and combines the results into a tuple.

--- a/src/extensions/Relude_Extensions_Functor.re
+++ b/src/extensions/Relude_Extensions_Functor.re
@@ -5,13 +5,20 @@ module FunctorExtensions = (F: BsBastet.Interface.FUNCTOR) => {
   module BsFunctorExtensions = BsBastet.Functions.Functor(F);
 
   /**
-   * Flipped version of the map function which has the functor on the left, and the function on the right.
+   * Flipped version of the map function which has the functor on the left, and
+   * the function on the right.
    */
   let flipMap: 'a 'b. (F.t('a), 'a => 'b) => F.t('b) =
     (fa, f) => F.map(f, fa);
 
   /**
-   * Clears the value(s) of a functor by mapping a function that produces unit for each value in the functor.
+   * Special let binding for functors, allowing simpler, non-nested chaining.
+   */
+  let (let+) = flipMap;
+
+  /**
+   * Clears the value(s) of a functor by mapping a function that produces unit
+   * for each value in the functor.
    */
   let void: 'a. F.t('a) => F.t(unit) = BsFunctorExtensions.void;
 

--- a/src/extensions/Relude_Extensions_Monad.re
+++ b/src/extensions/Relude_Extensions_Monad.re
@@ -4,6 +4,8 @@
 module MonadExtensions = (M: BsBastet.Interface.MONAD) => {
   module BsMonadExtensions = BsBastet.Functions.Monad(M);
 
+  let ( let* ) = M.flat_map;
+
   /**
    * Flipped version of `bind` which has the function on the left and the monad on the right.
    * We're calling this `flatMap` because the signature closely resembles the signature of


### PR DESCRIPTION
So... that was easy. :joy: 

This is not ready to use yet! It's pinned to a specific Bucklescript PR ([this one](https://github.com/BuckleScript/bucklescript/pull/4271) to be precise). Once that is merged and a Bucklescript release is made, we can release this as well.

This PR adds `let+` to all members of Functor, `and+` to all members of Apply, and `let*` to all members of `Monad` in Relude. I also included a couple tests (`let*` with IO and `let+`/`and+` with Validation) to prove it works and to demonstrate its usage. If you want to learn more, [this blog post](https://jobjo.github.io/2019/04/24/ocaml-has-some-new-shiny-syntax.html) (in OCaml syntax) is probably the most comprehensive overview of the feature.

For now, I stuck to `let+`, `and+`, and `let*`. I know the symbolic naming can be hard to read, but something like `let.opt` would require us to special case each type (and it's not clear whether that refers to `map` or `bind`). Alternatively, we could use `let.bind`, but `and.ap` isn't much more clear than `and+`, and the non-symbolic names aren't compatible with OCaml.