### PR TITLE
Upgrade bisect ppx to 2.4.1 and fix setupFilesAfterEnv config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1445,9 +1445,9 @@
       "dev": true
     },
     "bisect_ppx": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bisect_ppx/-/bisect_ppx-2.4.0.tgz",
-      "integrity": "sha512-rpmu45zDbrc/z529vDom/umb3D0IUO5D5bEkPSJchbtAW4F0S5FXXZ18eEmuEpcsLViHqlM9howwO7QIY12vmA=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/bisect_ppx/-/bisect_ppx-2.4.1.tgz",
+      "integrity": "sha512-U6sd2mMqg28NEBmB4NuJRUJq0aTrzVCIkv8bnbzaomIZfO0DMWZ7B8QJ5aBY46tbaIeNrvmYWylnNNaoPEWZmw=="
     },
     "boxen": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bs-platform": "^7.2.2"
   },
   "dependencies": {
-    "bisect_ppx": "^2.4.0"
+    "bisect_ppx": "^2.4.1"
   },
   "jest": {
     "verbose": false,
@@ -51,7 +51,7 @@
       "/testUtils/"
     ],
     "setupFilesAfterEnv": [
-      "bisect_ppx/src/runtime/bucklescript/jest.js"
+      "bisect_ppx/lib/js/src/runtime/bucklescript/jest.js"
     ]
   }
 }


### PR DESCRIPTION
This will fix an error like this"

```sh
npm test

> relude@0.63.0 test /Repos/relude
> jest

● Validation Error:

  Module bisect_ppx/lib/js/src/runtime/bucklescript/jest.js in the setupFilesAfterEnv option was not found.
         <rootDir> is: /Repos/relude

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html

npm ERR! Test failed.  See above for more details.
```