### PR TITLE
Add tuple functions first, second etc (a la haskells fst, snd)

### DIFF
--- a/__tests__/Relude_Tuple_test.re
+++ b/__tests__/Relude_Tuple_test.re
@@ -158,6 +158,72 @@ describe("Tuple apply", () => {
   );
 });
 
+describe("Tuple first", () => {
+  test("first2", () => {
+    expect(Tuple.first2((42, "hi"))) |> toEqual(42)
+  });
+
+  test("first3", () => {
+    expect(Tuple.first3((42, "hi", true))) |> toEqual(42)
+  });
+
+  test("first4", () => {
+    expect(Tuple.first4((42, "hi", true, ()))) |> toEqual(42)
+  });
+
+  test("first5", () => {
+    expect(Tuple.first5((42, "hi", true, (), 99.9))) |> toEqual(42)
+  });
+});
+
+describe("Tuple second", () => {
+  test("second2", () => {
+    expect(Tuple.second2((42, "hi"))) |> toEqual("hi")
+  });
+
+  test("second3", () => {
+    expect(Tuple.second3((42, "hi", true))) |> toEqual("hi")
+  });
+
+  test("second4", () => {
+    expect(Tuple.second4((42, "hi", true, ()))) |> toEqual("hi")
+  });
+
+  test("second5", () => {
+    expect(Tuple.second5((42, "hi", true, (), 99.9))) |> toEqual("hi")
+  });
+});
+
+describe("Tuple third", () => {
+  test("third3", () => {
+    expect(Tuple.third3((42, "hi", true))) |> toEqual(true)
+  });
+
+  test("third4", () => {
+    expect(Tuple.third4((42, "hi", true, ()))) |> toEqual(true)
+  });
+
+  test("third5", () => {
+    expect(Tuple.third5((42, "hi", true, (), 99.9))) |> toEqual(true)
+  });
+});
+
+describe("Tuple fourth", () => {
+  test("fourth4", () => {
+    expect(Tuple.fourth4((42, "hi", true, ()))) |> toEqual()
+  });
+
+  test("fourth5", () => {
+    expect(Tuple.fourth5((42, "hi", true, (), 99.9))) |> toEqual()
+  });
+});
+
+describe("Tuple fifth", () => {
+  test("fifth5", () => {
+    expect(Tuple.fifth5((42, "hi", true, (), 99.9))) |> toEqual(99.9)
+  })
+});
+
 describe("Tuple showBy", () => {
   test("showBy2", () => {
     expect(Tuple.showBy2(Int.show, String.show, (42, "hi")))

--- a/src/Relude_Tuple.re
+++ b/src/Relude_Tuple.re
@@ -45,6 +45,30 @@ let apply3 = Relude_Function.uncurry3;
 let apply4 = Relude_Function.uncurry4;
 let apply5 = Relude_Function.uncurry5;
 
+let first = Tuple2.first;
+let first2 = Tuple2.first;
+let first3 = Tuple3.first;
+let first4 = Tuple4.first;
+let first5 = Tuple5.first;
+
+let second = Tuple2.second;
+let second2 = Tuple2.second;
+let second3 = Tuple3.second;
+let second4 = Tuple4.second;
+let second5 = Tuple5.second;
+
+let third = Tuple3.third;
+let third3 = Tuple3.third;
+let third4 = Tuple4.third;
+let third5 = Tuple5.third;
+
+let fourth = Tuple4.fourth;
+let fourth4 = Tuple4.fourth;
+let fourth5 = Tuple5.fourth;
+
+let fifth = Tuple5.fifth;
+let fifth5 = Tuple5.fifth;
+
 let showBy = Tuple2.showBy;
 let showBy2 = Tuple2.showBy;
 let showBy3 = Tuple3.showBy;

--- a/src/Relude_Tuple2.re
+++ b/src/Relude_Tuple2.re
@@ -32,6 +32,16 @@ let fromListAtLeast: 'a. list('a) => option(('a, 'a)) =
   xs => Relude_List.take(2, xs) |> fromList;
 
 /**
+Gets the first value of a tuple-2
+*/
+let first: 'a 'b. (('a, 'b)) => 'a = ((a, _b)) => a;
+
+/**
+Gets the second value of a tuple-2
+*/
+let second: 'a 'b. (('a, 'b)) => 'b = ((_a, b)) => b;
+
+/**
 Shows a tuple ('a, 'b) using show functions for 'a and 'b
 */
 let showBy: 'a 'b. ('a => string, 'b => string, ('a, 'b)) => string =

--- a/src/Relude_Tuple3.re
+++ b/src/Relude_Tuple3.re
@@ -31,6 +31,21 @@ Constructs a tuple-3 from a list of at least 3 values
 let fromListAtLeast: 'a. list('a) => option(('a, 'a, 'a)) =
   xs => Relude_List.take(3, xs) |> fromList;
 
+/**
+Gets the first value of a tuple-3
+*/
+let first: 'a 'b 'c. (('a, 'b, 'c)) => 'a = ((a, _b, _c)) => a;
+
+/**
+Gets the second value of a tuple-3
+*/
+let second: 'a 'b 'c. (('a, 'b, 'c)) => 'b = ((_a, b, _c)) => b;
+
+/**
+Gets the third value of a tuple-3
+*/
+let third: 'a 'b 'c. (('a, 'b, 'c)) => 'c = ((_a, _b, c)) => c;
+
 let showBy:
   'a 'b 'c.
   ('a => string, 'b => string, 'c => string, ('a, 'b, 'c)) => string

--- a/src/Relude_Tuple4.re
+++ b/src/Relude_Tuple4.re
@@ -32,6 +32,26 @@ Constructs a tuple-4 from a list of at least 4 values
 let fromListAtLeast: 'a. list('a) => option(('a, 'a, 'a, 'a)) =
   xs => Relude_List.take(4, xs) |> fromList;
 
+/**
+Gets the first value of a tuple-4
+*/
+let first: 'a 'b 'c 'd. (('a, 'b, 'c, 'd)) => 'a = ((a, _b, _c, _d)) => a;
+
+/**
+Gets the second value of a tuple-4
+*/
+let second: 'a 'b 'c 'd. (('a, 'b, 'c, 'd)) => 'b = ((_a, b, _c, _d)) => b;
+
+/**
+Gets the third value of a tuple-4
+*/
+let third: 'a 'b 'c 'd. (('a, 'b, 'c, 'd)) => 'c = ((_a, _b, c, _d)) => c;
+
+/**
+Gets the fourth value of a tuple-4
+*/
+let fourth: 'a 'b 'c 'd. (('a, 'b, 'c, 'd)) => 'd = ((_a, _b, _c, d)) => d;
+
 let showBy:
   'a 'b 'c 'd.
   (

--- a/src/Relude_Tuple5.re
+++ b/src/Relude_Tuple5.re
@@ -41,6 +41,36 @@ let apply:
  =
   (f, (a, b, c, d, e)) => f(a, b, c, d, e);
 
+/**
+Gets the first value of a tuple-5
+*/
+let first: 'a 'b 'c 'd 'e. (('a, 'b, 'c, 'd, 'e)) => 'a =
+  ((a, _b, _c, _d, _e)) => a;
+
+/**
+Gets the second value of a tuple-5
+*/
+let second: 'a 'b 'c 'd 'e. (('a, 'b, 'c, 'd, 'e)) => 'b =
+  ((_a, b, _c, _d, _e)) => b;
+
+/**
+Gets the third value of a tuple-5
+*/
+let third: 'a 'b 'c 'd 'e. (('a, 'b, 'c, 'd, 'e)) => 'c =
+  ((_a, _b, c, _d, _e)) => c;
+
+/**
+Gets the fourth value of a tuple-5
+*/
+let fourth: 'a 'b 'c 'd 'e. (('a, 'b, 'c, 'd, 'e)) => 'd =
+  ((_a, _b, _c, d, _e)) => d;
+
+/**
+Gets the fifth value of a tuple-5
+*/
+let fifth: 'a 'b 'c 'd 'e. (('a, 'b, 'c, 'd, 'e)) => 'e =
+  ((_a, _b, _c, _d, e)) => e;
+
 let showBy:
   'a 'b 'c 'd 'e.
   (


### PR DESCRIPTION
After seeing an issue was already made, there are `fst` and `snd` for pairs/tuple-2s, but that's it. 

I added `first`, `second`, `third`, `fourth`, and `fifth` to the appropriate tuple files, as well as tests for all of them. 

I can make `Tuple2.first` and `Tuple2.second` aliases to `fst` and `snd` if preferred. 