### PR TITLE
Add `singleton` to Set

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "ocaml.sandbox": {
+    "kind": "custom",
+    "template": "esy $prog $args --fallback-read-dot-merlin"
+  }
+}

--- a/__tests__/Relude_Set_test.re
+++ b/__tests__/Relude_Set_test.re
@@ -1,0 +1,86 @@
+open Jest;
+open Expect;
+
+module IntSet = Relude_Set.WithOrd(Relude_Int.Ord);
+
+describe("Set", () => {
+  test("length of empty set", () =>
+    expect(IntSet.(empty |> length)) |> toEqual(0)
+  );
+
+  test("length of non-empty set", () =>
+    expect(IntSet.(singleton(1) |> length)) |> toEqual(1)
+  );
+
+  test("isEmpty (empty set)", () =>
+    expect(IntSet.(empty |> isEmpty)) |> toEqual(true)
+  );
+
+  test("isEmpty (nonempty set)", () =>
+    expect(IntSet.(singleton(1) |> isEmpty)) |> toEqual(false)
+  );
+
+  test("fromArray (empty)", () =>
+    expect(IntSet.fromArray([||])) |> toEqual(IntSet.empty)
+  );
+
+  test("fromArray (nonEmpty, unique)", () =>
+    expect(IntSet.(fromArray([|1, 2, 3|]) |> length)) |> toEqual(3)
+  );
+
+  test("fromArray (nonEmpty, removes duplicates)", () =>
+    expect(IntSet.(fromArray([|1, 2, 1|]) |> length)) |> toEqual(2)
+  );
+
+  test("fromList (empty)", () =>
+    expect(IntSet.fromList([])) |> toEqual(IntSet.empty)
+  );
+
+  test("fromList (nonEmpty)", () =>
+    expect(IntSet.(fromList([4, 4, 4, 4, 3]) |> length)) |> toEqual(2)
+  );
+
+  test("contains (false)", () =>
+    expect(IntSet.(fromList([1, 3, 3, 4]) |> contains(5)))
+    |> toEqual(false)
+  );
+
+  test("contains (true)", () =>
+    expect(IntSet.(fromList([1, 3, 3, 4]) |> contains(3))) |> toEqual(true)
+  );
+
+  test("add (new unique value)", () =>
+    expect(IntSet.(fromList([1, 2]) |> add(3)))
+    |> toEqual(IntSet.fromList([1, 2, 3]))
+  );
+
+  test("add (duplicate value)", () =>
+    expect(IntSet.(fromList([1, 2]) |> add(1)))
+    |> toEqual(IntSet.fromList([1, 2]))
+  );
+
+  test("mergeMany (empty array to merge)", () =>
+    expect(IntSet.(singleton(1) |> mergeMany([||])))
+    |> toEqual(IntSet.fromList([1]))
+  );
+
+  test("mergeMany (all unique)", () =>
+    expect(
+      IntSet.(
+        singleton(1) |> mergeMany([|2, 3|]) |> eq(fromList([1, 2, 3]))
+      ),
+    )
+    |> toEqual(true)
+  );
+
+  test("mergeMany (some duplicates)", () =>
+    expect(
+      IntSet.(
+        fromList([1, 2, 3])
+        |> mergeMany([|2, 3, 4|])
+        |> eq(fromList([1, 2, 3, 4]))
+      ),
+    )
+    |> toEqual(true)
+  );
+});

--- a/esy.json
+++ b/esy.json
@@ -5,10 +5,12 @@
     "melange": "melange-re/melange#53a354a69172629033ce63d2d8eb9d8ea7ad1cdc"
   },
   "devDependencies": {
-    "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#c275140"
+    "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#c275140",
+    "@opam/dot-merlin-reader": "4.2"
   },
   "resolutions": {
-    "@opam/reason": "reasonml/reason:reason.opam#4f6ff7616bfa699059d642a3d16d8905d83555f6"
+    "@opam/reason": "reasonml/reason:reason.opam#4f6ff7616bfa699059d642a3d16d8905d83555f6",
+    "@opam/ocamlfind": "1.9.3"
   },
   "esy": {
     "buildsInSource": "unsafe",

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "8fd5122d1f55ac72df73118508174d42",
+  "checksum": "72dc56b3fa7da723bd926a844ae13c57",
   "root": "relude@link-dev:./esy.json",
   "node": {
     "relude@link-dev:./esy.json": {
@@ -14,7 +14,8 @@
         "@opam/dune@opam:3.1.0@4993f3c0"
       ],
       "devDependencies": [
-        "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#c275140@d41d8cd9"
+        "@opam/ocaml-lsp-server@github:ocaml/ocaml-lsp:ocaml-lsp-server.opam#c275140@d41d8cd9",
+        "@opam/dot-merlin-reader@opam:4.2@1605899e"
       ],
       "installConfig": { "pnp": false }
     },
@@ -876,6 +877,35 @@
       "devDependencies": [
         "ocaml@4.14.0@d41d8cd9", "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084"
+      ]
+    },
+    "@opam/dot-merlin-reader@opam:4.2@1605899e": {
+      "id": "@opam/dot-merlin-reader@opam:4.2@1605899e",
+      "name": "@opam/dot-merlin-reader",
+      "version": "opam:4.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/31/31587b422b5ebd3eebda730e946868807d829128f8dc7153fb05c0c82742058e#sha256:31587b422b5ebd3eebda730e946868807d829128f8dc7153fb05c0c82742058e",
+          "archive:https://github.com/ocaml/merlin/releases/download/v4.5-414/merlin-4.5-414.tbz#sha256:31587b422b5ebd3eebda730e946868807d829128f8dc7153fb05c0c82742058e"
+        ],
+        "opam": {
+          "name": "dot-merlin-reader",
+          "version": "4.2",
+          "path": "esy.lock/opam/dot-merlin-reader.4.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.14.0@d41d8cd9", "@opam/yojson@opam:2.0.0@ce9e86eb",
+        "@opam/ocamlfind@opam:1.9.3@781b30f3",
+        "@opam/dune@opam:3.1.0@4993f3c0", "@opam/csexp@opam:1.5.1@8a8fb3a7",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.14.0@d41d8cd9", "@opam/yojson@opam:2.0.0@ce9e86eb",
+        "@opam/ocamlfind@opam:1.9.3@781b30f3",
+        "@opam/dune@opam:3.1.0@4993f3c0", "@opam/csexp@opam:1.5.1@8a8fb3a7"
       ]
     },
     "@opam/csexp@opam:1.5.1@8a8fb3a7": {

--- a/esy.lock/opam/dot-merlin-reader.4.2/opam
+++ b/esy.lock/opam/dot-merlin-reader.4.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9.0"}
+  "yojson" {>= "1.6.0"}
+  "ocamlfind" {>= "1.6.0"}
+  "csexp" {>= "1.5.1"}
+]
+description:
+  "Helper process: reads .merlin files and gives the normalized content to merlin"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.5-414/merlin-4.5-414.tbz"
+  checksum: [
+    "sha256=31587b422b5ebd3eebda730e946868807d829128f8dc7153fb05c0c82742058e"
+    "sha512=cc2cf2c208091b3ae435a8124617e56f2002b7091532002ab49a1f817d90a5c4f9cf0bc5741dc7f2526e0352c3ca95b42c3b3a17c6cbfb80ad73d42310a25d22"
+  ]
+}
+x-commit-hash: "cc1582373e5baea1d236a63be39493858032a182"

--- a/src/Relude_Set.re
+++ b/src/Relude_Set.re
@@ -9,6 +9,17 @@ let empty:
   Belt.Set.make(~id=_);
 
 /**
+[Set.singleton] constructs a new set from a single value
+*/
+let singleton:
+  (
+    (module Belt.Id.Comparable with type t = 'value and type identity = 'id),
+    'value
+  ) =>
+  Belt.Set.t('value, 'id) =
+  (id, value) => Belt.Set.make(~id) |> Belt.Set.add(_, value);
+
+/**
 [Set.fromArray] converts an array of values into a new set of those values,
 ordered by the comparator function from the provided [Comparable] module.
 */
@@ -298,6 +309,7 @@ module type SET = {
   type value;
   type t = Belt.Set.t(value, Comparable.identity);
   let empty: t;
+  let singleton: value => t;
   let fromArray: array(value) => t;
   let fromList: list(value) => t;
   let isEmpty: t => bool;
@@ -348,6 +360,7 @@ module WithOrd =
   type nonrec t = t(value, Comparable.identity);
 
   let empty: t = empty((module Comparable));
+  let singleton: value => t = singleton((module Comparable));
   let fromArray: array(value) => t = fromArray((module Comparable));
   let fromList: list(value) => t = fromList((module Comparable));
   let isEmpty: t => bool = isEmpty;


### PR DESCRIPTION
- Fix ocamllsp in vscode, following the instructions here: https://github.com/trite/trite.io-content/blob/main/posts/2022/2022-06-10_melange-ocamllsp-vscode.md
- Add a `singleton` constructor to `Set`. This isn't named `pure` in part to be consistent with `Map`, and in part because `Set` is not a valid `Applicative` because the `map` operation is not guaranteed to preserve the structure
- Add a handful of tests to what was previously an untested module