### PR TITLE
sanitize bsconfig.json and package.json before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cleanwatch": "npm run clean && npm run watch",
     "cleantest": "npm run cleanbuild && npm run test",
     "cleancoverage": "npm run cleanbisect && BISECT_ENABLE=yes npm run cleanbuild && npm run coverage",
+    "prepack": "node scripts/prepack.js",
     "releasebuild": "npm run cleancoverage"
   },
   "keywords": [

--- a/scripts/prepack.js
+++ b/scripts/prepack.js
@@ -1,0 +1,38 @@
+const fs = require("fs");
+const path = require("path");
+const pkg = require("../package.json");
+const bsConfig = require("../bsconfig.json");
+
+const bsConfigWriter = json => {
+  const bsConfigPath = path.join(__dirname, "..", "bsconfig.json");
+  fs.writeFileSync(bsConfigPath, JSON.stringify(json, null, 2));
+};
+
+const packageWriter = json => {
+  const packagePath = path.join(__dirname, "..", "package.json");
+  fs.writeFileSync(packagePath, JSON.stringify(json, null, 2));
+}
+
+const dependenciesNotNeededForPkg = ["bisect_ppx"];
+const hasToBeRemoved = (dep) => !dependenciesNotNeededForPkg.includes(dep)
+
+const filteredDependencies = Object.entries(pkg.dependencies).filter(
+  ([dep]) => hasToBeRemoved(dep)
+);
+
+const newPkg = {
+  ...pkg,
+  dependencies: Object.fromEntries(filteredDependencies)
+};
+
+packageWriter(newPkg)
+
+const bsDependencies = bsConfig["bs-dependencies"].filter(hasToBeRemoved);
+
+const { ["ppx-flags"]: _, ...rest } = bsConfig;
+const newBsConfig = {
+  ...rest,
+  "bs-dependencies": bsDependencies
+};
+
+bsConfigWriter(newBsConfig)


### PR DESCRIPTION
Hey,
This is an attempt to fix #267  by removing `bisect_ppx`  from the published package outputs are

```json
{
  "name": "relude",
  "description": "Alternative standard library (prelude) for ReasonML",
  "homepage": "https://github.com/reazen/relude",
  "bugs": "https://github.com/reazen/relude/issues",
  "version": "0.65.0",
  "repository": {
    "type": "git",
    "url": "https://github.com/reazen/relude.git"
  },
  "scripts": {
    "clean": "bsb -clean-world",
    "build": "bsb -make-world",
    "watch": "bsb -make-world -w",
    "test": "jest",
    "coverage": "npm run test",
    "docs": "docsify serve ./docs",
    "cleanbisect": "rm bisect*.coverage || true",
    "cleanbuild": "npm run clean && npm run build",
    "cleanwatch": "npm run clean && npm run watch",
    "cleantest": "npm run cleanbuild && npm run test",
    "cleancoverage": "npm run cleanbisect && BISECT_ENABLE=yes npm run cleanbuild && npm run coverage",
    "prepack": "node scripts/prepack.js",
    "releasebuild": "npm run cleancoverage"
  },
  "keywords": [
    "ReasonML",
    "BuckleScript",
    "Utility",
    "Prelude",
    "Standard Library"
  ],
  "author": "",
  "license": "MIT",
  "devDependencies": {
    "@glennsl/bs-jest": "^0.5.1",
    "bs-bastet": "^1.2.5",
    "bs-platform": "^7.2.2",
    "docsify-cli": "~4.4.0"
  },
  "peerDependencies": {
    "bs-bastet": "^1.2.5",
    "bs-platform": "^7.2.2"
  },
  "dependencies": {},
  "jest": {
    "verbose": false,
    "testPathIgnorePatterns": [
      "/node_modules/",
      "/testUtils/"
    ],
    "setupFilesAfterEnv": [
      "bisect_ppx/lib/js/src/runtime/bucklescript/jest.js"
    ]
  }
}
```
and 
```json
{
  "name": "relude",
  "bsc-flags": [
    "-bs-no-version-header",
    "-bs-super-errors"
  ],
  "version": "0.1.0",
  "sources": [
    {
      "dir": "src",
      "subdirs": true
    },
    {
      "dir": "__tests__",
      "subdirs": true,
      "type": "dev"
    }
  ],
  "package-specs": {
    "module": "commonjs",
    "in-source": false
  },
  "suffix": ".bs.js",
  "bs-dependencies": [
    "bs-bastet"
  ],
  "bs-dev-dependencies": [
    "@glennsl/bs-jest"
  ],
  "warnings": {
    "number": "+A-4-40-42",
    "error": "+A"
  },
  "namespace": false,
  "refmt": 3
}
```
