### PR TITLE
Add list unfold

### DIFF
--- a/__tests__/Relude_List_test.re
+++ b/__tests__/Relude_List_test.re
@@ -114,6 +114,16 @@ describe("List", () => {
     |> toEqual([5, 4, 3, 2, 1])
   );
 
+  test("unfold", () =>
+    expect(
+      List.unfold(
+        x => if (x>5) None else Some((x, x+1)),
+        0,
+      ),
+    )
+    |> toEqual([0, 1, 2, 3, 4, 5])
+  );
+
   test("scanLeft", () =>
     expect(
       List.scanLeft(

--- a/src/list/Relude_List_Instances.re
+++ b/src/list/Relude_List_Instances.re
@@ -109,6 +109,18 @@ module Foldable: FOLDABLE with type t('a) = list('a) = {
 };
 include Relude_Extensions_Foldable.FoldableExtensions(Foldable);
 
+/**
+ * Create a list by recursively unfolding with a generator function and seed value
+ */
+let unfold = BsBastet.List.Unfoldable.unfold;
+
+module Unfoldable: UNFOLDABLE with type t('a) = list('a) = {
+  include BsBastet.List.Unfoldable;
+  let unfold = unfold;
+};
+include Relude_Extensions_Unfoldable.UnfoldableExtensions(Unfoldable);
+
+
 module Traversable: BsBastet.List.TRAVERSABLE_F = BsBastet.List.Traversable;
 
 /**


### PR DESCRIPTION
I had meant to add the unfold interface and various implementations to Relude after getting them merged to `bs-bastet`, but forgot since I was using bastet's unfold directly.

I see you're already using the bastet interface for your Tree `unfold`, which is cool.

Here I've just hooked up bastet's list unfold and added a test.