### PR TITLE
Inverse map functions

### DIFF
--- a/__tests__/extensions/Relude_Extensions_Enum_test.re
+++ b/__tests__/extensions/Relude_Extensions_Enum_test.re
@@ -262,12 +262,14 @@ describe("Relude_Extensions_BoundedEnum", () => {
   );
   describe("Relude_Extensions_BoundedEnum", () => {
     let show = Show.show;
-    let parse = inverseMap(show);
-    let parseOrdered =
-      inverseMapWithComparator(~compare=Relude.String.compare, show);
+    let parseOrd = inverseMapOrd(~ordA=(module Relude_String.Ord), show);
+    let parseOrdBy = inverseMapOrdBy(Relude.String.compare, show);
+    let parseEq = inverseMapEq(~eqA=(module Relude_String.Eq), show);
+    let parseEqBy = inverseMapEqBy(Relude.String.eq, show);
+    let parseString = inverseMapString(show);
 
     testAll(
-      "inverseMap",
+      "inverseMapOrd",
       [
         ("Jan", Some(Jan)),
         ("Feb", Some(Feb)),
@@ -296,7 +298,7 @@ describe("Relude_Extensions_BoundedEnum", () => {
         ("dec", None),
       ],
       ((string, expected)) => {
-        let actual = parse(string);
+        let actual = parseOrd(string);
         expect(actual) |> toEqual(expected);
       },
     );
@@ -331,7 +333,7 @@ describe("Relude_Extensions_BoundedEnum", () => {
         ("dec", None),
       ],
       ((string, expected)) => {
-        let actual = parseOrdered(string);
+        let actual = parseOrdBy(string);
         expect(actual) |> toEqual(expected);
       },
     );
@@ -366,9 +368,25 @@ describe("Relude_Extensions_BoundedEnum", () => {
         "dec",
       ],
       string => {
-        let usingInverseMap = parse(string);
-        let usingInverseMapWithComparator = parseOrdered(string);
-        expect(usingInverseMap) |> toEqual(usingInverseMapWithComparator);
+        let usingInverseMapOrd = parseOrd(string);
+        let usingInverseMapOrdBy = parseOrdBy(string);
+        let usingInverseMapEq = parseEq(string);
+        let usingInverseMapEqBy = parseEqBy(string);
+        let usingInverseMapString = parseString(string);
+        expect((
+          usingInverseMapOrd,
+          usingInverseMapOrdBy,
+          usingInverseMapEq,
+          usingInverseMapEqBy,
+          usingInverseMapString,
+        ))
+        |> toEqual((
+             usingInverseMapOrdBy,
+             usingInverseMapEq,
+             usingInverseMapEqBy,
+             usingInverseMapString,
+             usingInverseMapOrd,
+           ));
       },
     );
   });

--- a/__tests__/extensions/Relude_Extensions_Enum_test.re
+++ b/__tests__/extensions/Relude_Extensions_Enum_test.re
@@ -259,5 +259,117 @@ describe("Relude_Extensions_BoundedEnum", () => {
       let actual = Month.fromThenToAsList(~start, ~next, ~finish);
       expect(actual) |> toEqual(expected);
     },
-  )
+  );
+  describe("Relude_Extensions_BoundedEnum", () => {
+    let show = Show.show;
+    let parse = inverseMap(show);
+    let parseOrdered =
+      inverseMapWithComparator(~compare=Relude.String.compare, show);
+
+    testAll(
+      "inverseMap",
+      [
+        ("Jan", Some(Jan)),
+        ("Feb", Some(Feb)),
+        ("Mar", Some(Mar)),
+        ("Apr", Some(Apr)),
+        ("May", Some(May)),
+        ("Jun", Some(Jun)),
+        ("Jul", Some(Jul)),
+        ("Aug", Some(Aug)),
+        ("Sep", Some(Sep)),
+        ("Oct", Some(Oct)),
+        ("Nov", Some(Nov)),
+        ("Dec", Some(Dec)),
+        ("", None),
+        ("jan", None),
+        ("feb", None),
+        ("mar", None),
+        ("apr", None),
+        ("may", None),
+        ("jun", None),
+        ("jul", None),
+        ("aug", None),
+        ("sep", None),
+        ("oct", None),
+        ("nov", None),
+        ("dec", None),
+      ],
+      ((string, expected)) => {
+        let actual = parse(string);
+        expect(actual) |> toEqual(expected);
+      },
+    );
+
+    testAll(
+      "inverseMapWithComparator",
+      [
+        ("Jan", Some(Jan)),
+        ("Feb", Some(Feb)),
+        ("Mar", Some(Mar)),
+        ("Apr", Some(Apr)),
+        ("May", Some(May)),
+        ("Jun", Some(Jun)),
+        ("Jul", Some(Jul)),
+        ("Aug", Some(Aug)),
+        ("Sep", Some(Sep)),
+        ("Oct", Some(Oct)),
+        ("Nov", Some(Nov)),
+        ("Dec", Some(Dec)),
+        ("", None),
+        ("jan", None),
+        ("feb", None),
+        ("mar", None),
+        ("apr", None),
+        ("may", None),
+        ("jun", None),
+        ("jul", None),
+        ("aug", None),
+        ("sep", None),
+        ("oct", None),
+        ("nov", None),
+        ("dec", None),
+      ],
+      ((string, expected)) => {
+        let actual = parseOrdered(string);
+        expect(actual) |> toEqual(expected);
+      },
+    );
+
+    testAll(
+      "inverseMapWithComparator",
+      [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+        "",
+        "jan",
+        "feb",
+        "mar",
+        "apr",
+        "may",
+        "jun",
+        "jul",
+        "aug",
+        "sep",
+        "oct",
+        "nov",
+        "dec",
+      ],
+      string => {
+        let usingInverseMap = parse(string);
+        let usingInverseMapWithComparator = parseOrdered(string);
+        expect(usingInverseMap) |> toEqual(usingInverseMapWithComparator);
+      },
+    );
+  });
 });

--- a/src/extensions/Relude_Extensions_BoundedEnum.re
+++ b/src/extensions/Relude_Extensions_BoundedEnum.re
@@ -2,7 +2,6 @@ let listAppend = (value, list) => List.concat([list, [value]]);
 //let arrayAppend = (value, array) => Array.concat([array, [|value|]]);
 
 module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
-
   include Relude_Extensions_Enum.EnumExtensions(E);
 
   /**
@@ -20,7 +19,7 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
         | `equal_to => listAppend(current, acc)
         | `less_than
         | `greater_than =>
-        /**
+          /**
         Since step can be positive or negative, we handle less_than
         and greater_than the same way by just adding the step
         */
@@ -92,8 +91,9 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
 
   let inverseMapEqBy2: type a. ((a, a) => bool, E.t => a, a) => option(E.t) =
     (eqA, eToA) => {
-      let arr = upFromIncludingAsList(E.bottom)
-        |> Belt.List.mapU(_,  (. e) => (e, eToA(e)))
+      let arr =
+        upFromIncludingAsList(E.bottom)
+        |> Belt.List.mapU(_, (. e) => (e, eToA(e)))
         |> Belt.List.toArray;
       let len = Belt.Array.length(arr);
       // generate the closure to pass back to the caller:
@@ -209,14 +209,18 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
              };
          })): (module Map.S with type key = a)
       );
-      let lst = upFromIncludingAsList(E.bottom);
-      let store = Belt.List.reduceU(lst, M.empty, (. acc, e) => {
-        let a = eToA(e);
-        M.add(a, e, acc);
-      });
+      let store =
+        upFromIncludingAsList(E.bottom)
+        ->Belt.List.reduceU(
+            M.empty,
+            (. acc, e) => {
+              let a = eToA(e);
+              M.add(a, e, acc);
+            },
+          );
 
       M.find_opt(_, store);
-  };
+    };
 
   /**
    [BoundedEnumExtensions.inverseMapOrd] takes a first-class [ORD] module

--- a/src/extensions/Relude_Extensions_BoundedEnum.re
+++ b/src/extensions/Relude_Extensions_BoundedEnum.re
@@ -91,6 +91,7 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
 
   let inverseMapEqBy2: type a. ((a, a) => bool, E.t => a, a) => option(E.t) =
     (eqA, eToA) => {
+      // create an associative array for reverse lookups:
       let arr =
         upFromIncludingAsList(E.bottom)
         |> Belt.List.mapU(_, (. e) => (e, eToA(e)))

--- a/src/extensions/Relude_Extensions_BoundedEnum.re
+++ b/src/extensions/Relude_Extensions_BoundedEnum.re
@@ -27,4 +27,109 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
       };
       go([], start, startInt);
     };
+
+  /**
+   [BoundedEnumExtensions.inverseMap] takes a function of type [t => a],
+   where each [a] is a unique value, and returns a new function of type
+   [a => option(t)].
+
+   This is useful for generating parser utilities, reverse-lookup functions,
+   etc.
+
+   Note: since there is no way to determine the ordering of [a] without
+   a comparator function, any call to the returned function must iterate
+   through the entire list of possible values until it finds a match or
+   reaches the end of the list. Therefore, the worst-case time complexity
+   of the returned function is necessarily **linear**, and failed lookups
+   will always be worst-case.
+
+   See {!val:inverseMapToOrd} for a similar function that accepts a
+   comparator for [a], and returns a reverse-lookup function with a
+   worst-case running time of O(log(n)).
+
+   Running time for staging: O(n)
+   Running time of the returned lookup function: O(n)
+   */
+  let inverseMap: (E.t => 'a, 'a) => option(E.t) =
+    map => {
+      let rec loop = (lst, maybeE, getNextE) => {
+        switch (maybeE) {
+        | None =>
+          // generate the closure to pass back to the caller:
+          let arr = Belt.List.toArray(lst);
+          let len = Belt.Array.length(arr);
+          let return = a => {
+            let rec find = (arr, i, limit) =>
+              if (i < limit) {
+                let (e__, a__) = Belt.Array.getUnsafe(arr, i);
+                if (a__ === a) {
+                  Some(e__);
+                } else {
+                  find(arr, succ(i), limit);
+                };
+              } else {
+                None;
+              };
+            find(arr, 0, len);
+          };
+          return;
+        | Some(e) =>
+          // Continue building the associative list:
+          loop([(e, map(e)), ...lst], getNextE(e), getNextE)
+        };
+      };
+
+      // Build associative list and pass a lookup function to the caller:
+      loop([], Some(E.bottom), E.succ);
+    };
+
+  /**
+   [BoundedEnum.inverseMapToOrd] takes a [~compare] function of type
+   [(a, a) => Relude.Ordering.t], along with a mapping function of type
+   [t => a], where each [a] is a unique value, and returns a new function
+   of type [a => option(t)].
+
+   It works similarly to `inverseMap`, but uses a comparator function for
+   the ordered type [a]. This enables the use of an internal Map structure
+   for O(log(n)) lookups. This might yield a slightly higher constant
+   factor, but scales favorably for large enums.
+
+   Running time for staging: O(n)
+   Running time for returned lookup function: O(log(n))
+   */
+  let inverseMapToOrd:
+    type a.
+      (~compare: (a, a) => BsBastet.Interface.ordering, E.t => a, a) =>
+      option(E.t) =
+    (~compare, map) => {
+      // Generate the Map data structure:
+      let (module M_) = (
+        (module
+         Map.Make({
+           type t = a;
+           let compare = (a, b) =>
+             switch (compare(a, b)) {
+             | `equal_to => 0
+             | `less_than => (-1)
+             | `greater_than => 1
+             };
+         })): (module Map.S with type key = a)
+      );
+
+      /**
+       * Produce an 'a' value for each 'enum' value that exists,
+       * then insert each of them into the Map.
+       * */
+      let rec loop = (insert, store, current) => {
+        switch (current) {
+        | None => M_.find_opt(_, store)
+        | Some(e) =>
+          let a = map(e);
+          let st = insert(a, e, store);
+          loop(insert, st, E.succ(e));
+        };
+      };
+
+      loop(M_.add, M_.empty, Some(E.bottom));
+    };
 };

--- a/src/extensions/Relude_Extensions_BoundedEnum.re
+++ b/src/extensions/Relude_Extensions_BoundedEnum.re
@@ -29,29 +29,30 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
     };
 
   /**
-   [BoundedEnumExtensions.inverseMap] takes a function of type [t => a],
-   where each [a] is a unique value, and returns a new function of type
-   [a => option(t)].
+   [BoundedEnumExtensions.inverseMapEqBy] takes a equality function of type
+   [(a, a) => bool] along with a function of type [t => a], where each [a]
+   is a unique value, and returns a new function of type [a => option(t)].
 
-   This is useful for generating parser utilities, reverse-lookup functions,
-   etc.
+   [inverseMapEqBy] performs the same operations as [inverseMapEq], but
+   it accepts an equality function for [a], instead of a first-class
+   [Eq] module.
 
    Note: since there is no way to determine the ordering of [a] without
    a comparator function, any call to the returned function must iterate
    through the entire list of possible values until it finds a match or
    reaches the end of the list. Therefore, the worst-case time complexity
-   of the returned function is necessarily **linear**, and failed lookups
-   will always be worst-case.
+   of the returned function is **linear**, and failed lookups will always
+   be worst-case.
 
-   See {!val:inverseMapToOrd} for a similar function that accepts a
-   comparator for [a], and returns a reverse-lookup function with a
-   worst-case running time of O(log(n)).
+   See {!val:inverseMapOrd} or {!val: inverseMapOrdBy} for a similar function
+   that accepts a comparator for [a], and returns a reverse-lookup function
+   with a worst-case running time of O(log(n)).
 
    Running time for staging: O(n)
    Running time of the returned lookup function: O(n)
    */
-  let inverseMap: (E.t => 'a, 'a) => option(E.t) =
-    map => {
+  let inverseMapEqBy: type a. ((a, a) => bool, E.t => a, a) => option(E.t) =
+    (eqA, eToA) => {
       let rec loop = (lst, maybeE, getNextE) => {
         switch (maybeE) {
         | None =>
@@ -62,7 +63,7 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
             let rec find = (arr, i, limit) =>
               if (i < limit) {
                 let (e__, a__) = Belt.Array.getUnsafe(arr, i);
-                if (a__ === a) {
+                if (eqA(a__, a)) {
                   Some(e__);
                 } else {
                   find(arr, succ(i), limit);
@@ -75,7 +76,7 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
           return;
         | Some(e) =>
           // Continue building the associative list:
-          loop([(e, map(e)), ...lst], getNextE(e), getNextE)
+          loop([(e, eToA(e)), ...lst], getNextE(e), getNextE)
         };
       };
 
@@ -84,31 +85,60 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
     };
 
   /**
-   [BoundedEnum.inverseMapWithComparator] takes a [~compare] function of
+   [BoundedEnumExtensions.inverseMapEq] takes a first-class [EQ] module for
+   type [a], along with a function of type [t => a] where each [a] is a
+   unique value, and returns a new function of type [a => option(t)].
+
+   This is useful for generating parser utilities, reverse-lookup functions,
+   etc.
+
+   Note: since there is no way to determine the ordering of [a] without
+   a comparator function, any call to the returned function must iterate
+   through the entire list of possible values until it finds a match or
+   reaches the end of the list. Therefore, the worst-case time complexity
+   of the returned function is **linear**, and failed lookups will always
+   be worst-case.
+
+   See {!val:inverseMapToOrd} for a similar function that accepts a
+   comparator for [a], and returns a reverse-lookup function with a
+   worst-case running time of O(log(n)).
+
+   Running time for staging: O(n)
+   Running time of the returned lookup function: O(n)
+   */
+  let inverseMapEq:
+    type a.
+      (~eqA: (module BsBastet.Interface.EQ with type t = a), E.t => a, a) =>
+      option(E.t) =
+    (~eqA, eToA) => {
+      let (module EqA) = (eqA: (module BsBastet.Interface.EQ with type t = a));
+      inverseMapEqBy(EqA.eq, eToA);
+    };
+
+  /**
+   [BoundedEnumExtensions.inverseMapOrdBy] takes a comparator function of
    type [(a, a) => Relude.Ordering.t], along with a mapping function of type
    [t => a], where each [a] is a unique value, and returns a new function
    of type [a => option(t)].
 
-   It works similarly to `inverseMap`, but uses a comparator function for
-   the ordered type [a]. This enables the use of an internal Map structure
-   for O(log(n)) lookups. This might yield a slightly higher constant
-   factor, but scales favorably for large enums.
+   [inverseMapOrdBy] performs the same operations as [inverseMapOrd], but
+   it accepts a comparator function for [a], instead of a first-class
+   [Ord] module.
 
    Running time for staging: O(n)
    Running time for returned lookup function: O(log(n))
    */
-  let inverseMapWithComparator:
+  let inverseMapOrdBy:
     type a.
-      (~compare: (a, a) => BsBastet.Interface.ordering, E.t => a, a) =>
-      option(E.t) =
-    (~compare, map) => {
+      ((a, a) => BsBastet.Interface.ordering, E.t => a, a) => option(E.t) =
+    (cmp, eToA) => {
       // Generate the Map data structure:
-      let (module M_) = (
+      let (module M) = (
         (module
          Map.Make({
            type t = a;
            let compare = (a, b) =>
-             switch (compare(a, b)) {
+             switch (cmp(a, b)) {
              | `equal_to => 0
              | `less_than => (-1)
              | `greater_than => 1
@@ -117,19 +147,65 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
       );
 
       /**
-       * Produce an 'a' value for each 'enum' value that exists,
-       * then insert each of them into the Map.
-       * */
-      let rec loop = (insert, store, current) => {
+       Produce an 'a' value for each 'enum' value that exists,
+       then insert each of them into the Map.
+       */
+      let rec loop = (store, current) => {
         switch (current) {
-        | None => M_.find_opt(_, store)
+        | None => M.find_opt(_, store)
         | Some(e) =>
-          let a = map(e);
-          let st = insert(a, e, store);
-          loop(insert, st, E.succ(e));
+          let a = eToA(e);
+          let st = M.add(a, e, store);
+          loop(st, E.succ(e));
         };
       };
 
-      loop(M_.add, M_.empty, Some(E.bottom));
+      loop(M.empty, Some(E.bottom));
+    };
+
+  /**
+   [BoundedEnumExtensions.inverseMapOrd] takes a first-class [ORD] module
+   for type [a], along with a function of type [t => a] where each [a] is
+   a unique value, and returns a new function of type [a => option(t)].
+
+   This is useful for generating parser utilities, reverse-lookup functions,
+   etc.
+
+   Running time for staging: O(n)
+   Running time for returned lookup function: O(log(n))
+   */
+  let inverseMapOrd:
+    type a.
+      (~ordA: (module BsBastet.Interface.ORD with type t = a), E.t => a, a) =>
+      option(E.t) =
+    (~ordA, eToA) => {
+      let (module OrdA) = (
+        ordA: (module BsBastet.Interface.ORD with type t = a)
+      );
+      inverseMapOrdBy(OrdA.compare, eToA);
+    };
+
+  /**
+   [BoundedEnumExtensions.inverseMapString] is specialized version of
+   [inverseMapOrd] that is optimized for [string] types. It takes function
+   of type [t => string], where each value of [t] maps to a unique [string]
+   value. It returns a new function of type [string => option(t)], which inverts
+   that mapping.
+
+   Running time for staging: O(n)
+   Running time for returned lookup function: O(log(n))
+   */
+  let inverseMapString: (E.t => string, string) => option(E.t) =
+    (eToString: E.t => string) => {
+      let strMap = Belt.MutableMap.String.make();
+      let rec loop = (store, maybeE) => {
+        switch (maybeE) {
+        | None => (string => Belt.MutableMap.String.get(store, string))
+        | Some(e) =>
+          Belt.MutableMap.String.set(store, eToString(e), e);
+          loop(store, E.succ(e));
+        };
+      };
+      loop(strMap, Some(E.bottom));
     };
 };

--- a/src/extensions/Relude_Extensions_BoundedEnum.re
+++ b/src/extensions/Relude_Extensions_BoundedEnum.re
@@ -84,8 +84,8 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
     };
 
   /**
-   [BoundedEnum.inverseMapToOrd] takes a [~compare] function of type
-   [(a, a) => Relude.Ordering.t], along with a mapping function of type
+   [BoundedEnum.inverseMapWithComparator] takes a [~compare] function of
+   type [(a, a) => Relude.Ordering.t], along with a mapping function of type
    [t => a], where each [a] is a unique value, and returns a new function
    of type [a => option(t)].
 
@@ -97,7 +97,7 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
    Running time for staging: O(n)
    Running time for returned lookup function: O(log(n))
    */
-  let inverseMapToOrd:
+  let inverseMapWithComparator:
     type a.
       (~compare: (a, a) => BsBastet.Interface.ordering, E.t => a, a) =>
       option(E.t) =

--- a/src/extensions/Relude_Extensions_BoundedEnum.re
+++ b/src/extensions/Relude_Extensions_BoundedEnum.re
@@ -2,6 +2,9 @@ let listAppend = (value, list) => List.concat([list, [value]]);
 //let arrayAppend = (value, array) => Array.concat([array, [|value|]]);
 
 module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
+
+  include Relude_Extensions_Enum.EnumExtensions(E);
+
   /**
   Generates a list of enum values starting at [~start], then going to [~next],
   then using that step size to generate the rest of the list.

--- a/src/extensions/Relude_Extensions_BoundedEnum.re
+++ b/src/extensions/Relude_Extensions_BoundedEnum.re
@@ -17,7 +17,10 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
         | `equal_to => listAppend(current, acc)
         | `less_than
         | `greater_than =>
-          // Since step can be positive or negative, we handle less_than and greater_than the same way by just adding the step
+        /**
+        Since step can be positive or negative, we handle less_than
+        and greater_than the same way by just adding the step
+        */
           let nextInt = currentInt + stepInt;
           switch (E.toEnum(nextInt)) {
           | Some(next) => go(listAppend(current, acc), next, nextInt)
@@ -29,7 +32,7 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
     };
 
   /**
-   [BoundedEnumExtensions.inverseMapEqBy] takes a equality function of type
+   [BoundedEnumExtensions.inverseMapEqBy] takes an equality function of type
    [(a, a) => bool] along with a function of type [t => a], where each [a]
    is a unique value, and returns a new function of type [a => option(t)].
 
@@ -59,7 +62,7 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
           // generate the closure to pass back to the caller:
           let arr = Belt.List.toArray(lst);
           let len = Belt.Array.length(arr);
-          let return = a => {
+          let result = a => {
             let rec find = (arr, i, limit) =>
               if (i < limit) {
                 let (e__, a__) = Belt.Array.getUnsafe(arr, i);
@@ -73,7 +76,7 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
               };
             find(arr, 0, len);
           };
-          return;
+          result;
         | Some(e) =>
           // Continue building the associative list:
           loop([(e, eToA(e)), ...lst], getNextE(e), getNextE)


### PR DESCRIPTION
This PR adds two functions based on [inverseMap](https://hackage.haskell.org/package/relude-0.6.0.0/docs/Relude-Extra-Enum.html#v:inverseMap) from Haskell's `relude` library.

The idea is, given an ordered bounded enum `t` and a function that maps each `t` value to a unique `a` value, we can derive the inverse mapping function from that particular set of `a` values to their corresponding `t` values. Obviously, we can't account for *all* `a` values, so `inverseMap` must return `option(t)`.

This is particularly nice if you already have a `show` function, and want to generate the inverse function to parse strings to that data type.

Note:

Functions generated using `inverseMap` will never be as efficient as their hand-written counterparts. This is because they need to perform dynamic lookups to get a return value. Even worse, the inverse of `t => a` has O(n) worst-case time complexity if we don't have a comparator function for `a` (we are forced to use an associated list/array for lookups). Therefore, I made a second function, `inverseMapWithComparator`, which takes a `compare` function for `a` and uses a `Map.t(a, t)` for the internal lookup table, which should be roughly O(log(n)).

I also included some tests for these functions.