### PR TITLE
Fix node engine version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Relude
 
-[![GitHub CI](https://img.shields.io/github/workflow/status/reazen/relude/CI/master)](https://github.com/reazen/relude/actions)
+[![GitHub CI](https://img.shields.io/github/workflow/status/reazen/relude/CI/main)](https://github.com/reazen/relude/actions)
 [![npm](https://img.shields.io/npm/v/relude.svg)](https://www.npmjs.com/package/relude)
 [![Coveralls](https://img.shields.io/coveralls/github/reazen/relude.svg)](https://coveralls.io/github/reazen/relude)
 
@@ -68,7 +68,7 @@ The [Reazen](https://github.com/reazen) GitHub organization, and some individual
 
 |GitHub|Build|Package|Description|
 |-------|-----|-------|-----------|
-|[relude](https://github.com/reazen/relude)|[![GitHub CI](https://img.shields.io/github/workflow/status/reazen/relude/CI/master)](https://github.com/reazen/relude/actions)|[![npm](https://img.shields.io/npm/v/relude.svg)](https://www.npmjs.com/package/relude)|ReasonML prelude/standard library|
+|[relude](https://github.com/reazen/relude)|[![GitHub CI](https://img.shields.io/github/workflow/status/reazen/relude/CI/main)](https://github.com/reazen/relude/actions)|[![npm](https://img.shields.io/npm/v/relude.svg)](https://www.npmjs.com/package/relude)|ReasonML prelude/standard library|
 |[relude-csv](https://github.com/reazen/relude-csv)|[![GitHub CI](https://img.shields.io/github/workflow/status/reazen/relude-csv/CI/master)](https://github.com/reazen/relude-csv/actions)|[![npm](https://img.shields.io/npm/v/relude-csv.svg)](https://www.npmjs.com/package/relude-csv)|Pure functional CSV parser library|
 |[relude-eon](https://github.com/reazen/relude-eon)|[![GitHub CI](https://img.shields.io/github/workflow/status/reazen/relude-eon/CI/master)](https://github.com/reazen/relude-eon/actions)|[![npm](https://img.shields.io/npm/v/relude-eon.svg)](https://www.npmjs.com/package/relude-eon)|a native Reason/OCaml date/time library|
 |[relude-fetch](https://github.com/reazen/relude-fetch)|[![GitHub CI](https://img.shields.io/github/workflow/status/reazen/relude-fetch/CI/master)](https://github.com/reazen/relude-fetch/actions)|[![npm](https://img.shields.io/npm/v/relude-fetch.svg)](https://www.npmjs.com/package/relude-fetch)|an interop and utility library for the [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API|

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -7,7 +7,7 @@
 - Typeclasses and extensions
 
 
-[![GitHub CI](https://img.shields.io/github/workflow/status/reazen/relude/CI/master)](https://github.com/reazen/relude/actions)
+[![GitHub CI](https://img.shields.io/github/workflow/status/reazen/relude/CI/main)](https://github.com/reazen/relude/actions)
 [![npm](https://img.shields.io/npm/v/relude.svg)](https://www.npmjs.com/package/relude)
 [![Coveralls](https://img.shields.io/coveralls/github/reazen/relude.svg)](https://coveralls.io/github/reazen/relude)
 

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
   ],
   "author": "",
   "license": "MIT",
-  "engines": {
-    "node": "v16.15.0"
-  },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.7.0",
     "bs-bastet": "^2.0.0",


### PR DESCRIPTION
And by "fix" I mean "remove."

I forget why I added it in the first place, but I think I was just trying to more clearly express the expected node version for CI and local dev. I hadn't realized that setting the `engines` field in `package.json` can actually prevent your package from being installed in cases where the local Node version doesn't match. That's really dumb and not at all what I wanted.