### PR TITLE
chore: stop using internal Relude_* in tests

### DIFF
--- a/__tests__/Relude_Debounce_test.re
+++ b/__tests__/Relude_Debounce_test.re
@@ -1,8 +1,8 @@
 open Jest;
 open Expect;
 
-module Timer = Relude_Timer;
-module Debounce = Relude_Debounce;
+module Timer = Relude.Timer;
+module Debounce = Relude.Debounce;
 
 describe("Debounce", () => {
   test("debounce (leading=false)", () => {

--- a/__tests__/Relude_Free_Applicative_test.re
+++ b/__tests__/Relude_Free_Applicative_test.re
@@ -105,7 +105,7 @@ let validateUser =
   SchemaValidate.foldFree(User.schema);
 };
 
-describe("Relude_Free_Applicative", () => {
+describe("Relude.Free_Applicative", () => {
   test("validateUser success", () =>
     expect(validateUser("Andy", "White", "101"))
     |> toEqual(

--- a/__tests__/Relude_Free_Monad_test.re
+++ b/__tests__/Relude_Free_Monad_test.re
@@ -97,7 +97,7 @@ module StorageAPI = {
   include StorageFWithKeyAndValue.FreeMonad.WithMonad(State.Monad);
 };
 
-describe("Relude_Free_Monad", () => {
+describe("Relude.Free_Monad", () => {
   describe("StorageAPI", () => {
     test("StorageState interpreter", () => {
       // This is our monadic program stored as our free monad

--- a/__tests__/Relude_Function_test.re
+++ b/__tests__/Relude_Function_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 
-module Function = Relude_Function;
+module Function = Relude.Function;
 module StringArgument = {
   type t = string;
   module Type: BsBastet.Interface.TYPE with type t = t = {

--- a/__tests__/Relude_IO_test.re
+++ b/__tests__/Relude_IO_test.re
@@ -169,7 +169,7 @@ describe("IO basics", () => {
     |> IO.unsafeRunAsync(
          fun
          | Ok(ior) =>
-           onDone(expect(ior) |> toEqual(Relude_Ior_Type.Both(42, "a")))
+           onDone(expect(ior) |> toEqual(Relude.Ior_Type.Both(42, "a")))
          | Error(_) => onDone(fail("Fail")),
        )
   );
@@ -179,7 +179,7 @@ describe("IO basics", () => {
     |> IO.unsafeRunAsync(
          fun
          | Ok(ior) =>
-           onDone(expect(ior) |> toEqual(Relude_Ior_Type.This(42)))
+           onDone(expect(ior) |> toEqual(Relude.Ior_Type.This(42)))
          | Error(_) => onDone(fail("Fail")),
        )
   );
@@ -189,7 +189,7 @@ describe("IO basics", () => {
     |> IO.unsafeRunAsync(
          fun
          | Ok(ior) =>
-           onDone(expect(ior) |> toEqual(Relude_Ior_Type.That(99)))
+           onDone(expect(ior) |> toEqual(Relude.Ior_Type.That(99)))
          | Error(_) => onDone(fail("Fail")),
        )
   );
@@ -206,9 +206,9 @@ describe("IO basics", () => {
   testAsync("alignWith pure pure", onDone => {
     let f =
       fun
-      | Relude_Ior_Type.This(a) => a
-      | Relude_Ior_Type.That(b) => int_of_string(b)
-      | Relude_Ior_Type.Both(a, b) => a + int_of_string(b);
+      | Relude.Ior_Type.This(a) => a
+      | Relude.Ior_Type.That(b) => int_of_string(b)
+      | Relude.Ior_Type.Both(a, b) => a + int_of_string(b);
     IO.alignWith(f, IO.pure(42), IO.pure("99"))
     |> IO.unsafeRunAsync(
          fun
@@ -220,9 +220,9 @@ describe("IO basics", () => {
   testAsync("alignWith pure throw", onDone => {
     let f =
       fun
-      | Relude_Ior_Type.This(a) => a
-      | Relude_Ior_Type.That(b) => int_of_string(b)
-      | Relude_Ior_Type.Both(a, b) => a + int_of_string(b);
+      | Relude.Ior_Type.This(a) => a
+      | Relude.Ior_Type.That(b) => int_of_string(b)
+      | Relude.Ior_Type.Both(a, b) => a + int_of_string(b);
     IO.alignWith(f, IO.pure(42), IO.throw("e2"))
     |> IO.unsafeRunAsync(
          fun
@@ -234,9 +234,9 @@ describe("IO basics", () => {
   testAsync("alignWith throw pure", onDone => {
     let f =
       fun
-      | Relude_Ior_Type.This(a) => a
-      | Relude_Ior_Type.That(b) => int_of_string(b)
-      | Relude_Ior_Type.Both(a, b) => a + int_of_string(b);
+      | Relude.Ior_Type.This(a) => a
+      | Relude.Ior_Type.That(b) => int_of_string(b)
+      | Relude.Ior_Type.Both(a, b) => a + int_of_string(b);
     IO.alignWith(f, IO.throw("e1"), IO.pure("99"))
     |> IO.unsafeRunAsync(
          fun
@@ -248,9 +248,9 @@ describe("IO basics", () => {
   testAsync("alignWith throw throw", onDone => {
     let f =
       fun
-      | Relude_Ior_Type.This(a) => a
-      | Relude_Ior_Type.That(b) => int_of_string(b)
-      | Relude_Ior_Type.Both(a, b) => a + int_of_string(b);
+      | Relude.Ior_Type.This(a) => a
+      | Relude.Ior_Type.That(b) => int_of_string(b)
+      | Relude.Ior_Type.Both(a, b) => a + int_of_string(b);
     IO.alignWith(f, IO.throw("e1"), IO.throw("e2"))
     |> IO.unsafeRunAsync(
          fun
@@ -1355,7 +1355,7 @@ describe("IO mapError", () => {
 
   testAsync("throw mapError unsafeRunAsync", onDone =>
     IO.throw("this is a test")
-    |> IO.mapError(msg => Relude_Js_Exn.make(msg))
+    |> IO.mapError(msg => Relude.Js_Exn.make(msg))
     |> IO.unsafeRunAsync(
          fun
          | Ok(_a) => onDone(fail("Failed"))
@@ -3165,7 +3165,7 @@ describe("IO debounce", () => {
       IO.unsafeRunAsync(
         Result.fold(
           _ => "IO should not have failed" |> fail |> onDone,
-          Relude_Option.foldLazy(ignore, () =>
+          Relude.Option.foldLazy(ignore, () =>
             "IO should not have been run" |> fail |> onDone
           ),
         ),
@@ -3176,7 +3176,7 @@ describe("IO debounce", () => {
     debouncedIO() |> checkNonRunIO;
 
     debouncedIO()
-    |> IO.flatMap(Relude_Option.fold(IO.pure(None), debouncedIO))
+    |> IO.flatMap(Relude.Option.fold(IO.pure(None), debouncedIO))
     |> checkNonRunIO;
 
     debouncedIO()
@@ -3231,11 +3231,11 @@ describe("IO debounce", () => {
     debouncedIO() |> IO.unsafeRunAsync(ignore);
 
     debouncedIO()
-    |> IO.flatMap(Relude_Option.fold(IO.pure(None), debouncedIO))
+    |> IO.flatMap(Relude.Option.fold(IO.pure(None), debouncedIO))
     |> IO.unsafeRunAsync(ignore);
 
     debouncedIO()
-    |> IO.flatMap(Relude_Option.fold(IO.pure(None), debouncedIO))
+    |> IO.flatMap(Relude.Option.fold(IO.pure(None), debouncedIO))
     |> IO.flatMap(_ => IO.delay(300))
     |> IO.unsafeRunAsync(_ =>
          (
@@ -3513,9 +3513,9 @@ describe("IO FS examples", () => {
     >>= (_ => FS.IO.readFile(testFilePath))
     >>= (
       content =>
-        Relude_String.toNonWhitespace(content)
+        Relude.String.toNonWhitespace(content)
         |> IO.fromOption(_ =>
-             Relude_Js_Exn.make("Failed to get non-empty file content")
+             Relude.Js_Exn.make("Failed to get non-empty file content")
            )
     )
     >>= (content => IO.pure(expect(content) |> toEqual("IO Aff test")))

--- a/__tests__/Relude_Identity_test.re
+++ b/__tests__/Relude_Identity_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 
-module Identity = Relude_Identity;
+module Identity = Relude.Identity;
 
 describe("Identity", () => {
   test("pure", () =>
@@ -29,14 +29,14 @@ describe("Identity", () => {
   );
 
   test("show", () =>
-    expect(Identity.show((module Relude_Int.Show), 5)) |> toEqual("5")
+    expect(Identity.show((module Relude.Int.Show), 5)) |> toEqual("5")
   );
 
   test("eq true", () =>
-    expect(Identity.eq((module Relude_Int.Eq), 5, 5)) |> toEqual(true)
+    expect(Identity.eq((module Relude.Int.Eq), 5, 5)) |> toEqual(true)
   );
 
   test("eq false", () =>
-    expect(Identity.eq((module Relude_Int.Eq), 5, 10)) |> toEqual(false)
+    expect(Identity.eq((module Relude.Int.Eq), 5, 10)) |> toEqual(false)
   );
 });

--- a/__tests__/Relude_Int_test.re
+++ b/__tests__/Relude_Int_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 
-module Int = Relude_Int;
+module Int = Relude.Int;
 
 describe("Int", () => {
   test("toFloat", () =>

--- a/__tests__/Relude_Ior_test.re
+++ b/__tests__/Relude_Ior_test.re
@@ -1,8 +1,8 @@
 open Jest;
 open Expect;
 
-module NonEmptyList = Relude_NonEmpty.List;
-module Ior = Relude_Ior;
+module NonEmptyList = Relude.NonEmpty.List;
+module Ior = Relude.Ior;
 open Ior;
 
 module That = {

--- a/__tests__/Relude_ListZipper_test.re
+++ b/__tests__/Relude_ListZipper_test.re
@@ -307,13 +307,13 @@ describe("ListZipper", () => {
   );
 
   test("isAtItemBy", () =>
-    expect(LZ.make([2, 1], 3, []) |> LZ.isAtItemBy(Relude_Int.Eq.eq, 3))
+    expect(LZ.make([2, 1], 3, []) |> LZ.isAtItemBy(Relude.Int.Eq.eq, 3))
     |> toEqual(true)
   );
 
   test("isAtItem", () =>
     expect(
-      LZ.make([2, 1], 3, []) |> LZ.isAtItem((module Relude_Int.Eq), 3),
+      LZ.make([2, 1], 3, []) |> LZ.isAtItem((module Relude.Int.Eq), 3),
     )
     |> toEqual(true)
   );
@@ -549,21 +549,21 @@ describe("ListZipper", () => {
 
   test("findItemLeftBy", () =>
     expect(
-      LZ.make([2, 1], 3, [4, 5]) |> LZ.findItemLeftBy(Relude_Int.Eq.eq, 1),
+      LZ.make([2, 1], 3, [4, 5]) |> LZ.findItemLeftBy(Relude.Int.Eq.eq, 1),
     )
     |> toEqual(Some(LZ.make([], 1, [2, 3, 4, 5])))
   );
 
   test("findItemRightBy", () =>
     expect(
-      LZ.make([2, 1], 3, [4, 5]) |> LZ.findItemRightBy(Relude_Int.Eq.eq, 5),
+      LZ.make([2, 1], 3, [4, 5]) |> LZ.findItemRightBy(Relude.Int.Eq.eq, 5),
     )
     |> toEqual(Some(LZ.make([4, 3, 2, 1], 5, [])))
   );
 
   test("findItemBy", () =>
     expect(
-      LZ.make([2, 1], 3, [4, 5]) |> LZ.findItemBy(Relude_Int.Eq.eq, 5),
+      LZ.make([2, 1], 3, [4, 5]) |> LZ.findItemBy(Relude.Int.Eq.eq, 5),
     )
     |> toEqual(Some(LZ.make([4, 3, 2, 1], 5, [])))
   );
@@ -571,7 +571,7 @@ describe("ListZipper", () => {
   test("findItemLeft", () =>
     expect(
       LZ.make([2, 1], 3, [4, 5])
-      |> LZ.findItemLeft((module Relude_Int.Eq), 1),
+      |> LZ.findItemLeft((module Relude.Int.Eq), 1),
     )
     |> toEqual(Some(LZ.make([], 1, [2, 3, 4, 5])))
   );
@@ -579,14 +579,14 @@ describe("ListZipper", () => {
   test("findItemRight", () =>
     expect(
       LZ.make([2, 1], 3, [4, 5])
-      |> LZ.findItemRight((module Relude_Int.Eq), 5),
+      |> LZ.findItemRight((module Relude.Int.Eq), 5),
     )
     |> toEqual(Some(LZ.make([4, 3, 2, 1], 5, [])))
   );
 
   test("findItem", () =>
     expect(
-      LZ.make([2, 1], 3, [4, 5]) |> LZ.findItem((module Relude_Int.Eq), 5),
+      LZ.make([2, 1], 3, [4, 5]) |> LZ.findItem((module Relude.Int.Eq), 5),
     )
     |> toEqual(Some(LZ.make([4, 3, 2, 1], 5, [])))
   );

--- a/__tests__/Relude_List_test.re
+++ b/__tests__/Relude_List_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 
-module Int = Relude_Int;
+module Int = Relude.Int;
 module List = Relude.List;
 module IO = Relude.IO;
 
@@ -556,11 +556,11 @@ describe("List", () => {
   );
 
   test("min empty", () =>
-    expect(List.min((module Relude_String.Ord), [])) |> toEqual(None)
+    expect(List.min((module Relude.String.Ord), [])) |> toEqual(None)
   );
 
   test("min many", () =>
-    expect(List.min((module Relude_String.Ord), ["b", "a", "c"]))
+    expect(List.min((module Relude.String.Ord), ["b", "a", "c"]))
     |> toEqual(Some("a"))
   );
 
@@ -762,7 +762,7 @@ describe("List", () => {
   );
 
   test("mapOption keep int", () =>
-    expect(List.mapOption(Relude_String.toInt, ["1", "a", "2", "", "3"]))
+    expect(List.mapOption(Relude.String.toInt, ["1", "a", "2", "", "3"]))
     |> toEqual([1, 2, 3])
   );
 
@@ -972,7 +972,7 @@ describe("List", () => {
 
   test("Validation.traverse success", () =>
     expect(List.Validation.traverse(a => Ok(a), [1, 2, 3, 4, 5]))
-    |> toEqual(Relude_Validation.VOk([1, 2, 3, 4, 5]))
+    |> toEqual(Relude.Validation.VOk([1, 2, 3, 4, 5]))
   );
 
   test("Validation.traverse failure", () =>
@@ -983,8 +983,8 @@ describe("List", () => {
       ),
     )
     |> toEqual(
-         Relude_Validation.VError(
-           Relude_NonEmpty.List.make(
+         Relude.Validation.VError(
+           Relude.NonEmpty.List.make(
              "1 is bad",
              ["2 is bad", "3 is bad", "4 is bad", "5 is bad"],
            ),

--- a/__tests__/Relude_NonEmpty_test.re
+++ b/__tests__/Relude_NonEmpty_test.re
@@ -148,25 +148,25 @@ describe("NonEmpty.List", () => {
 
   test("eq tail", () => {
     let ne = NonEmpty.List.make(1, [2, 3]);
-    expect(NonEmpty.List.eq((module Relude_Int.Eq), ne, ne))
+    expect(NonEmpty.List.eq((module Relude.Int.Eq), ne, ne))
     |> toEqual(true);
   });
 
   test("eq head", () => {
     let ne1 = NonEmpty.List.make(0, [2, 3]);
     let ne2 = NonEmpty.List.make(1, [2, 3]);
-    expect(NonEmpty.List.eq((module Relude_Int.Eq), ne1, ne2))
+    expect(NonEmpty.List.eq((module Relude.Int.Eq), ne1, ne2))
     |> toEqual(false);
   });
 
   test("show", () => {
     let ne = NonEmpty.List.make(1, [2, 3]);
-    expect(NonEmpty.List.show((module Relude_Int.Show), ne))
+    expect(NonEmpty.List.show((module Relude.Int.Show), ne))
     |> toEqual("[!1, 2, 3!]");
   });
 
   module NonEmptyListWithOption =
-    NonEmpty.List.WithApplicative(Relude_Option.Applicative);
+    NonEmpty.List.WithApplicative(Relude.Option.Applicative);
 
   test("traverse option", () =>
     expect(
@@ -271,12 +271,12 @@ describe("NonEmpty.Array", () => {
 
   test("show", () => {
     let ne = NonEmpty.Array.make(1, [|2, 3|]);
-    expect(NonEmpty.Array.show((module Relude_Int.Show), ne))
+    expect(NonEmpty.Array.show((module Relude.Int.Show), ne))
     |> toEqual("[!1, 2, 3!]");
   });
 
   module NonEmptyArrayWithOption =
-    NonEmpty.Array.WithApplicative(Relude_Option.Applicative);
+    NonEmpty.Array.WithApplicative(Relude.Option.Applicative);
 
   test("traverse option", () =>
     expect(

--- a/__tests__/Relude_Option_test.re
+++ b/__tests__/Relude_Option_test.re
@@ -142,9 +142,9 @@ describe("Option", () => {
   testAll(
     "align",
     [
-      (Some(42), Some("a"), Some(Relude_Ior_Type.Both(42, "a"))),
-      (Some(42), None, Some(Relude_Ior_Type.This(42))),
-      (None, Some("a"), Some(Relude_Ior_Type.That("a"))),
+      (Some(42), Some("a"), Some(Relude.Ior_Type.Both(42, "a"))),
+      (Some(42), None, Some(Relude.Ior_Type.This(42))),
+      (None, Some("a"), Some(Relude.Ior_Type.That("a"))),
       (None, None, None),
     ],
     ((fa, fb, expected)) => {
@@ -162,9 +162,9 @@ describe("Option", () => {
     ((fa, fb, expected)) => {
       let f =
         fun
-        | Relude_Ior_Type.This(a) => a
-        | Relude_Ior_Type.That(b) => int_of_string(b)
-        | Relude_Ior_Type.Both(a, b) => a + int_of_string(b);
+        | Relude.Ior_Type.This(a) => a
+        | Relude.Ior_Type.That(b) => int_of_string(b)
+        | Relude.Ior_Type.Both(a, b) => a + int_of_string(b);
       expect(Option.alignWith(f, fa, fb)) |> toEqual(expected);
     },
   );
@@ -178,7 +178,7 @@ describe("Option", () => {
   );
 
   test(">>=", () => {
-    let (>>=) = Relude_Option.Infix.(>>=);
+    let (>>=) = Relude.Option.Infix.(>>=);
     expect(Some(1) >>= (a => Some(a + 2))) |> toEqual(Some(3));
   });
 

--- a/__tests__/Relude_RIO_test.re
+++ b/__tests__/Relude_RIO_test.re
@@ -17,7 +17,7 @@ module Reader =
     type t = env;
   });
 
-module RIO = Relude_RIO.WithErrorAndEnv(
+module RIO = Relude.RIO.WithErrorAndEnv(
   {
     type t = error;
   },
@@ -39,10 +39,10 @@ describe("Reader IO", () =>
         <$$> (a => a ++ env.stringValue);
       }
     )
-    |> RIO.semiflatMap(c => Relude_IO.pure(c ++ "semi"))
+    |> RIO.semiflatMap(c => Relude.IO.pure(c ++ "semi"))
     |> RIO.runRIO(testEnv)
-    |> Relude_IO.map(a => expect(a) |> toEqual("-42abcsemi"))
-    |> Relude_IO.unsafeRunAsync(
+    |> Relude.IO.map(a => expect(a) |> toEqual("-42abcsemi"))
+    |> Relude.IO.unsafeRunAsync(
          fun
          | Ok(assertion) => onDone(assertion)
          | Error(_) => onDone(fail("fail")),

--- a/__tests__/Relude_Result_test.re
+++ b/__tests__/Relude_Result_test.re
@@ -93,7 +93,7 @@ describe("Result", () => {
   test("alignWith Ok Ok", () => {
     let f =
       fun
-      | Relude_Ior_Type.This(a) => a
+      | Relude.Ior_Type.This(a) => a
       | That(b) => int_of_string(b)
       | Both(a, b) => a + int_of_string(b);
     expect(Result.alignWith(f, Result.ok(42), Result.ok("99")))
@@ -103,7 +103,7 @@ describe("Result", () => {
   test("alignWith Ok Error", () => {
     let f =
       fun
-      | Relude_Ior_Type.This(a) => a
+      | Relude.Ior_Type.This(a) => a
       | That(b) => int_of_string(b)
       | Both(a, b) => a + int_of_string(b);
     expect(Result.alignWith(f, Result.ok(42), Result.error("99")))
@@ -113,7 +113,7 @@ describe("Result", () => {
   test("alignWith Error Ok", () => {
     let f =
       fun
-      | Relude_Ior_Type.This(a) => a
+      | Relude.Ior_Type.This(a) => a
       | That(b) => int_of_string(b)
       | Both(a, b) => a + int_of_string(b);
     expect(Result.alignWith(f, Result.error(42), Result.ok("99")))
@@ -123,7 +123,7 @@ describe("Result", () => {
   test("alignWith Error Ok", () => {
     let f =
       fun
-      | Relude_Ior_Type.This(a) => a
+      | Relude.Ior_Type.This(a) => a
       | That(b) => int_of_string(b)
       | Both(a, b) => a + int_of_string(b);
     expect(Result.alignWith(f, Result.error("a"), Result.error("b")))
@@ -329,12 +329,12 @@ describe("Result", () => {
   );
 
   test("eqBy when eq, both Ok", () =>
-    expect(Result.eqBy(Relude_Int.eq, Relude_String.eq, Ok("a"), Ok("a")))
+    expect(Result.eqBy(Relude.Int.eq, Relude.String.eq, Ok("a"), Ok("a")))
     |> toEqual(true)
   );
 
   test("eqBy when not eq, both Ok", () =>
-    expect(Result.eqBy((_, _) => true, Relude_Int.eq, Ok(1), Ok(2)))
+    expect(Result.eqBy((_, _) => true, Relude.Int.eq, Ok(1), Ok(2)))
     |> toEqual(false)
   );
 
@@ -349,7 +349,7 @@ describe("Result", () => {
   );
 
   test("eqBy when eq, both Error", () =>
-    expect(Result.eqBy(Relude_Int.eq, (_, _) => true, Error(1), Error(1)))
+    expect(Result.eqBy(Relude.Int.eq, (_, _) => true, Error(1), Error(1)))
     |> toEqual(true)
   );
 

--- a/__tests__/Relude_Set_test.re
+++ b/__tests__/Relude_Set_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 
-module IntSet = Relude_Set.WithOrd(Relude_Int.Ord);
+module IntSet = Relude.Set.WithOrd(Relude.Int.Ord);
 
 describe("Set", () => {
   test("length of empty set", () =>

--- a/__tests__/Relude_String_test.re
+++ b/__tests__/Relude_String_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 
-module Str = Relude_String;
+module Str = Relude.String;
 
 describe("String", () => {
   test("length empty string", () =>
@@ -192,7 +192,7 @@ describe("String", () => {
   test("foldLeft", () =>
     expect(
       Str.foldLeft(
-        (acc, str) => Relude_List.concat(acc, [str]),
+        (acc, str) => Relude.List.concat(acc, [str]),
         [],
         "abc",
       ),
@@ -203,7 +203,7 @@ describe("String", () => {
   test("foldRight", () =>
     expect(
       Str.foldRight(
-        (str, acc) => Relude_List.concat(acc, [str]),
+        (str, acc) => Relude.List.concat(acc, [str]),
         [],
         "abc",
       ),

--- a/__tests__/Relude_Timer_test.re
+++ b/__tests__/Relude_Timer_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 
-module Timer = Relude_Timer;
+module Timer = Relude.Timer;
 
 describe("Timer", () => {
   test("delay", () => {

--- a/__tests__/Relude_TreeZipper_test.re
+++ b/__tests__/Relude_TreeZipper_test.re
@@ -888,7 +888,7 @@ describe("TreeZipper", () => {
              `Right(1),
              `Down(1),
            ],
-           (l, v) => l |> Relude_List.append(v),
+           (l, v) => l |> Relude.List.append(v),
            [],
          );
     let expectedZipper =
@@ -935,7 +935,7 @@ describe("TreeZipper", () => {
 
   test("findInFocus", () => {
     let actual = testTree1 |> fromTree |> findInFocus(a => a == 1);
-    let expected = testTree1 |> fromTree |> Relude_Option.pure; // 1
+    let expected = testTree1 |> fromTree |> Relude.Option.pure; // 1
     let actual2 = testTree1 |> fromTree |> findInFocus(a => a == 0);
     let expected2 = None;
     expect((actual, actual2)) |> toEqual((expected, expected2));

--- a/__tests__/Relude_Tree_test.re
+++ b/__tests__/Relude_Tree_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 open! Relude.Globals;
-open Relude_Tree;
+open Relude.Tree;
 
 let testTree1 = Tree.make(1, [Tree.pure(2), Tree.pure(3)]);
 
@@ -296,7 +296,7 @@ describe("Tree", () => {
   });
 
   test("traverse", () => {
-    module TreeOption = Tree.WithApplicative(Relude_Option.Applicative);
+    module TreeOption = Tree.WithApplicative(Relude.Option.Applicative);
     let actual =
       TreeOption.Traversable.traverse(
         a => Some(a + 100),
@@ -307,7 +307,7 @@ describe("Tree", () => {
   });
 
   test("sequence", () => {
-    module TreeOption = Tree.WithApplicative(Relude_Option.Applicative);
+    module TreeOption = Tree.WithApplicative(Relude.Option.Applicative);
     let actual =
       TreeOption.Traversable.sequence(
         Tree.make(Some(1), [Tree.pure(Some(2)), Tree.pure(Some(3))]),
@@ -336,7 +336,7 @@ describe("Tree", () => {
   );
 
   test("Show", () => {
-    module Show = Tree.Show(Relude_Int.Show);
+    module Show = Tree.Show(Relude.Int.Show);
     expect(testTree1 |> Show.show)
     |> toEqual("Tree 1 [Tree 2 [], Tree 3 []]");
   });

--- a/__tests__/Relude_Validation_test.re
+++ b/__tests__/Relude_Validation_test.re
@@ -1,11 +1,11 @@
 open Jest;
 open Expect;
 
-module NonEmptyList = Relude_NonEmpty.List;
-module String = Relude_String;
-module Result = Relude_Result;
-module Option = Relude_Option;
-module Validation = Relude_Validation;
+module NonEmptyList = Relude.NonEmpty.List;
+module String = Relude.String;
+module Result = Relude.Result;
+module Option = Relude.Option;
+module Validation = Relude.Validation;
 
 module Error = {
   type t =
@@ -332,17 +332,17 @@ describe("Validation", () => {
       (
         Validation.ok(42),
         Validation.ok("a"),
-        Validation.ok(Relude_Ior_Type.Both(42, "a")),
+        Validation.ok(Relude.Ior_Type.Both(42, "a")),
       ),
       (
         Validation.ok(42),
         Validation.error("fail2"),
-        Validation.ok(Relude_Ior_Type.This(42)),
+        Validation.ok(Relude.Ior_Type.This(42)),
       ),
       (
         Validation.error("fail1"),
         Validation.ok("a"),
-        Validation.ok(Relude_Ior_Type.That("a")),
+        Validation.ok(Relude.Ior_Type.That("a")),
       ),
       (
         Validation.error("fail1"),
@@ -372,9 +372,9 @@ describe("Validation", () => {
     ((inputA, inputB, expected)) => {
       let f =
         fun
-        | Relude_Ior_Type.This(a) => a
-        | Relude_Ior_Type.That(b) => int_of_string(b)
-        | Relude_Ior_Type.Both(a, b) => a + int_of_string(b);
+        | Relude.Ior_Type.This(a) => a
+        | Relude.Ior_Type.That(b) => int_of_string(b)
+        | Relude.Ior_Type.Both(a, b) => a + int_of_string(b);
       let actual =
         Validation.alignWithWithAppendErrors(
           (a, b) => a ++ b,

--- a/__tests__/extensions/Relude_Extensions_Enum_test.re
+++ b/__tests__/extensions/Relude_Extensions_Enum_test.re
@@ -111,7 +111,7 @@ module Month = {
 
 open Month;
 
-describe("Relude_Extensions_Enum", () => {
+describe("Relude.Extensions_Enum", () => {
   testAll(
     "fromToAsList",
     [
@@ -200,7 +200,7 @@ describe("Relude_Extensions_Enum", () => {
   );
 });
 
-describe("Relude_Extensions_BoundedEnum", () => {
+describe("Relude.Extensions_BoundedEnum", () => {
   testAll(
     "fromThenToAsList",
     [
@@ -260,11 +260,11 @@ describe("Relude_Extensions_BoundedEnum", () => {
       expect(actual) |> toEqual(expected);
     },
   );
-  describe("Relude_Extensions_BoundedEnum", () => {
+  describe("Relude.Extensions_BoundedEnum", () => {
     let show = Show.show;
-    let parseOrd = inverseMapOrd(~ordA=(module Relude_String.Ord), show);
+    let parseOrd = inverseMapOrd(~ordA=(module Relude.String.Ord), show);
     let parseOrdBy = inverseMapOrdBy(Relude.String.compare, show);
-    let parseEq = inverseMapEq(~eqA=(module Relude_String.Eq), show);
+    let parseEq = inverseMapEq(~eqA=(module Relude.String.Eq), show);
     let parseEqBy = inverseMapEqBy(Relude.String.eq, show);
     let parseString = inverseMapString(show);
 

--- a/__tests__/js/Relude_Js_Exn_test.re
+++ b/__tests__/js/Relude_Js_Exn_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 
-module Exn = Relude_Js_Exn;
+module Exn = Relude.Js_Exn;
 
 describe("Js.Exn", () => {
   test("make", () => {

--- a/__tests__/js/Relude_Js_Json_test.re
+++ b/__tests__/js/Relude_Js_Json_test.re
@@ -1,12 +1,12 @@
 open Jest;
 open Expect;
 
-module Json = Relude_Js_Json;
-module List = Relude_List;
-module NonEmptyArray = Relude_NonEmpty.Array;
-module Option = Relude_Option;
-module Result = Relude_Result;
-module Validation = Relude_Validation;
+module Json = Relude.Js_Json;
+module List = Relude.List;
+module NonEmptyArray = Relude.NonEmpty.Array;
+module Option = Relude.Option;
+module Result = Relude.Result;
+module Validation = Relude.Validation;
 
 module MyType = {
   type t = {

--- a/__tests__/js/Relude_Js_Promise_test.re
+++ b/__tests__/js/Relude_Js_Promise_test.re
@@ -1,13 +1,13 @@
 open Jest;
 open Expect;
 
-module IO = Relude_IO;
-module RPromise = Relude_Js_Promise;
+module IO = Relude.IO;
+module RPromise = Relude.Js_Promise;
 
 describe("Js.Promise", () => {
   testAsync("toIO success", onDone =>
     Js.Promise.resolve(42)
-    |> Relude_Js_Promise.toIO
+    |> Relude.Js_Promise.toIO
     |> IO.unsafeRunAsync(
          fun
          | Ok(value) => onDone(expect(value) |> toEqual(42))
@@ -17,13 +17,13 @@ describe("Js.Promise", () => {
 
   // Unsafe.coerces here b/c I can't figure how to make this compile with the actual types
   testAsync("toIO error", onDone =>
-    Js.Promise.reject(Relude_Unsafe.coerce("my error toIO"))
-    |> Relude_Js_Promise.toIO
+    Js.Promise.reject(Relude.Unsafe.coerce("my error toIO"))
+    |> Relude.Js_Promise.toIO
     |> IO.unsafeRunAsync(
          fun
          | Ok(_) => onDone(fail("failed"))
          | Error(e) => {
-             let str: string = Relude_Unsafe.coerce(e);
+             let str: string = Relude.Unsafe.coerce(e);
              onDone(expect(str) |> toEqual("my error toIO"));
            },
        )
@@ -31,7 +31,7 @@ describe("Js.Promise", () => {
 
   testAsync("toIOLazy success", onDone =>
     (() => Js.Promise.resolve(42))
-    |> Relude_Js_Promise.toIOLazy
+    |> Relude.Js_Promise.toIOLazy
     |> IO.unsafeRunAsync(
          fun
          | Ok(value) => onDone(expect(value) |> toEqual(42))
@@ -41,49 +41,49 @@ describe("Js.Promise", () => {
 
   // Unsafe.coerces here b/c I can't figure how to make this compile with the actual types
   testAsync("toIOLazy error", onDone =>
-    (() => Js.Promise.reject(Relude_Unsafe.coerce("my error toIOLazy")))
-    |> Relude_Js_Promise.toIOLazy
+    (() => Js.Promise.reject(Relude.Unsafe.coerce("my error toIOLazy")))
+    |> Relude.Js_Promise.toIOLazy
     |> IO.unsafeRunAsync(
          fun
          | Ok(_) => onDone(fail("failed"))
          | Error(e) => {
-             let str: string = Relude_Unsafe.coerce(e);
+             let str: string = Relude.Unsafe.coerce(e);
              onDone(expect(str) |> toEqual("my error toIOLazy"));
            },
        )
   );
 
   testPromise("fromIOWithResult success", () =>
-    Relude_IO.pure(42)
-    |> Relude_Js_Promise.fromIOWithResult
+    Relude.IO.pure(42)
+    |> Relude.Js_Promise.fromIOWithResult
     |> Js.Promise.then_(actual =>
          actual |> expect |> toEqual(Ok(42)) |> Js.Promise.resolve
        )
   );
 
   testPromise("fromIOWithResult error", () =>
-    Relude_IO.throw(42)
-    |> Relude_Js_Promise.fromIOWithResult
+    Relude.IO.throw(42)
+    |> Relude.Js_Promise.fromIOWithResult
     |> Js.Promise.then_(actual =>
          actual |> expect |> toEqual(Error(42)) |> Js.Promise.resolve
        )
   );
 
   testPromise("fromIO success", () =>
-    Relude_IO.pure(42)
-    |> Relude_Js_Promise.fromIO
+    Relude.IO.pure(42)
+    |> Relude.Js_Promise.fromIO
     |> Js.Promise.then_(actual =>
          actual |> expect |> toEqual(42) |> Js.Promise.resolve
        )
   );
 
   testPromise("fromIO error", () =>
-    Relude_IO.throw(42)
-    |> Relude_Js_Promise.fromIO
+    Relude.IO.throw(42)
+    |> Relude.Js_Promise.fromIO
     |> Js.Promise.then_(_ => fail("fail") |> Js.Promise.resolve)
     |> Js.Promise.catch(error =>
          error
-         |> Relude_Unsafe.coerce
+         |> Relude.Unsafe.coerce
          |> expect
          |> toEqual(42)
          |> Js.Promise.resolve
@@ -91,45 +91,45 @@ describe("Js.Promise", () => {
   );
 
   testPromise("fromIOExn success", () =>
-    Relude_IO.pure(42)
-    |> Relude_Js_Promise.fromIOExn
+    Relude.IO.pure(42)
+    |> Relude.Js_Promise.fromIOExn
     |> Js.Promise.then_(actual =>
          actual |> expect |> toEqual(42) |> Js.Promise.resolve
        )
   );
 
   testPromise("fromIOExn error", () =>
-    Relude_IO.suspendThrow(() =>
-      Relude_Js_Exn.make("exn") |> Relude_Js_Exn.unsafeToExn
+    Relude.IO.suspendThrow(() =>
+      Relude.Js_Exn.make("exn") |> Relude.Js_Exn.unsafeToExn
     )
-    |> Relude_Js_Promise.fromIOExn
+    |> Relude.Js_Promise.fromIOExn
     |> Js.Promise.then_(_ => fail("fail") |> Js.Promise.resolve)
     |> Js.Promise.catch(error =>
          error
-         |> Relude_Unsafe.coerce
+         |> Relude.Unsafe.coerce
          |> expect
-         |> toEqual(Relude_Js_Exn.make("exn") |> Relude_Js_Exn.unsafeToExn)
+         |> toEqual(Relude.Js_Exn.make("exn") |> Relude.Js_Exn.unsafeToExn)
          |> Js.Promise.resolve
        )
   );
 
   testPromise("fromIOJsExn success", () =>
-    Relude_IO.pure(42)
-    |> Relude_Js_Promise.fromIOJsExn
+    Relude.IO.pure(42)
+    |> Relude.Js_Promise.fromIOJsExn
     |> Js.Promise.then_(actual =>
          actual |> expect |> toEqual(42) |> Js.Promise.resolve
        )
   );
 
   testPromise("fromIOJsExn error", () =>
-    Relude_IO.suspendThrow(() => Relude_Js_Exn.make("js_exn"))
-    |> Relude_Js_Promise.fromIOJsExn
+    Relude.IO.suspendThrow(() => Relude.Js_Exn.make("js_exn"))
+    |> Relude.Js_Promise.fromIOJsExn
     |> Js.Promise.then_(_ => fail("fail") |> Js.Promise.resolve)
     |> Js.Promise.catch(error =>
          error
-         |> Relude_Unsafe.coerce
+         |> Relude.Unsafe.coerce
          |> expect
-         |> toEqual(Relude_Js_Exn.make("js_exn"))
+         |> toEqual(Relude.Js_Exn.make("js_exn"))
          |> Js.Promise.resolve
        )
   );

--- a/__tests__/testUtils/FS.re
+++ b/__tests__/testUtils/FS.re
@@ -46,16 +46,16 @@ by IO.
 */
 module IO = {
   // Read a file with no accomodation for errors
-  let readFileSync: string => Relude_IO.t(string, Js.Exn.t) =
-    path => Relude_IO.triesJS(() => Native.readFileSync(path, `utf8));
+  let readFileSync: string => Relude.IO.t(string, Js.Exn.t) =
+    path => Relude.IO.triesJS(() => Native.readFileSync(path, `utf8));
 
-  let writeFileSync: (string, string) => Relude_IO.t(unit, Js.Exn.t) =
+  let writeFileSync: (string, string) => Relude.IO.t(unit, Js.Exn.t) =
     (path, content) =>
-      Relude_IO.triesJS(() => Native.writeFileSync(path, content, `utf8));
+      Relude.IO.triesJS(() => Native.writeFileSync(path, content, `utf8));
 
-  let readFile: string => Relude_IO.t(string, Js.Exn.t) =
+  let readFile: string => Relude.IO.t(string, Js.Exn.t) =
     path =>
-      Relude_IO.async(onDone =>
+      Relude.IO.async(onDone =>
         Native.readFile(path, `utf8, (err, content) =>
           switch (Js.Null.toOption(err), content) {
           | (Some(err'), _) =>
@@ -63,7 +63,7 @@ module IO = {
               "Read failed: "
               ++ (
                 Js.Exn.message(err')
-                |> Relude_Option.getOrElseLazy(_ => "No error")
+                |> Relude.Option.getOrElseLazy(_ => "No error")
               ),
             );
             onDone(Error(err'));
@@ -72,9 +72,9 @@ module IO = {
         )
       );
 
-  let writeFile: (string, string) => Relude_IO.t(unit, Js.Exn.t) =
+  let writeFile: (string, string) => Relude.IO.t(unit, Js.Exn.t) =
     (path, content) =>
-      Relude_IO.async(onDone =>
+      Relude.IO.async(onDone =>
         Native.writeFile(path, content, `utf8, err =>
           switch (Js.Null.toOption(err)) {
           | Some(err') =>
@@ -82,7 +82,7 @@ module IO = {
               "Write failed: "
               ++ (
                 Js.Exn.message(err')
-                |> Relude_Option.getOrElseLazy(_ => "No error")
+                |> Relude.Option.getOrElseLazy(_ => "No error")
               ),
             );
             onDone(Error(err'));


### PR DESCRIPTION
This is a chunk of the work that was happening in @trite's dunification branch. Specifically, this makes it so all of the tests in `__tests__` no longer use `Relude_*` modules, which are internal and won't be available to the tests module once we properly set up dune packages.