### PR TITLE
Add type defs to internal Comparable module in Map/Set

### DIFF
--- a/src/Relude_Map.re
+++ b/src/Relude_Map.re
@@ -416,7 +416,9 @@ module type MAP = {
   let groupArrayBy: ('a => key, array('a)) => t(array('a));
 };
 
-module WithOrd = (M: ORD) : (MAP with type key = M.t) => {
+module WithOrd =
+       (M: ORD)
+       : (MAP with type key = M.t and type Comparable.t = M.t) => {
   type key = M.t;
 
   module Comparable =

--- a/src/Relude_Set.re
+++ b/src/Relude_Set.re
@@ -334,7 +334,9 @@ module type SET = {
   let split: (value, t) => ((t, t), bool);
 };
 
-module WithOrd = (M: BsBastet.Interface.ORD) : (SET with type value = M.t) => {
+module WithOrd =
+       (M: BsBastet.Interface.ORD)
+       : (SET with type value = M.t and type Comparable.t = M.t) => {
   type value = M.t;
 
   module Comparable =


### PR DESCRIPTION
When using maps and sets, the type definition for the internal comparable is obfuscated so it cannot be used in any other context (even if the types should line up). For example, if you try to use the key of a `String.Map` as a string you will get a type error.

Adding the type defs to the module definition is a simple fix that will allow this functionality.