### PR TITLE
Add Result Extraction Helpers

### DIFF
--- a/__tests__/Relude_Result_test.re
+++ b/__tests__/Relude_Result_test.re
@@ -191,6 +191,14 @@ describe("Result", () => {
     |> toEqual("error")
   );
 
+  test("getOrElseBy Ok", () =>
+    expect(Result.ok(42) |> Result.getOrElseBy(_ => 5)) |> toEqual(42)
+  );
+
+  test("getOrElseBy Error", () =>
+    expect(Result.error(42) |> Result.getOrElseBy(x => x / 7)) |> toEqual(6)
+  );
+
   test("getOrElse Ok", () =>
     expect(Result.ok(42) |> Result.getOrElse(5)) |> toEqual(42)
   );

--- a/__tests__/Relude_Result_test.re
+++ b/__tests__/Relude_Result_test.re
@@ -223,6 +223,17 @@ describe("Result", () => {
   test("getErrorOrElse Error", () =>
     expect(Result.error(42) |> Result.getErrorOrElse(5)) |> toEqual(42)
   );
+
+  test("getErrorOrElseBy Ok", () =>
+    expect(Result.ok(42) |> Result.getErrorOrElseBy(x => x / 7))
+    |> toEqual(6)
+  );
+
+  test("getErrorOrElseBy Error", () =>
+    expect(Result.error(42) |> Result.getErrorOrElseBy(x => x / 7))
+    |> toEqual(42)
+  );
+
   test("merge Error", () =>
     expect(Result.merge(Error(1))) |> toEqual(1)
   );

--- a/__tests__/Relude_Result_test.re
+++ b/__tests__/Relude_Result_test.re
@@ -216,6 +216,13 @@ describe("Result", () => {
     |> toEqual(5)
   );
 
+  test("getErrorOrElse Ok", () =>
+    expect(Result.ok(42) |> Result.getErrorOrElse(5)) |> toEqual(5)
+  );
+
+  test("getErrorOrElse Error", () =>
+    expect(Result.error(42) |> Result.getErrorOrElse(5)) |> toEqual(42)
+  );
   test("merge Error", () =>
     expect(Result.merge(Error(1))) |> toEqual(1)
   );

--- a/src/Relude_Result.re
+++ b/src/Relude_Result.re
@@ -215,6 +215,34 @@ let getErrorOrElse: 'e 'e. ('e, t('a, 'e)) => 'e =
     | Ok(_) => default 
     | Error(e) => e
     };
+
+/**
+[Result.getErrorOrElse] attempts to get the [Error] value out of a [result]. If
+the result is an [Ok], the provided default value is returned instead. It's 
+similar to {!val:getOrElse}, but better suited when conceptually, it's the 
+error flow you want to handle.
+
+{[
+  // Imagine a part of your application that is only interested in error logging
+  // It receives an error and logs it if it is one. If not, it logs 
+  // that it's handled, but includes the request id.
+  type response('a) = Result(String, {id: string, payload: 'a})
+  let handleResErr = res => "Handled: " ++ id;
+
+  Result.getErrorOrElse(handleResErr, Err("Not Found")) 
+    == "Not Found";
+
+  Result.getErrorOrElse(handleResErr, Ok({id: 1, payload: "foo"})) 
+    == "Handled: 1";
+]}
+*/
+let getErrorOrElseBy: 'e 'e. ('a => 'e, t('a, 'e)) => 'e =
+  (fn, fa) =>
+    switch (fa) {
+    | Ok(a) => fn(a) 
+    | Error(e) => e
+    };
+
 /**
 [Result.merge] returns the inner value from the [result]. This requires both the
 [Ok] and [Error] channels to hold the same type of value.

--- a/src/Relude_Result.re
+++ b/src/Relude_Result.re
@@ -209,7 +209,7 @@ error flow you want to handle.
   Result.getErrorOrElse("Handled", Ok({id, payload})) == "Handled";
 ]}
 */
-let getErrorOrElse: 'e 'e. ('e, t('a, 'e)) => 'e =
+let getErrorOrElse: 'a 'e. ('e, t('a, 'e)) => 'e =
   (default, fa) =>
     switch (fa) {
     | Ok(_) => default 
@@ -237,7 +237,7 @@ suited when conceptually, it's the error flow you want to handle.
     == "Handled: 1";
 ]}
 */
-let getErrorOrElseBy: 'e 'e. ('a => 'e, t('a, 'e)) => 'e =
+let getErrorOrElseBy: 'a 'e. ('a => 'e, t('a, 'e)) => 'e =
   (fn, fa) =>
     switch (fa) {
     | Ok(a) => fn(a) 

--- a/src/Relude_Result.re
+++ b/src/Relude_Result.re
@@ -194,6 +194,28 @@ let getOrElseLazy: 'a 'e. (unit => 'a, t('a, 'e)) => 'a =
     };
 
 /**
+[Result.getErrorOrElse] attempts to get the [Error] value out of a [result]. If
+the result is an [Ok], the provided default value is returned instead. It's 
+similar to {!val:getOrElse}, but better suited when conceptually, it's the 
+error flow you want to handle.
+
+{[
+  // Imagine a part of your application that is only interested in error logging
+  // It receives an error and logs it if it is one. If not, it logs 
+  // that it's handled.
+  type response('a) = Result(String, {id: string, payload: 'a})
+
+  Result.getErrorOrElse("Handled", Err("Not Found")) == "Not Found";
+  Result.getErrorOrElse("Handled", Ok({id, payload})) == "Handled";
+]}
+*/
+let getErrorOrElse: 'e 'e. ('e, t('a, 'e)) => 'e =
+  (default, fa) =>
+    switch (fa) {
+    | Ok(_) => default 
+    | Error(e) => e
+    };
+/**
 [Result.merge] returns the inner value from the [result]. This requires both the
 [Ok] and [Error] channels to hold the same type of value.
 

--- a/src/Relude_Result.re
+++ b/src/Relude_Result.re
@@ -217,15 +217,16 @@ let getErrorOrElse: 'e 'e. ('e, t('a, 'e)) => 'e =
     };
 
 /**
-[Result.getErrorOrElse] attempts to get the [Error] value out of a [result]. If
-the result is an [Ok], the provided default value is returned instead. It's 
-similar to {!val:getOrElse}, but better suited when conceptually, it's the 
-error flow you want to handle.
+[Result.getErrorOrElseBy] attempts to get the [Error] value out of a [result]. 
+If the result is an [Ok], the provided default fn is apply to the error, and 
+the result is returned instead. It's similar to {!val:getOrElseBy}, but better 
+suited when conceptually, it's the error flow you want to handle.
 
 {[
-  // Imagine a part of your application that is only interested in error logging
-  // It receives an error and logs it if it is one. If not, it logs 
-  // that it's handled, but includes the request id.
+  // Imagine a part of your application that is only interested in error 
+  // logging. It receives a [Result] and logs it the error. If it isn't an 
+  // error, it logs that it's handled, but include the request id.
+
   type response('a) = Result(String, {id: string, payload: 'a})
   let handleResErr = res => "Handled: " ++ id;
 


### PR DESCRIPTION
As discussed in: https://github.com/reazen/relude/issues/285

This PR adds the following three functions:

```reason
getOrElseBy: ('e => 'a, result('a, 'e)) => 'a
getErrorOrElse: ('e, result('a, 'e)) => 'e)
getErrorOrElseBy: ('a => 'e, result('a, 'e)) => 'e
```

Since these are a bit niche, the examples are a bit niche as well. Given the rest of the examples they might be a bit verbose. Please let me know if that's the case, then I'll try and make it less so.

The PR can be reviewed commit-by-commit.